### PR TITLE
Parse canonical function

### DIFF
--- a/src/parser/canon.ts
+++ b/src/parser/canon.ts
@@ -1,0 +1,19 @@
+/* eslint-disable no-console */
+import { SyncSource } from '../utils/streaming';
+import { ParserContext } from './types';
+import { readU32, readCanonicalFunction } from './values';
+import { CanonicalFunction } from '../model/canonicals';
+
+export function parseSectionCanon(
+    ctx: ParserContext,
+    src: SyncSource,
+): CanonicalFunction[] {
+    const canonFunctions: CanonicalFunction[] = [];
+    const count = readU32(src);
+    for (let i = 0; i < count; i++) {
+        console.log(`parseSectionCannon: count=${count}`);
+        const canonicalFun: CanonicalFunction = readCanonicalFunction(src);
+        canonFunctions.push(canonicalFun);
+    }
+    return canonFunctions;
+}

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -10,6 +10,7 @@ import { readU32Async } from './values';
 import { parseSectionAlias } from './alias';
 import { parseSectionImport } from './import';
 import { parseSectionType } from './type';
+import { parseSectionCanon } from './canon';
 
 export const WIT_MAGIC = [0x00, 0x61, 0x73, 0x6d];
 export const WIT_VERSION = [0x0D, 0x00];
@@ -95,13 +96,13 @@ async function parseSection(ctx: ParserContext, src: Source): Promise<WITSection
             case 11: return parseSectionExport(ctx, sub!);
             case 10: return parseSectionImport(ctx, sub!);
             case 7: return parseSectionType(ctx, sub!);
+            case 8: return parseSectionCanon(ctx, sub!);
 
             //TODO: to implement
             case 2: // core instance
             case 3: // core type - we don't have it in the sample
             case 4: // component
             case 5: // instance
-            case 8: // canon
                 return skipSection(ctx, sub!, type, size); // this is all TODO
             default:
                 throw new Error(`unknown section: ${type}`);

--- a/tests/hello.ts
+++ b/tests/hello.ts
@@ -171,11 +171,11 @@ export const canonicalFuncLower2: CanonicalFunctionLower = {
     func_index: 0,
     options: [
         {
-            tag: ModelTag.CanonicalOptionUTF8
-        },
-        {
             tag: ModelTag.CanonicalOptionMemory,
             value: 0
+        },
+        {
+            tag: ModelTag.CanonicalOptionUTF8
         }
     ],
 };
@@ -246,16 +246,16 @@ export const canonicalFuncLift1: CanonicalFunctionLift = {
     type_index: 2,
     options: [
         {
-            tag: ModelTag.CanonicalOptionUTF8
+            tag: ModelTag.CanonicalOptionMemory,
+            value: 0
         },
         {
             tag: ModelTag.CanonicalOptionRealloc,
             value: 1
         },
         {
-            tag: ModelTag.CanonicalOptionMemory,
-            value: 0
-        }
+            tag: ModelTag.CanonicalOptionUTF8
+        },
     ],
 };
 


### PR DESCRIPTION
Parses e.g.:
```
(core func (;2;) (canon lower (func 0) (memory 0) string-encoding=utf8))
(func (;1;) (type 2) (canon lift (core func 3) (memory 0) (realloc 1) string-encoding=utf8))
```
cc @AaronRobinsonMSFT 