### PR TITLE
[parser] Parse component import

### DIFF
--- a/src/model/imports.ts
+++ b/src/model/imports.ts
@@ -74,7 +74,7 @@ export type ComponentImport = {
     /// The name of the imported item.
     name: ComponentExternName,
     /// The type reference for the import.
-    ty: ComponentTypeRef | undefined,
+    ty: ComponentTypeRef,
 }
 
 /// Represents an export in a WebAssembly component.

--- a/src/model/imports.ts
+++ b/src/model/imports.ts
@@ -74,7 +74,7 @@ export type ComponentImport = {
     /// The name of the imported item.
     name: ComponentExternName,
     /// The type reference for the import.
-    ty: ComponentTypeRef,
+    ty: ComponentTypeRef | undefined,
 }
 
 /// Represents an export in a WebAssembly component.

--- a/src/parser/import.ts
+++ b/src/parser/import.ts
@@ -1,0 +1,22 @@
+import { SyncSource } from '../utils/streaming';
+import { ParserContext } from './types';
+import { readU32, readComponentExternName, readComponentTypeRef } from './values';
+import { ModelTag } from '../model/tags';
+import { ComponentImport } from '../model/imports';
+
+export function parseSectionImport(
+    ctx: ParserContext,
+    src: SyncSource,
+): ComponentImport[] {
+    const sections: ComponentImport[] = [];
+    const count = readU32(src);
+    for (let i = 0; i < count; i++) {
+        const section: ComponentImport = {
+            tag: ModelTag.ComponentImport,
+            name: readComponentExternName(src),
+            ty: readComponentTypeRef(src)
+        };
+        sections.push(section);
+    }
+    return sections;
+}

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -8,7 +8,7 @@ import { parseSectionExport } from './export';
 import { parseModule } from './module';
 import { readU32Async } from './values';
 import { parseSectionAlias } from './alias';
-import { ModelTag } from '../model/tags';
+import { parseSectionImport } from './import';
 
 export const WIT_MAGIC = [0x00, 0x61, 0x73, 0x6d];
 export const WIT_VERSION = [0x0D, 0x00];
@@ -92,15 +92,15 @@ async function parseSection(ctx: ParserContext, src: Source): Promise<WITSection
             case 1: return parseModule(ctx, asyncSub!, size);
             case 6: return parseSectionAlias(ctx, sub!);
             case 11: return parseSectionExport(ctx, sub!);
+            case 10: return parseSectionImport(ctx, sub!);
 
             //TODO: to implement
             case 2: // core instance
-            case 3: // core type
+            case 3: // core type - we don't have it in the sample
             case 4: // component
             case 5: // instance
             case 7: // type
             case 8: // canon
-            case 10: // import
                 return skipSection(ctx, sub!, type, size); // this is all TODO
             default:
                 throw new Error(`unknown section: ${type}`);

--- a/tests/hello.ts
+++ b/tests/hello.ts
@@ -94,7 +94,7 @@ export const componentImport: ComponentImport = {
         name: 'hello:city/city'
     },
     ty: {
-        tag: ModelTag.ComponentTypeRefInstance,
+        tag: ModelTag.ComponentTypeRefComponent,
         value: 0
     },
 };


### PR DESCRIPTION
Nearly the same as `ComponentExport`.
After implementation a small error in the mock model was revealed.