### PR TITLE
Resolver: ResolvedContext extraction, closure elimination, and memoization fix

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -3,6 +3,7 @@
 ## Coding Conventions
 
 - **Always use numeric `const enum`** — never string-valued enum members. Numeric enums inline to integer literals in the bundle, saving significant minified code size. String enums emit string comparisons and string literals that cannot be minified.
+- **Never use inline `import()` for types** — always use top-level `import` or `import type` statements. Inline `import('...').SomeType` in type annotations is prohibited; add the type to an existing top-level import (or create a new `import type` line) instead.
 
 ## Testing
 

--- a/TODO.md
+++ b/TODO.md
@@ -3,12 +3,13 @@
 - export and import ABI interfaces for direct binding without JS ("fused adapters")
 - make sure we don't keep references to model after component was created (memory leak risk)
 - consider "inlining" https://github.com/bytecodealliance/wasmtime/blob/main/crates/environ/src/component/translate/inline.rs
-- instance-local type isolation: `registerInstanceLocalTypes` overwrites global `resolvedTypes` entries — could cause bugs if multiple instances share type indices
 
 # Binder todo
 - respect model options for CompactUTF-16 (latin1+utf16) encoding
 - option to bind lazily only when methods are called
 - fused adapters https://github.com/bytecodealliance/wasmtime/blob/main/crates/environ/src/component/translate/adapt.rs
+- validate string, list and buffer sizes to not cause OOM or out of range
+- validate HTTP API to not receive evil payload, like unlimited body or headers
 
 # Parser todo
 - add options to delay parsing core modules
@@ -24,6 +25,18 @@
 - use JSCO to bind multiple components at runtime
 - add Firefox browser test (Chrome done via Playwright)
 - improve utils/ coverage (47% — lowest in project)
+- Nested compound types | `option<option<u8>>`, `result<list<u8>, string>` | High |
+- Resource borrow accounting | `trap_if(h.num_lends != 0)` for own lift/drop | High |
+- Discriminant size boundaries | Variant/enum 255 vs 256 cases | Medium |
+- Multi-word flags | >32 flag members | Medium |
+- Empty containers | Empty record, empty tuple | Low |
+
+# Integration Test Plan
+- Implementation, consumer, forwarder components
+- For each WASI API
+- All parameter types (core + component), as param and return value
+- Sync and async, in Rust and JS
+- Cross-component callbacks (A→B→A) and multi-component instantiation
 
 # Build
 - add coverage to CI, fail if lower than some %
@@ -31,6 +44,23 @@
 - rollup magic to eliminate debug helpers and asserts (jsco_assert TODO in assert.ts)
 - use quoted properties for identifiers that must survive terser mangling (e.g. `leb128DecodeU64`, `buf`, `memory`)
 - reduce Release bundle size (264KB debug — target <40KB minified+gzipped)
+
+# WASI Preview 1
+- implement by forwarding to WASIp2 or WASIp3
+- test with D:\nesm\tests\samples\wasi\
+
+# WASI Preview 2 Implementation Status
+- implement socket and http server on nodeJS
+- have look at https://github.com/pavelsavara/node-mono-server
+
+# WASI Preview 3
+- interleaved suspension
+- re-entry on async - queue
+
+# Minification
+- `jsco_assert` should be eliminated in Release builds via Rollup plugin (inline macro)
+- Jest can't resolve Rollup virtual modules for build-time constant injection
+- internal fields
 
 # Demo
 - create demo web site
@@ -44,76 +74,3 @@
 - write article on how it works
 - multi-memory https://github.com/bytecodealliance/jco/blob/main/crates/js-component-bindgen/src/core.rs
 - implement WASIp3 (async model with native WASM stack switching, replaces JSPI workaround)
-
-# WASI Preview 2 Implementation Status
-
-Browser-native WASI preview 2 host. Independent implementation from first principles.
-
-## Approach
-
-- **Source location:** `src/host/wasip2/`
-- **Async strategy:** JSPI experimental support for blocking calls
-- **Spec conformance:** Pragmatic — make real components work, fix spec gaps as encountered
-- **No external dependencies:** Not wrapping `@bytecodealliance/preview2-shim`
-
-## Implemented (all with tests, 84% coverage)
-
-- wasi:random/random, insecure, insecure-seed
-- wasi:clocks/wall-clock, monotonic-clock
-- wasi:io/error, poll, streams
-- wasi:cli/environment, exit, stdin, stdout, stderr, terminal-*
-- wasi:filesystem/types (in-memory VFS), preopens
-- wasi:http/types, outgoing-handler (fetch() backend)
-- wasi:sockets/* (stubs — not-supported, browser limitation)
-- JSPI integration with WebAssembly.promising/Suspending
-
-## Remaining Work
-
-### Resolver: Import index space unification
-- `importToInstanceIndex` only covers instance-kind imports
-- Function imports work via name lookup; unified index spaces would allow `CanonicalFunctionLower` to reference them by index
-
-### Build: Assert elimination
-- `jsco_assert` should be eliminated in Release builds via Rollup plugin (inline macro)
-- Jest can't resolve Rollup virtual modules for build-time constant injection
-
-### Test Coverage Gaps
-
-| Category | Detail | Priority |
-|----------|--------|----------|
-| Nested compound types | `option<option<u8>>`, `result<list<u8>, string>` | High |
-| Resource borrow accounting | `trap_if(h.num_lends != 0)` for own lift/drop | High |
-| Discriminant size boundaries | Variant/enum 255 vs 256 cases | Medium |
-| Multi-word flags | >32 flag members | Medium |
-| Empty containers | Empty record, empty tuple | Low |
-
-### Integration Test Plan
-- Implementation, consumer, forwarder components
-- For each WASI API
-- All parameter types (core + component), as param and return value
-- Sync and async, in Rust and JS
-- Cross-component callbacks (A→B→A) and multi-component instantiation
-
-## Current Stats (April 2026)
-- **775 tests** across **25 suites** (774 pass, 1 skipped)
-- **69 source files**, **25 test files**
-- **264KB bundle** (debug), 28KB types
-- Coverage: Model 100%, Binding 95%, WASI 84%, Resolver 76%, Parser 67%, Utils 47%
-- Overall: 81% statements, 70% branches
-
-## JSPI Strategy
-
-1. **Detection:** Probe for `WebAssembly.Suspending` at `createWasiHost()` time
-2. **Fail-early:** Throw if unavailable — JSPI is required for WASI blocking calls
-3. **`noJspi` option:** Available for non-JSPI environments
-4. Internal APIs are async; WASI-facing functions use `WebAssembly.promising()` / `WebAssembly.Suspending`
-
-## Key Reference Specs
-
-- [Component Model Binary Format](https://github.com/WebAssembly/component-model/blob/main/design/mvp/Binary.md)
-- [Canonical ABI definitions.py](https://github.com/WebAssembly/component-model/blob/main/design/mvp/canonical-abi/definitions.py)
-- [JCO transpile_bindgen.rs](https://github.com/bytecodealliance/jco/blob/main/crates/js-component-bindgen/src/transpile_bindgen.rs)
-- [Wasmtime component types.rs](https://github.com/bytecodealliance/wasmtime/blob/main/crates/environ/src/component/types.rs)
-
-## Minify
-- internal fields

--- a/TODO.md
+++ b/TODO.md
@@ -3,11 +3,10 @@
 - export and import ABI interfaces for direct binding without JS ("fused adapters")
 - make sure we don't keep references to model after component was created (memory leak risk)
 - consider "inlining" https://github.com/bytecodealliance/wasmtime/blob/main/crates/environ/src/component/translate/inline.rs
-- convert `export const enum` to numeric literals via rollup transform to save download size
 - instance-local type isolation: `registerInstanceLocalTypes` overwrites global `resolvedTypes` entries — could cause bugs if multiple instances share type indices
 
 # Binder todo
-- respect model options for UTF-16 encoding (currently UTF-8 only)
+- respect model options for CompactUTF-16 (latin1+utf16) encoding
 - option to bind lazily only when methods are called
 - fused adapters https://github.com/bytecodealliance/wasmtime/blob/main/crates/environ/src/component/translate/adapt.rs
 

--- a/inspiration.md
+++ b/inspiration.md
@@ -1,5 +1,12 @@
 # Inspiration
 
+## Key Reference Specs
+
+- [Component Model Binary Format](https://github.com/WebAssembly/component-model/blob/main/design/mvp/Binary.md)
+- [Canonical ABI definitions.py](https://github.com/WebAssembly/component-model/blob/main/design/mvp/canonical-abi/definitions.py)
+- [JCO transpile_bindgen.rs](https://github.com/bytecodealliance/jco/blob/main/crates/js-component-bindgen/src/transpile_bindgen.rs)
+- [Wasmtime component types.rs](https://github.com/bytecodealliance/wasmtime/blob/main/crates/environ/src/component/types.rs)
+
 ## Documentation
 - https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md
 - https://github.com/WebAssembly/component-model/blob/main/design/mvp/Binary.md

--- a/src/host/wasip2/filesystem.test.ts
+++ b/src/host/wasip2/filesystem.test.ts
@@ -1,4 +1,5 @@
 import { createWasiFilesystem, WasiDescriptor, WasiFilesystem, FsResult, DirectoryEntry } from './filesystem';
+import type { WasiDatetime } from './types';
 
 /** Helper: unwrap an ok result or throw */
 function unwrap<T>(result: FsResult<T>): T {
@@ -538,7 +539,7 @@ describe('wasi:filesystem', () => {
             ]));
             const root = fs.rootDescriptor();
             const file = unwrap(root.openAt({}, 'file.txt', {}, { write: true }));
-            const newTime: import('./types').WasiDatetime = { seconds: 1234567890n, nanoseconds: 0 };
+            const newTime: WasiDatetime = { seconds: 1234567890n, nanoseconds: 0 };
             unwrap(file.setTimes(newTime, newTime));
             const stat = unwrap(file.stat());
             expect(stat.dataAccessTimestamp?.seconds).toBe(1234567890n);
@@ -551,7 +552,7 @@ describe('wasi:filesystem', () => {
             ]));
             const root = fs.rootDescriptor();
             const dir = unwrap(root.openAt({}, 'dir', { directory: true }, {}));
-            const newTime: import('./types').WasiDatetime = { seconds: 999n, nanoseconds: 500 };
+            const newTime: WasiDatetime = { seconds: 999n, nanoseconds: 500 };
             unwrap(dir.setTimesAt({}, 'file.txt', newTime, undefined));
             const stat = unwrap(dir.statAt({}, 'file.txt'));
             expect(stat.dataAccessTimestamp?.seconds).toBe(999n);

--- a/src/model/tags.ts
+++ b/src/model/tags.ts
@@ -75,6 +75,7 @@ export const enum ModelTag {
     ComponentTypeInstance,
     ComponentTypeResource,
     ComponentValTypePrimitive,
+    ComponentValTypeResolved,
     ComponentValTypeType,
     CoreTypeFunc,
     CoreTypeModule,

--- a/src/model/types.ts
+++ b/src/model/types.ts
@@ -70,6 +70,7 @@ export type ModuleTypeDeclarationImport = Import & {
 export type ComponentValType =
     | ComponentValTypePrimitive
     | ComponentValTypeType
+    | ComponentValTypeResolved
 
 /// The value type is a primitive type.
 export type ComponentValTypePrimitive = {
@@ -81,6 +82,13 @@ export type ComponentValTypePrimitive = {
 export type ComponentValTypeType = {
     tag: ModelTag.ComponentValTypeType
     value: u32
+}
+
+/// The value type has been pre-resolved at binder creation time.
+/// Used by the resolver to avoid call-time resolvedTypes lookups.
+export type ComponentValTypeResolved = {
+    tag: ModelTag.ComponentValTypeResolved
+    resolved: unknown // ResolvedType at runtime, unknown to avoid circular model→resolver deps
 }
 
 /// Represents a primitive value type.

--- a/src/resolver/binding-plan.ts
+++ b/src/resolver/binding-plan.ts
@@ -1,7 +1,7 @@
 import { isDebug } from '../utils/assert';
 import { JsImports, WasmComponentInstance } from './api-types';
 import { createBindingContext } from './context';
-import { BinderArgs, BindingContext, ResolverContext, ResolverRes } from './types';
+import { BinderArgs, BindingContext, ResolverRes } from './types';
 
 export const enum PlanOpKind {
     CoreInstantiate,
@@ -33,12 +33,11 @@ export type ExportBindOp = {
 }
 
 export async function executePlan<TJSExports>(
-    rctx: ResolverContext,
     plan: PlanOp[],
     componentImports?: JsImports,
 ): Promise<WasmComponentInstance<TJSExports>> {
     componentImports = componentImports ?? {};
-    const ctx: BindingContext = createBindingContext(rctx, componentImports);
+    const ctx: BindingContext = createBindingContext(componentImports);
 
     const imports = {};
     const exports = {};

--- a/src/resolver/binding/canonical-abi.test.ts
+++ b/src/resolver/binding/canonical-abi.test.ts
@@ -9,6 +9,7 @@ import { createLifting, createFunctionLifting, storeToMemory } from './to-abi';
 import { createLowering, loadFromMemory } from './to-js';
 import { WasmPointer, WasmSize } from './types';
 import { validateAllocResult, validatePointerAlignment, validateUtf8, checkNotPoisoned, checkNotReentrant } from './validation';
+import { deepResolveType } from '../calling-convention';
 
 // --- Test helpers ---
 
@@ -18,6 +19,7 @@ function createMinimalRctx(usesNumberForInt64 = false): ResolverContext {
         resolvedTypes: new Map(),
         usesNumberForInt64,
         stringEncoding: StringEncoding.Utf8,
+        canonicalResourceIds: new Map(),
     } as any as ResolverContext;
 }
 
@@ -544,10 +546,10 @@ describe('C3: nested compound types through memory', () => {
         } as any;
         (rctx.resolvedTypes as Map<any, any>).set(100, listModel);
 
-        const optionModel = {
+        const optionModel = deepResolveType(rctx, {
             tag: ModelTag.ComponentTypeDefinedOption,
             value: { tag: ModelTag.ComponentValTypeType, value: 100 },
-        } as any;
+        } as any);
         (rctx.resolvedTypes as Map<any, any>).set(101, optionModel);
 
         // Store Some([1,2,3]) through memory
@@ -564,7 +566,7 @@ describe('C3: nested compound types through memory', () => {
         dv.setInt32(20, 200, true); // list ptr
         dv.setInt32(24, 3, true); // list len
 
-        const result = loadFromMemory(ctx, rctx, 16, optionModel);
+        const result = loadFromMemory(ctx, 16, optionModel, rctx.stringEncoding, rctx.canonicalResourceIds);
         expect(result).toEqual([1, 2, 3]);
     });
 
@@ -578,16 +580,16 @@ describe('C3: nested compound types through memory', () => {
         } as any;
         (rctx.resolvedTypes as Map<any, any>).set(100, innerOption);
 
-        const outerOption = {
+        const outerOption = deepResolveType(rctx, {
             tag: ModelTag.ComponentTypeDefinedOption,
             value: { tag: ModelTag.ComponentValTypeType, value: 100 },
-        } as any;
+        } as any);
 
         // Store None at offset 16
         const dv = new DataView(buffer);
         dv.setUint8(16, 0); // outer discriminant = None
 
-        const result = loadFromMemory(ctx, rctx, 16, outerOption);
+        const result = loadFromMemory(ctx, 16, outerOption, rctx.stringEncoding, rctx.canonicalResourceIds);
         expect(result).toBeNull();
     });
 
@@ -607,7 +609,7 @@ describe('C3: nested compound types through memory', () => {
         dv.setInt32(16, 0, true); // discriminant = ok
         dv.setUint32(20, 42, true); // payload = 42
 
-        const result = loadFromMemory(ctx, rctx, 16, resultModel);
+        const result = loadFromMemory(ctx, 16, resultModel, rctx.stringEncoding, rctx.canonicalResourceIds);
         expect(result).toEqual({ tag: 'ok', val: 42 });
     });
 
@@ -632,7 +634,7 @@ describe('C3: nested compound types through memory', () => {
         dv.setInt32(20, 200, true); // string ptr
         dv.setInt32(24, 4, true); // string len
 
-        const result = loadFromMemory(ctx, rctx, 16, resultModel);
+        const result = loadFromMemory(ctx, 16, resultModel, rctx.stringEncoding, rctx.canonicalResourceIds);
         expect(result).toEqual({ tag: 'err', val: 'oops' });
     });
 
@@ -650,10 +652,10 @@ describe('C3: nested compound types through memory', () => {
         } as any;
 
         // Store: u8 at offset 16, padding to 20, u32 at 20, u8 at 24
-        storeToMemory(ctx, rctx, 16, tupleModel, [0xAB, 0x12345678, 0xCD]);
+        storeToMemory(ctx, 16, tupleModel, [0xAB, 0x12345678, 0xCD], rctx.stringEncoding, rctx.canonicalResourceIds);
 
         // Read back
-        const result = loadFromMemory(ctx, rctx, 16, tupleModel);
+        const result = loadFromMemory(ctx, 16, tupleModel, rctx.stringEncoding, rctx.canonicalResourceIds);
         expect(result).toEqual([0xAB, 0x12345678, 0xCD]);
     });
 
@@ -672,8 +674,8 @@ describe('C3: nested compound types through memory', () => {
         } as any;
 
         const original = { flag: true, count: 100, score: 3.14, byte: 0xFF };
-        storeToMemory(ctx, rctx, 16, recordModel, original);
-        const result = loadFromMemory(ctx, rctx, 16, recordModel) as any;
+        storeToMemory(ctx, 16, recordModel, original, rctx.stringEncoding, rctx.canonicalResourceIds);
+        const result = loadFromMemory(ctx, 16, recordModel, rctx.stringEncoding, rctx.canonicalResourceIds) as any;
 
         expect(result.flag).toBe(true);
         expect(result.count).toBe(100);
@@ -695,13 +697,13 @@ describe('C3: nested compound types through memory', () => {
         } as any;
 
         // Test case 1: just-int(42)
-        storeToMemory(ctx, rctx, 16, variantModel, { tag: 'just-int', val: 42 });
-        let result = loadFromMemory(ctx, rctx, 16, variantModel);
+        storeToMemory(ctx, 16, variantModel, { tag: 'just-int', val: 42 }, rctx.stringEncoding, rctx.canonicalResourceIds);
+        let result = loadFromMemory(ctx, 16, variantModel, rctx.stringEncoding, rctx.canonicalResourceIds);
         expect(result).toEqual({ tag: 'just-int', val: 42 });
 
         // Test case 0: none
-        storeToMemory(ctx, rctx, 64, variantModel, { tag: 'none', val: undefined });
-        result = loadFromMemory(ctx, rctx, 64, variantModel);
+        storeToMemory(ctx, 64, variantModel, { tag: 'none', val: undefined }, rctx.stringEncoding, rctx.canonicalResourceIds);
+        result = loadFromMemory(ctx, 64, variantModel, rctx.stringEncoding, rctx.canonicalResourceIds);
         expect(result).toEqual({ tag: 'none', val: undefined });
     });
 
@@ -725,8 +727,8 @@ describe('C3: nested compound types through memory', () => {
 
         // tuple<u8, u32> has size=8 (1 byte + 3 padding + 4 bytes), align=4
         // Store 2 elements at offset 200
-        storeToMemory(ctx, rctx, 200, tupleModel, [0xAA, 100]);
-        storeToMemory(ctx, rctx, 208, tupleModel, [0xBB, 200]);
+        storeToMemory(ctx, 200, tupleModel, [0xAA, 100], rctx.stringEncoding, rctx.canonicalResourceIds);
+        storeToMemory(ctx, 208, tupleModel, [0xBB, 200], rctx.stringEncoding, rctx.canonicalResourceIds);
 
         // Now set up list pointer: ptr=200, len=2
         const dv = new DataView(buffer);
@@ -1040,7 +1042,7 @@ describe('C-integration: full round-trip with validation', () => {
         dv.setInt32(36, 200, true); // name ptr
         dv.setInt32(40, 5, true); // name len
 
-        const result = loadFromMemory(ctx, rctx, 32, recordModel);
+        const result = loadFromMemory(ctx, 32, recordModel, rctx.stringEncoding, rctx.canonicalResourceIds);
         expect(result.id).toBe(42);
         expect(result.name).toBe('Alice');
     });
@@ -1169,9 +1171,9 @@ describe('UTF-16 string encoding', () => {
             const { ctx } = createMockMemoryContext();
 
             const strType = prim(PrimitiveValType.String);
-            storeToMemory(ctx, rctx, 32, strType as any, 'hëllo');
+            storeToMemory(ctx, 32, strType as any, 'hëllo', rctx.stringEncoding, rctx.canonicalResourceIds);
 
-            const result = loadFromMemory(ctx, rctx, 32, strType as any);
+            const result = loadFromMemory(ctx, 32, strType as any, rctx.stringEncoding, rctx.canonicalResourceIds);
             expect(result).toBe('hëllo');
         });
 
@@ -1180,9 +1182,9 @@ describe('UTF-16 string encoding', () => {
             const { ctx } = createMockMemoryContext();
 
             const strType = prim(PrimitiveValType.String);
-            storeToMemory(ctx, rctx, 32, strType as any, '日本語');
+            storeToMemory(ctx, 32, strType as any, '日本語', rctx.stringEncoding, rctx.canonicalResourceIds);
 
-            const result = loadFromMemory(ctx, rctx, 32, strType as any);
+            const result = loadFromMemory(ctx, 32, strType as any, rctx.stringEncoding, rctx.canonicalResourceIds);
             expect(result).toBe('日本語');
         });
     });

--- a/src/resolver/binding/canonical-abi.test.ts
+++ b/src/resolver/binding/canonical-abi.test.ts
@@ -3,7 +3,7 @@ setConfiguration('Debug');
 
 import { ModelTag } from '../../model/tags';
 import { ComponentValType, PrimitiveValType } from '../../model/types';
-import { ResolverContext, BindingContext } from '../types';
+import { ResolverContext, BindingContext, StringEncoding } from '../types';
 import { createResourceTable } from '../context';
 import { createLifting, createFunctionLifting, storeToMemory } from './to-abi';
 import { createLowering, loadFromMemory } from './to-js';
@@ -17,6 +17,7 @@ function createMinimalRctx(usesNumberForInt64 = false): ResolverContext {
         memoizeCache: new Map(),
         resolvedTypes: new Map(),
         usesNumberForInt64,
+        stringEncoding: StringEncoding.Utf8,
     } as any as ResolverContext;
 }
 
@@ -1042,5 +1043,147 @@ describe('C-integration: full round-trip with validation', () => {
         const result = loadFromMemory(ctx, rctx, 32, recordModel);
         expect(result.id).toBe(42);
         expect(result.name).toBe('Alice');
+    });
+});
+
+// =============================================================================
+// UTF-16 String Encoding
+// =============================================================================
+
+describe('UTF-16 string encoding', () => {
+    function createUtf16Rctx(): ResolverContext {
+        return {
+            memoizeCache: new Map(),
+            resolvedTypes: new Map(),
+            usesNumberForInt64: false,
+            stringEncoding: StringEncoding.Utf16,
+        } as any as ResolverContext;
+    }
+
+    describe('lifting (JS → WASM memory)', () => {
+        test('ASCII string encodes as UTF-16LE', () => {
+            const rctx = createUtf16Rctx();
+            const lifter = createLifting(rctx, prim(PrimitiveValType.String));
+            const { ctx, buffer } = createMockMemoryContext();
+
+            const [ptr, codeUnits] = lifter(ctx, 'hello') as [number, number];
+            expect(codeUnits).toBe(5);
+            const view = new Uint8Array(buffer, ptr, 10);
+            // 'h'=0x0068 'e'=0x0065 'l'=0x006C 'l'=0x006C 'o'=0x006F (little-endian)
+            expect(view[0]).toBe(0x68); expect(view[1]).toBe(0x00);
+            expect(view[2]).toBe(0x65); expect(view[3]).toBe(0x00);
+            expect(view[4]).toBe(0x6C); expect(view[5]).toBe(0x00);
+        });
+
+        test('empty string returns [0, 0]', () => {
+            const rctx = createUtf16Rctx();
+            const lifter = createLifting(rctx, prim(PrimitiveValType.String));
+            const { ctx } = createMockMemoryContext();
+
+            const [ptr, codeUnits] = lifter(ctx, '') as [number, number];
+            expect(ptr).toBe(0);
+            expect(codeUnits).toBe(0);
+        });
+
+        test('BMP characters encode correctly', () => {
+            const rctx = createUtf16Rctx();
+            const lifter = createLifting(rctx, prim(PrimitiveValType.String));
+            const { ctx, buffer } = createMockMemoryContext();
+
+            // Japanese characters — all BMP (2 bytes each in UTF-16)
+            const [ptr, codeUnits] = lifter(ctx, '日本') as [number, number];
+            expect(codeUnits).toBe(2);
+            const dv = new DataView(buffer, ptr, 4);
+            expect(dv.getUint16(0, true)).toBe('日'.charCodeAt(0));
+            expect(dv.getUint16(2, true)).toBe('本'.charCodeAt(0));
+        });
+
+        test('surrogate pairs encode correctly', () => {
+            const rctx = createUtf16Rctx();
+            const lifter = createLifting(rctx, prim(PrimitiveValType.String));
+            const { ctx, buffer } = createMockMemoryContext();
+
+            // 𝄞 = U+1D11E → surrogate pair D834 DD1E
+            const [ptr, codeUnits] = lifter(ctx, '𝄞') as [number, number];
+            expect(codeUnits).toBe(2); // surrogate pair = 2 code units
+            const dv = new DataView(buffer, ptr, 4);
+            expect(dv.getUint16(0, true)).toBe(0xD834);
+            expect(dv.getUint16(2, true)).toBe(0xDD1E);
+        });
+    });
+
+    describe('lowering (WASM memory → JS)', () => {
+        test('UTF-16LE in memory decodes to JS string', () => {
+            const rctx = createUtf16Rctx();
+            const lowerer = createLowering(rctx, prim(PrimitiveValType.String));
+
+            const { ctx, buffer } = createMockMemoryContext();
+            // Write "hi" as UTF-16LE at offset 16
+            const dv = new DataView(buffer);
+            dv.setUint16(16, 'h'.charCodeAt(0), true);
+            dv.setUint16(18, 'i'.charCodeAt(0), true);
+
+            const result = (lowerer as any)(ctx, 16, 2);
+            expect(result).toBe('hi');
+        });
+
+        test('empty string (0 code units) loads correctly', () => {
+            const rctx = createUtf16Rctx();
+            const lowerer = createLowering(rctx, prim(PrimitiveValType.String));
+
+            const { ctx } = createMockMemoryContext();
+            const result = (lowerer as any)(ctx, 0, 0);
+            expect(result).toBe('');
+        });
+
+        test('surrogate pairs in memory decode correctly', () => {
+            const rctx = createUtf16Rctx();
+            const lowerer = createLowering(rctx, prim(PrimitiveValType.String));
+
+            const { ctx, buffer } = createMockMemoryContext();
+            // Write 𝄞 (U+1D11E) as surrogate pair at offset 16
+            const dv = new DataView(buffer);
+            dv.setUint16(16, 0xD834, true);
+            dv.setUint16(18, 0xDD1E, true);
+
+            const result = (lowerer as any)(ctx, 16, 2);
+            expect(result).toBe('𝄞');
+        });
+
+        test('misaligned UTF-16 pointer traps', () => {
+            const rctx = createUtf16Rctx();
+            const lowerer = createLowering(rctx, prim(PrimitiveValType.String));
+
+            const { ctx, buffer } = createMockMemoryContext();
+            // Write at odd offset
+            new Uint8Array(buffer).set([0x68, 0x00], 17);
+
+            expect(() => (lowerer as any)(ctx, 17, 1))
+                .toThrow('UTF-16 string pointer not aligned');
+        });
+    });
+
+    describe('memory path (storeToMemory/loadFromMemory)', () => {
+        test('UTF-16 string round-trips through memory', () => {
+            const rctx = createUtf16Rctx();
+            const { ctx } = createMockMemoryContext();
+
+            const strType = prim(PrimitiveValType.String);
+            storeToMemory(ctx, rctx, 32, strType as any, 'hëllo');
+
+            const result = loadFromMemory(ctx, rctx, 32, strType as any);
+            expect(result).toBe('hëllo');
+        });
+
+        test('UTF-16 Japanese string round-trips through memory', () => {
+            const rctx = createUtf16Rctx();
+            const { ctx } = createMockMemoryContext();
+
+            const strType = prim(PrimitiveValType.String);
+            storeToMemory(ctx, rctx, 32, strType as any, '日本語');
+
+            const result = loadFromMemory(ctx, rctx, 32, strType as any);
+            expect(result).toBe('日本語');
+        });
     });
 });

--- a/src/resolver/binding/canonical-abi.test.ts
+++ b/src/resolver/binding/canonical-abi.test.ts
@@ -15,11 +15,13 @@ import { deepResolveType } from '../calling-convention';
 
 function createMinimalRctx(usesNumberForInt64 = false): ResolverContext {
     return {
-        memoizeCache: new Map(),
-        resolvedTypes: new Map(),
-        usesNumberForInt64,
-        stringEncoding: StringEncoding.Utf8,
-        canonicalResourceIds: new Map(),
+        resolved: {
+            memoizeCache: new Map(),
+            resolvedTypes: new Map(),
+            usesNumberForInt64,
+            stringEncoding: StringEncoding.Utf8,
+            canonicalResourceIds: new Map(),
+        },
     } as any as ResolverContext;
 }
 
@@ -222,7 +224,7 @@ describe('C1: list pointer alignment validation', () => {
             tag: ModelTag.ComponentTypeDefinedList,
             value: prim(PrimitiveValType.U32),
         } as any;
-        const lowerer = createLowering(rctx, listModel);
+        const lowerer = createLowering(rctx.resolved, listModel);
 
         const { ctx, buffer } = createMockMemoryContext();
         // Write list data at offset 0 with ptr=3 (misaligned for u32, align=4)
@@ -240,7 +242,7 @@ describe('C1: list pointer alignment validation', () => {
             tag: ModelTag.ComponentTypeDefinedList,
             value: prim(PrimitiveValType.U32),
         } as any;
-        const lowerer = createLowering(rctx, listModel);
+        const lowerer = createLowering(rctx.resolved, listModel);
 
         const { ctx, buffer } = createMockMemoryContext();
         const dv = new DataView(buffer);
@@ -256,7 +258,7 @@ describe('C1: list pointer alignment validation', () => {
             tag: ModelTag.ComponentTypeDefinedList,
             value: prim(PrimitiveValType.U8),
         } as any;
-        const lowerer = createLowering(rctx, listModel);
+        const lowerer = createLowering(rctx.resolved, listModel);
 
         const { ctx, buffer } = createMockMemoryContext();
         new Uint8Array(buffer)[7] = 0xAB;
@@ -273,7 +275,7 @@ describe('C1: list out-of-bounds validation', () => {
             tag: ModelTag.ComponentTypeDefinedList,
             value: prim(PrimitiveValType.U32),
         } as any;
-        const lowerer = createLowering(rctx, listModel);
+        const lowerer = createLowering(rctx.resolved, listModel);
 
         const { ctx } = createMockMemoryContext(64);
         // ptr=60, len=2 means 60 + 2*4 = 68 > 64
@@ -285,7 +287,7 @@ describe('C1: list out-of-bounds validation', () => {
 describe('C1: string out-of-bounds validation', () => {
     test('string beyond memory traps on load', () => {
         const rctx = createMinimalRctx();
-        const lowerer = createLowering(rctx, prim(PrimitiveValType.String));
+        const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.String));
 
         const { ctx } = createMockMemoryContext(64);
         // ptr=60, len=10 means 60+10=70 > 64
@@ -301,7 +303,7 @@ describe('C1: list lifting with misaligned realloc traps', () => {
             tag: ModelTag.ComponentTypeDefinedList,
             value: prim(PrimitiveValType.U32),
         } as any;
-        const lifter = createLifting(rctx, listModel);
+        const lifter = createLifting(rctx.resolved, listModel);
 
         const { ctx } = createMisalignedAllocContext();
         // list<u32> needs align=4 but allocator returns odd addresses
@@ -449,7 +451,7 @@ describe('C2: validateUtf8', () => {
 describe('C2: string lowering validates UTF-8 from memory', () => {
     test('valid UTF-8 string loads correctly', () => {
         const rctx = createMinimalRctx();
-        const lowerer = createLowering(rctx, prim(PrimitiveValType.String));
+        const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.String));
 
         const { ctx, buffer } = createMockMemoryContext();
         // Write "hello" at offset 16
@@ -462,7 +464,7 @@ describe('C2: string lowering validates UTF-8 from memory', () => {
 
     test('invalid UTF-8 in memory traps on load', () => {
         const rctx = createMinimalRctx();
-        const lowerer = createLowering(rctx, prim(PrimitiveValType.String));
+        const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.String));
 
         const { ctx, buffer } = createMockMemoryContext();
         // Write invalid UTF-8 at offset 16: standalone continuation byte
@@ -474,7 +476,7 @@ describe('C2: string lowering validates UTF-8 from memory', () => {
 
     test('surrogate in UTF-8 string traps on load', () => {
         const rctx = createMinimalRctx();
-        const lowerer = createLowering(rctx, prim(PrimitiveValType.String));
+        const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.String));
 
         const { ctx, buffer } = createMockMemoryContext();
         // Write U+D800 encoded as UTF-8 (0xED 0xA0 0x80)
@@ -486,7 +488,7 @@ describe('C2: string lowering validates UTF-8 from memory', () => {
 
     test('overlong encoding traps on load', () => {
         const rctx = createMinimalRctx();
-        const lowerer = createLowering(rctx, prim(PrimitiveValType.String));
+        const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.String));
 
         const { ctx, buffer } = createMockMemoryContext();
         // Overlong encoding of '/' (0x2F): 0xC0 0xAF
@@ -498,7 +500,7 @@ describe('C2: string lowering validates UTF-8 from memory', () => {
 
     test('empty string (len=0) loads without validation', () => {
         const rctx = createMinimalRctx();
-        const lowerer = createLowering(rctx, prim(PrimitiveValType.String));
+        const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.String));
 
         const { ctx } = createMockMemoryContext();
         const result = (lowerer as any)(ctx, 0, 0);
@@ -512,7 +514,7 @@ describe('C2: string lowering validates UTF-8 from memory', () => {
         const encoded = new TextEncoder().encode(original);
         new Uint8Array(buffer).set(encoded, 16);
 
-        const lowerer = createLowering(rctx, prim(PrimitiveValType.String));
+        const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.String));
         const result = (lowerer as any)(ctx, 16, encoded.length);
         expect(result).toBe(original);
     });
@@ -524,7 +526,7 @@ describe('C2: string lowering validates UTF-8 from memory', () => {
         const encoded = new TextEncoder().encode(original);
         new Uint8Array(buffer).set(encoded, 16);
 
-        const lowerer = createLowering(rctx, prim(PrimitiveValType.String));
+        const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.String));
         const result = (lowerer as any)(ctx, 16, encoded.length);
         expect(result).toBe(original);
     });
@@ -544,13 +546,13 @@ describe('C3: nested compound types through memory', () => {
             tag: ModelTag.ComponentTypeDefinedList,
             value: prim(PrimitiveValType.U8),
         } as any;
-        (rctx.resolvedTypes as Map<any, any>).set(100, listModel);
+        (rctx.resolved.resolvedTypes as Map<any, any>).set(100, listModel);
 
-        const optionModel = deepResolveType(rctx, {
+        const optionModel = deepResolveType(rctx.resolved, {
             tag: ModelTag.ComponentTypeDefinedOption,
             value: { tag: ModelTag.ComponentValTypeType, value: 100 },
         } as any);
-        (rctx.resolvedTypes as Map<any, any>).set(101, optionModel);
+        (rctx.resolved.resolvedTypes as Map<any, any>).set(101, optionModel);
 
         // Store Some([1,2,3]) through memory
         // option layout: discriminant(1 byte) + alignment padding + list(ptr + len = 8 bytes)
@@ -566,7 +568,7 @@ describe('C3: nested compound types through memory', () => {
         dv.setInt32(20, 200, true); // list ptr
         dv.setInt32(24, 3, true); // list len
 
-        const result = loadFromMemory(ctx, 16, optionModel, rctx.stringEncoding, rctx.canonicalResourceIds);
+        const result = loadFromMemory(ctx, 16, optionModel, rctx.resolved.stringEncoding, rctx.resolved.canonicalResourceIds);
         expect(result).toEqual([1, 2, 3]);
     });
 
@@ -578,9 +580,9 @@ describe('C3: nested compound types through memory', () => {
             tag: ModelTag.ComponentTypeDefinedOption,
             value: prim(PrimitiveValType.U8),
         } as any;
-        (rctx.resolvedTypes as Map<any, any>).set(100, innerOption);
+        (rctx.resolved.resolvedTypes as Map<any, any>).set(100, innerOption);
 
-        const outerOption = deepResolveType(rctx, {
+        const outerOption = deepResolveType(rctx.resolved, {
             tag: ModelTag.ComponentTypeDefinedOption,
             value: { tag: ModelTag.ComponentValTypeType, value: 100 },
         } as any);
@@ -589,7 +591,7 @@ describe('C3: nested compound types through memory', () => {
         const dv = new DataView(buffer);
         dv.setUint8(16, 0); // outer discriminant = None
 
-        const result = loadFromMemory(ctx, 16, outerOption, rctx.stringEncoding, rctx.canonicalResourceIds);
+        const result = loadFromMemory(ctx, 16, outerOption, rctx.resolved.stringEncoding, rctx.resolved.canonicalResourceIds);
         expect(result).toBeNull();
     });
 
@@ -609,7 +611,7 @@ describe('C3: nested compound types through memory', () => {
         dv.setInt32(16, 0, true); // discriminant = ok
         dv.setUint32(20, 42, true); // payload = 42
 
-        const result = loadFromMemory(ctx, 16, resultModel, rctx.stringEncoding, rctx.canonicalResourceIds);
+        const result = loadFromMemory(ctx, 16, resultModel, rctx.resolved.stringEncoding, rctx.resolved.canonicalResourceIds);
         expect(result).toEqual({ tag: 'ok', val: 42 });
     });
 
@@ -634,7 +636,7 @@ describe('C3: nested compound types through memory', () => {
         dv.setInt32(20, 200, true); // string ptr
         dv.setInt32(24, 4, true); // string len
 
-        const result = loadFromMemory(ctx, 16, resultModel, rctx.stringEncoding, rctx.canonicalResourceIds);
+        const result = loadFromMemory(ctx, 16, resultModel, rctx.resolved.stringEncoding, rctx.resolved.canonicalResourceIds);
         expect(result).toEqual({ tag: 'err', val: 'oops' });
     });
 
@@ -652,10 +654,10 @@ describe('C3: nested compound types through memory', () => {
         } as any;
 
         // Store: u8 at offset 16, padding to 20, u32 at 20, u8 at 24
-        storeToMemory(ctx, 16, tupleModel, [0xAB, 0x12345678, 0xCD], rctx.stringEncoding, rctx.canonicalResourceIds);
+        storeToMemory(ctx, 16, tupleModel, [0xAB, 0x12345678, 0xCD], rctx.resolved.stringEncoding, rctx.resolved.canonicalResourceIds);
 
         // Read back
-        const result = loadFromMemory(ctx, 16, tupleModel, rctx.stringEncoding, rctx.canonicalResourceIds);
+        const result = loadFromMemory(ctx, 16, tupleModel, rctx.resolved.stringEncoding, rctx.resolved.canonicalResourceIds);
         expect(result).toEqual([0xAB, 0x12345678, 0xCD]);
     });
 
@@ -674,8 +676,8 @@ describe('C3: nested compound types through memory', () => {
         } as any;
 
         const original = { flag: true, count: 100, score: 3.14, byte: 0xFF };
-        storeToMemory(ctx, 16, recordModel, original, rctx.stringEncoding, rctx.canonicalResourceIds);
-        const result = loadFromMemory(ctx, 16, recordModel, rctx.stringEncoding, rctx.canonicalResourceIds) as any;
+        storeToMemory(ctx, 16, recordModel, original, rctx.resolved.stringEncoding, rctx.resolved.canonicalResourceIds);
+        const result = loadFromMemory(ctx, 16, recordModel, rctx.resolved.stringEncoding, rctx.resolved.canonicalResourceIds) as any;
 
         expect(result.flag).toBe(true);
         expect(result.count).toBe(100);
@@ -697,13 +699,13 @@ describe('C3: nested compound types through memory', () => {
         } as any;
 
         // Test case 1: just-int(42)
-        storeToMemory(ctx, 16, variantModel, { tag: 'just-int', val: 42 }, rctx.stringEncoding, rctx.canonicalResourceIds);
-        let result = loadFromMemory(ctx, 16, variantModel, rctx.stringEncoding, rctx.canonicalResourceIds);
+        storeToMemory(ctx, 16, variantModel, { tag: 'just-int', val: 42 }, rctx.resolved.stringEncoding, rctx.resolved.canonicalResourceIds);
+        let result = loadFromMemory(ctx, 16, variantModel, rctx.resolved.stringEncoding, rctx.resolved.canonicalResourceIds);
         expect(result).toEqual({ tag: 'just-int', val: 42 });
 
         // Test case 0: none
-        storeToMemory(ctx, 64, variantModel, { tag: 'none', val: undefined }, rctx.stringEncoding, rctx.canonicalResourceIds);
-        result = loadFromMemory(ctx, 64, variantModel, rctx.stringEncoding, rctx.canonicalResourceIds);
+        storeToMemory(ctx, 64, variantModel, { tag: 'none', val: undefined }, rctx.resolved.stringEncoding, rctx.resolved.canonicalResourceIds);
+        result = loadFromMemory(ctx, 64, variantModel, rctx.resolved.stringEncoding, rctx.resolved.canonicalResourceIds);
         expect(result).toEqual({ tag: 'none', val: undefined });
     });
 
@@ -718,7 +720,7 @@ describe('C3: nested compound types through memory', () => {
                 prim(PrimitiveValType.U32),
             ],
         } as any;
-        (rctx.resolvedTypes as Map<any, any>).set(100, tupleModel);
+        (rctx.resolved.resolvedTypes as Map<any, any>).set(100, tupleModel);
 
         const listModel = {
             tag: ModelTag.ComponentTypeDefinedList,
@@ -727,8 +729,8 @@ describe('C3: nested compound types through memory', () => {
 
         // tuple<u8, u32> has size=8 (1 byte + 3 padding + 4 bytes), align=4
         // Store 2 elements at offset 200
-        storeToMemory(ctx, 200, tupleModel, [0xAA, 100], rctx.stringEncoding, rctx.canonicalResourceIds);
-        storeToMemory(ctx, 208, tupleModel, [0xBB, 200], rctx.stringEncoding, rctx.canonicalResourceIds);
+        storeToMemory(ctx, 200, tupleModel, [0xAA, 100], rctx.resolved.stringEncoding, rctx.resolved.canonicalResourceIds);
+        storeToMemory(ctx, 208, tupleModel, [0xBB, 200], rctx.resolved.stringEncoding, rctx.resolved.canonicalResourceIds);
 
         // Now set up list pointer: ptr=200, len=2
         const dv = new DataView(buffer);
@@ -736,7 +738,7 @@ describe('C3: nested compound types through memory', () => {
         dv.setInt32(20, 2, true); // len
 
         // Load the list using lowerer
-        const lowerer = createLowering(rctx, listModel);
+        const lowerer = createLowering(rctx.resolved, listModel);
         const result = (lowerer as any)(ctx, 200, 2);
         expect(result).toEqual([
             [0xAA, 100],
@@ -752,7 +754,7 @@ describe('C3: nested compound types through memory', () => {
             tag: ModelTag.ComponentTypeDefinedOption,
             value: prim(PrimitiveValType.U32),
         } as any;
-        (rctx.resolvedTypes as Map<any, any>).set(100, optionModel);
+        (rctx.resolved.resolvedTypes as Map<any, any>).set(100, optionModel);
 
         const listModel = {
             tag: ModelTag.ComponentTypeDefinedList,
@@ -772,7 +774,7 @@ describe('C3: nested compound types through memory', () => {
         dv.setUint8(216, 1); // discriminant = Some
         dv.setUint32(220, 20, true); // payload
 
-        const lowerer = createLowering(rctx, listModel);
+        const lowerer = createLowering(rctx.resolved, listModel);
         const result = (lowerer as any)(ctx, 200, 3);
         expect(result).toEqual([10, null, 20]);
     });
@@ -831,7 +833,7 @@ describe('C4: instance poisoning through liftingTrampoline', () => {
             results: { tag: ModelTag.ComponentFuncResultUnnamed, type: prim(PrimitiveValType.U32) },
         } as any;
 
-        const fnLifting = createFunctionLifting(rctx, funcModel);
+        const fnLifting = createFunctionLifting(rctx.resolved, funcModel);
         const { ctx } = createMockMemoryContext();
 
         let capturedInExport = false;
@@ -855,7 +857,7 @@ describe('C4: instance poisoning through liftingTrampoline', () => {
             results: { tag: ModelTag.ComponentFuncResultUnnamed, type: prim(PrimitiveValType.U32) },
         } as any;
 
-        const fnLifting = createFunctionLifting(rctx, funcModel);
+        const fnLifting = createFunctionLifting(rctx.resolved, funcModel);
         const { ctx } = createMockMemoryContext();
 
         const mockWasm = () => { throw new Error('wasm trap!'); };
@@ -874,7 +876,7 @@ describe('C4: instance poisoning through liftingTrampoline', () => {
             results: { tag: ModelTag.ComponentFuncResultUnnamed, type: prim(PrimitiveValType.U32) },
         } as any;
 
-        const fnLifting = createFunctionLifting(rctx, funcModel);
+        const fnLifting = createFunctionLifting(rctx.resolved, funcModel);
         const { ctx } = createMockMemoryContext();
 
         // First call traps
@@ -898,7 +900,7 @@ describe('C4: reentrance guard through liftingTrampoline', () => {
             results: { tag: ModelTag.ComponentFuncResultUnnamed, type: prim(PrimitiveValType.U32) },
         } as any;
 
-        const fnLifting = createFunctionLifting(rctx, funcModel);
+        const fnLifting = createFunctionLifting(rctx.resolved, funcModel);
         const { ctx } = createMockMemoryContext();
 
         let reentrantError: Error | null = null;
@@ -938,7 +940,7 @@ describe('C4: post-return cleanup', () => {
             results: { tag: ModelTag.ComponentFuncResultUnnamed, type: prim(PrimitiveValType.U32) },
         } as any;
 
-        const fnLifting = createFunctionLifting(rctx, funcModel);
+        const fnLifting = createFunctionLifting(rctx.resolved, funcModel);
         const { ctx } = createMockMemoryContext();
 
         let postReturnCalled = false;
@@ -963,7 +965,7 @@ describe('C4: post-return cleanup', () => {
             results: { tag: ModelTag.ComponentFuncResultUnnamed, type: prim(PrimitiveValType.U32) },
         } as any;
 
-        const fnLifting = createFunctionLifting(rctx, funcModel);
+        const fnLifting = createFunctionLifting(rctx.resolved, funcModel);
         const { ctx } = createMockMemoryContext();
 
         let postReturnCalled = false;
@@ -987,8 +989,8 @@ describe('C-integration: full round-trip with validation', () => {
         const lowerRctx = createMinimalRctx();
         const { ctx } = createMockMemoryContext();
 
-        const lifter = createLifting(liftRctx, prim(PrimitiveValType.String));
-        const lowerer = createLowering(lowerRctx, prim(PrimitiveValType.String));
+        const lifter = createLifting(liftRctx.resolved, prim(PrimitiveValType.String));
+        const lowerer = createLowering(lowerRctx.resolved, prim(PrimitiveValType.String));
 
         const original = 'hello world 🌍';
         const [ptr, len] = (lifter as any)(ctx, original) as [number, number];
@@ -1010,8 +1012,8 @@ describe('C-integration: full round-trip with validation', () => {
             value: prim(PrimitiveValType.U32),
         } as any;
 
-        const lifter = createLifting(liftRctx, listModelLift);
-        const lowerer = createLowering(lowerRctx, listModelLower);
+        const lifter = createLifting(liftRctx.resolved, listModelLift);
+        const lowerer = createLowering(lowerRctx.resolved, listModelLower);
 
         const original = [10, 20, 30];
         const [ptr, len] = (lifter as any)(ctx, original) as [number, number];
@@ -1042,7 +1044,7 @@ describe('C-integration: full round-trip with validation', () => {
         dv.setInt32(36, 200, true); // name ptr
         dv.setInt32(40, 5, true); // name len
 
-        const result = loadFromMemory(ctx, 32, recordModel, rctx.stringEncoding, rctx.canonicalResourceIds);
+        const result = loadFromMemory(ctx, 32, recordModel, rctx.resolved.stringEncoding, rctx.resolved.canonicalResourceIds);
         expect(result.id).toBe(42);
         expect(result.name).toBe('Alice');
     });
@@ -1055,17 +1057,19 @@ describe('C-integration: full round-trip with validation', () => {
 describe('UTF-16 string encoding', () => {
     function createUtf16Rctx(): ResolverContext {
         return {
-            memoizeCache: new Map(),
-            resolvedTypes: new Map(),
-            usesNumberForInt64: false,
-            stringEncoding: StringEncoding.Utf16,
+            resolved: {
+                memoizeCache: new Map(),
+                resolvedTypes: new Map(),
+                usesNumberForInt64: false,
+                stringEncoding: StringEncoding.Utf16,
+            },
         } as any as ResolverContext;
     }
 
     describe('lifting (JS → WASM memory)', () => {
         test('ASCII string encodes as UTF-16LE', () => {
             const rctx = createUtf16Rctx();
-            const lifter = createLifting(rctx, prim(PrimitiveValType.String));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.String));
             const { ctx, buffer } = createMockMemoryContext();
 
             const [ptr, codeUnits] = lifter(ctx, 'hello') as [number, number];
@@ -1079,7 +1083,7 @@ describe('UTF-16 string encoding', () => {
 
         test('empty string returns [0, 0]', () => {
             const rctx = createUtf16Rctx();
-            const lifter = createLifting(rctx, prim(PrimitiveValType.String));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.String));
             const { ctx } = createMockMemoryContext();
 
             const [ptr, codeUnits] = lifter(ctx, '') as [number, number];
@@ -1089,7 +1093,7 @@ describe('UTF-16 string encoding', () => {
 
         test('BMP characters encode correctly', () => {
             const rctx = createUtf16Rctx();
-            const lifter = createLifting(rctx, prim(PrimitiveValType.String));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.String));
             const { ctx, buffer } = createMockMemoryContext();
 
             // Japanese characters — all BMP (2 bytes each in UTF-16)
@@ -1102,7 +1106,7 @@ describe('UTF-16 string encoding', () => {
 
         test('surrogate pairs encode correctly', () => {
             const rctx = createUtf16Rctx();
-            const lifter = createLifting(rctx, prim(PrimitiveValType.String));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.String));
             const { ctx, buffer } = createMockMemoryContext();
 
             // 𝄞 = U+1D11E → surrogate pair D834 DD1E
@@ -1117,7 +1121,7 @@ describe('UTF-16 string encoding', () => {
     describe('lowering (WASM memory → JS)', () => {
         test('UTF-16LE in memory decodes to JS string', () => {
             const rctx = createUtf16Rctx();
-            const lowerer = createLowering(rctx, prim(PrimitiveValType.String));
+            const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.String));
 
             const { ctx, buffer } = createMockMemoryContext();
             // Write "hi" as UTF-16LE at offset 16
@@ -1131,7 +1135,7 @@ describe('UTF-16 string encoding', () => {
 
         test('empty string (0 code units) loads correctly', () => {
             const rctx = createUtf16Rctx();
-            const lowerer = createLowering(rctx, prim(PrimitiveValType.String));
+            const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.String));
 
             const { ctx } = createMockMemoryContext();
             const result = (lowerer as any)(ctx, 0, 0);
@@ -1140,7 +1144,7 @@ describe('UTF-16 string encoding', () => {
 
         test('surrogate pairs in memory decode correctly', () => {
             const rctx = createUtf16Rctx();
-            const lowerer = createLowering(rctx, prim(PrimitiveValType.String));
+            const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.String));
 
             const { ctx, buffer } = createMockMemoryContext();
             // Write 𝄞 (U+1D11E) as surrogate pair at offset 16
@@ -1154,7 +1158,7 @@ describe('UTF-16 string encoding', () => {
 
         test('misaligned UTF-16 pointer traps', () => {
             const rctx = createUtf16Rctx();
-            const lowerer = createLowering(rctx, prim(PrimitiveValType.String));
+            const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.String));
 
             const { ctx, buffer } = createMockMemoryContext();
             // Write at odd offset
@@ -1171,9 +1175,9 @@ describe('UTF-16 string encoding', () => {
             const { ctx } = createMockMemoryContext();
 
             const strType = prim(PrimitiveValType.String);
-            storeToMemory(ctx, 32, strType as any, 'hëllo', rctx.stringEncoding, rctx.canonicalResourceIds);
+            storeToMemory(ctx, 32, strType as any, 'hëllo', rctx.resolved.stringEncoding, rctx.resolved.canonicalResourceIds);
 
-            const result = loadFromMemory(ctx, 32, strType as any, rctx.stringEncoding, rctx.canonicalResourceIds);
+            const result = loadFromMemory(ctx, 32, strType as any, rctx.resolved.stringEncoding, rctx.resolved.canonicalResourceIds);
             expect(result).toBe('hëllo');
         });
 
@@ -1182,9 +1186,9 @@ describe('UTF-16 string encoding', () => {
             const { ctx } = createMockMemoryContext();
 
             const strType = prim(PrimitiveValType.String);
-            storeToMemory(ctx, 32, strType as any, '日本語', rctx.stringEncoding, rctx.canonicalResourceIds);
+            storeToMemory(ctx, 32, strType as any, '日本語', rctx.resolved.stringEncoding, rctx.resolved.canonicalResourceIds);
 
-            const result = loadFromMemory(ctx, 32, strType as any, rctx.stringEncoding, rctx.canonicalResourceIds);
+            const result = loadFromMemory(ctx, 32, strType as any, rctx.resolved.stringEncoding, rctx.resolved.canonicalResourceIds);
             expect(result).toBe('日本語');
         });
     });

--- a/src/resolver/binding/canonical-abi.test.ts
+++ b/src/resolver/binding/canonical-abi.test.ts
@@ -16,7 +16,7 @@ import { deepResolveType } from '../calling-convention';
 function createMinimalRctx(usesNumberForInt64 = false): ResolverContext {
     return {
         resolved: {
-            memoizeCache: new Map(),
+            liftingCache: new Map(), loweringCache: new Map(),
             resolvedTypes: new Map(),
             usesNumberForInt64,
             stringEncoding: StringEncoding.Utf8,
@@ -1058,7 +1058,7 @@ describe('UTF-16 string encoding', () => {
     function createUtf16Rctx(): ResolverContext {
         return {
             resolved: {
-                memoizeCache: new Map(),
+                liftingCache: new Map(), loweringCache: new Map(),
                 resolvedTypes: new Map(),
                 usesNumberForInt64: false,
                 stringEncoding: StringEncoding.Utf16,

--- a/src/resolver/binding/compound-types.test.ts
+++ b/src/resolver/binding/compound-types.test.ts
@@ -11,7 +11,7 @@ import { WasmPointer, WasmSize } from './types';
 function createMinimalRctx(): ResolverContext {
     return {
         resolved: {
-            memoizeCache: new Map(),
+            liftingCache: new Map(), loweringCache: new Map(),
             resolvedTypes: new Map(),
             usesNumberForInt64: false,
         },

--- a/src/resolver/binding/compound-types.test.ts
+++ b/src/resolver/binding/compound-types.test.ts
@@ -10,9 +10,11 @@ import { WasmPointer, WasmSize } from './types';
 
 function createMinimalRctx(): ResolverContext {
     return {
-        memoizeCache: new Map(),
-        resolvedTypes: new Map(),
-        usesNumberForInt64: false,
+        resolved: {
+            memoizeCache: new Map(),
+            resolvedTypes: new Map(),
+            usesNumberForInt64: false,
+        },
     } as any as ResolverContext;
 }
 
@@ -91,32 +93,32 @@ describe('option lifting (JS → WASM)', () => {
     });
 
     test('null lifts to [0, 0] (None)', () => {
-        const lifter = createLifting(rctx, optionModel(prim(PrimitiveValType.U32)));
+        const lifter = createLifting(rctx.resolved, optionModel(prim(PrimitiveValType.U32)));
         expect(lifter(bctx, null)).toEqual([0, 0]);
     });
 
     test('undefined lifts to [0, 0] (None)', () => {
-        const lifter = createLifting(rctx, optionModel(prim(PrimitiveValType.U32)));
+        const lifter = createLifting(rctx.resolved, optionModel(prim(PrimitiveValType.U32)));
         expect(lifter(bctx, undefined)).toEqual([0, 0]);
     });
 
     test('42 lifts to [1, 42] (Some(42))', () => {
-        const lifter = createLifting(rctx, optionModel(prim(PrimitiveValType.U32)));
+        const lifter = createLifting(rctx.resolved, optionModel(prim(PrimitiveValType.U32)));
         expect(lifter(bctx, 42)).toEqual([1, 42]);
     });
 
     test('0 lifts to [1, 0] (Some(0), not None)', () => {
-        const lifter = createLifting(rctx, optionModel(prim(PrimitiveValType.U32)));
+        const lifter = createLifting(rctx.resolved, optionModel(prim(PrimitiveValType.U32)));
         expect(lifter(bctx, 0)).toEqual([1, 0]);
     });
 
     test('false lifts to [1, 0] for option<bool>', () => {
-        const lifter = createLifting(rctx, optionModel(prim(PrimitiveValType.Bool)));
+        const lifter = createLifting(rctx.resolved, optionModel(prim(PrimitiveValType.Bool)));
         expect(lifter(bctx, false)).toEqual([1, 0]);
     });
 
     test('true lifts to [1, 1] for option<bool>', () => {
-        const lifter = createLifting(rctx, optionModel(prim(PrimitiveValType.Bool)));
+        const lifter = createLifting(rctx.resolved, optionModel(prim(PrimitiveValType.Bool)));
         expect(lifter(bctx, true)).toEqual([1, 1]);
     });
 });
@@ -133,22 +135,22 @@ describe('option lowering (WASM → JS)', () => {
     });
 
     test('discriminant 0 lowers to null (None)', () => {
-        const lowerer = createLowering(rctx, optionModel(prim(PrimitiveValType.U32)));
+        const lowerer = createLowering(rctx.resolved, optionModel(prim(PrimitiveValType.U32)));
         expect(lowerer(bctx, 0, 0)).toBeNull();
     });
 
     test('discriminant 1 with 42 lowers to 42 (Some(42))', () => {
-        const lowerer = createLowering(rctx, optionModel(prim(PrimitiveValType.U32)));
+        const lowerer = createLowering(rctx.resolved, optionModel(prim(PrimitiveValType.U32)));
         expect(lowerer(bctx, 1, 42)).toBe(42);
     });
 
     test('discriminant 1 with 0 lowers to 0 (Some(0))', () => {
-        const lowerer = createLowering(rctx, optionModel(prim(PrimitiveValType.U32)));
+        const lowerer = createLowering(rctx.resolved, optionModel(prim(PrimitiveValType.U32)));
         expect(lowerer(bctx, 1, 0)).toBe(0);
     });
 
     test('spill is 2 (1 discriminant + 1 u32)', () => {
-        const lowerer = createLowering(rctx, optionModel(prim(PrimitiveValType.U32)));
+        const lowerer = createLowering(rctx.resolved, optionModel(prim(PrimitiveValType.U32)));
         expect((lowerer as any).spill).toBe(2);
     });
 });
@@ -175,18 +177,18 @@ describe('nested option<option<u32>>', () => {
         // Actually, for nested options to work with inline models, the inner model
         // needs to be a ComponentTypeDefinedOption directly. Let's use resolvedTypes.
         const innerOption = optionModel(prim(PrimitiveValType.U32));
-        rctx.resolvedTypes = new Map([[0 as any, innerOption as any]]);
+        rctx.resolved.resolvedTypes = new Map([[0 as any, innerOption as any]]);
     });
 
     test('null lifts to [0, 0, 0] (outer None)', () => {
         const model = optionModel({ tag: ModelTag.ComponentValTypeType, value: 0 } as ComponentValType);
-        const lifter = createLifting(rctx, model);
+        const lifter = createLifting(rctx.resolved, model);
         expect(lifter(bctx, null)).toEqual([0, 0, 0]);
     });
 
     test('null inner lifts to [1, 0, 0] (outer Some, inner None)', () => {
         const model = optionModel({ tag: ModelTag.ComponentValTypeType, value: 0 } as ComponentValType);
-        const lifter = createLifting(rctx, model);
+        const lifter = createLifting(rctx.resolved, model);
         expect(lifter(bctx, null)).toEqual([0, 0, 0]);
         // Passing null → inner None: the inner lifter is called with null
         // outer Some(null) means the JS value is null, which means inner is None
@@ -195,31 +197,31 @@ describe('nested option<option<u32>>', () => {
 
     test('42 lifts to [1, 1, 42] (outer Some, inner Some(42))', () => {
         const model = optionModel({ tag: ModelTag.ComponentValTypeType, value: 0 } as ComponentValType);
-        const lifter = createLifting(rctx, model);
+        const lifter = createLifting(rctx.resolved, model);
         expect(lifter(bctx, 42)).toEqual([1, 1, 42]);
     });
 
     test('nested option lowering: [0, 0, 0] → null (outer None)', () => {
         const model = optionModel({ tag: ModelTag.ComponentValTypeType, value: 0 } as ComponentValType);
-        const lowerer = createLowering(rctx, model);
+        const lowerer = createLowering(rctx.resolved, model);
         expect(lowerer(bctx, 0, 0, 0)).toBeNull();
     });
 
     test('nested option lowering: [1, 0, 0] → null (outer Some, inner None)', () => {
         const model = optionModel({ tag: ModelTag.ComponentValTypeType, value: 0 } as ComponentValType);
-        const lowerer = createLowering(rctx, model);
+        const lowerer = createLowering(rctx.resolved, model);
         expect(lowerer(bctx, 1, 0, 0)).toBeNull();
     });
 
     test('nested option lowering: [1, 1, 42] → 42 (outer Some, inner Some(42))', () => {
         const model = optionModel({ tag: ModelTag.ComponentValTypeType, value: 0 } as ComponentValType);
-        const lowerer = createLowering(rctx, model);
+        const lowerer = createLowering(rctx.resolved, model);
         expect(lowerer(bctx, 1, 1, 42)).toBe(42);
     });
 
     test('nested option spill is 3 (1 + 1 + 1)', () => {
         const model = optionModel({ tag: ModelTag.ComponentValTypeType, value: 0 } as ComponentValType);
-        const lowerer = createLowering(rctx, model);
+        const lowerer = createLowering(rctx.resolved, model);
         expect((lowerer as any).spill).toBe(3);
     });
 });
@@ -242,17 +244,17 @@ describe('result lifting (JS → WASM)', () => {
     });
 
     test('{tag:"ok", val:42} lifts to [0, 42]', () => {
-        const lifter = createLifting(rctx, resultU32S32Model);
+        const lifter = createLifting(rctx.resolved, resultU32S32Model);
         expect(lifter(bctx, { tag: 'ok', val: 42 })).toEqual([0, 42]);
     });
 
     test('{tag:"err", val:-1} lifts to [1, -1]', () => {
-        const lifter = createLifting(rctx, resultU32S32Model);
+        const lifter = createLifting(rctx.resolved, resultU32S32Model);
         expect(lifter(bctx, { tag: 'err', val: -1 })).toEqual([1, -1]);
     });
 
     test('{tag:"ok", val:0} lifts to [0, 0]', () => {
-        const lifter = createLifting(rctx, resultU32S32Model);
+        const lifter = createLifting(rctx.resolved, resultU32S32Model);
         expect(lifter(bctx, { tag: 'ok', val: 0 })).toEqual([0, 0]);
     });
 });
@@ -275,22 +277,22 @@ describe('result lowering (WASM → JS)', () => {
     });
 
     test('discriminant 0 with 42 lowers to {tag:"ok", val:42}', () => {
-        const lowerer = createLowering(rctx, resultU32S32Model);
+        const lowerer = createLowering(rctx.resolved, resultU32S32Model);
         expect(lowerer(bctx, 0, 42)).toEqual({ tag: 'ok', val: 42 });
     });
 
     test('discriminant 1 with -1 lowers to {tag:"err", val:-1}', () => {
-        const lowerer = createLowering(rctx, resultU32S32Model);
+        const lowerer = createLowering(rctx.resolved, resultU32S32Model);
         expect(lowerer(bctx, 1, -1)).toEqual({ tag: 'err', val: -1 });
     });
 
     test('discriminant 0 with 0 lowers to {tag:"ok", val:0}', () => {
-        const lowerer = createLowering(rctx, resultU32S32Model);
+        const lowerer = createLowering(rctx.resolved, resultU32S32Model);
         expect(lowerer(bctx, 0, 0)).toEqual({ tag: 'ok', val: 0 });
     });
 
     test('spill is 2 (1 discriminant + max(1,1))', () => {
-        const lowerer = createLowering(rctx, resultU32S32Model);
+        const lowerer = createLowering(rctx.resolved, resultU32S32Model);
         expect((lowerer as any).spill).toBe(2);
     });
 });
@@ -312,27 +314,27 @@ describe('result with no error type', () => {
     });
 
     test('{tag:"ok", val:42} lifts to [0, 42]', () => {
-        const lifter = createLifting(rctx, resultOkOnlyModel);
+        const lifter = createLifting(rctx.resolved, resultOkOnlyModel);
         expect(lifter(bctx, { tag: 'ok', val: 42 })).toEqual([0, 42]);
     });
 
     test('{tag:"err"} lifts to [1, 0]', () => {
-        const lifter = createLifting(rctx, resultOkOnlyModel);
+        const lifter = createLifting(rctx.resolved, resultOkOnlyModel);
         expect(lifter(bctx, { tag: 'err' })).toEqual([1, 0]);
     });
 
     test('lowering ok: discriminant 0 with 42 → {tag:"ok", val:42}', () => {
-        const lowerer = createLowering(rctx, resultOkOnlyModel);
+        const lowerer = createLowering(rctx.resolved, resultOkOnlyModel);
         expect(lowerer(bctx, 0, 42)).toEqual({ tag: 'ok', val: 42 });
     });
 
     test('lowering err: discriminant 1 → {tag:"err", val:undefined}', () => {
-        const lowerer = createLowering(rctx, resultOkOnlyModel);
+        const lowerer = createLowering(rctx.resolved, resultOkOnlyModel);
         expect(lowerer(bctx, 1, 0)).toEqual({ tag: 'err', val: undefined });
     });
 
     test('spill is 2 (1 discriminant + max(1,0)=1)', () => {
-        const lowerer = createLowering(rctx, resultOkOnlyModel);
+        const lowerer = createLowering(rctx.resolved, resultOkOnlyModel);
         expect((lowerer as any).spill).toBe(2);
     });
 });
@@ -354,22 +356,22 @@ describe('result with no ok type (error-only)', () => {
     });
 
     test('{tag:"ok"} lifts to [0, 0]', () => {
-        const lifter = createLifting(rctx, resultErrOnlyModel);
+        const lifter = createLifting(rctx.resolved, resultErrOnlyModel);
         expect(lifter(bctx, { tag: 'ok' })).toEqual([0, 0]);
     });
 
     test('{tag:"err", val:-99} lifts to [1, -99]', () => {
-        const lifter = createLifting(rctx, resultErrOnlyModel);
+        const lifter = createLifting(rctx.resolved, resultErrOnlyModel);
         expect(lifter(bctx, { tag: 'err', val: -99 })).toEqual([1, -99]);
     });
 
     test('lowering ok: discriminant 0 → {tag:"ok", val:undefined}', () => {
-        const lowerer = createLowering(rctx, resultErrOnlyModel);
+        const lowerer = createLowering(rctx.resolved, resultErrOnlyModel);
         expect(lowerer(bctx, 0, 0)).toEqual({ tag: 'ok', val: undefined });
     });
 
     test('lowering err: discriminant 1 with -99 → {tag:"err", val:-99}', () => {
-        const lowerer = createLowering(rctx, resultErrOnlyModel);
+        const lowerer = createLowering(rctx.resolved, resultErrOnlyModel);
         expect(lowerer(bctx, 1, -99)).toEqual({ tag: 'err', val: -99 });
     });
 });
@@ -390,7 +392,7 @@ describe('list lifting (JS → WASM)', () => {
     test('[1, 2, 3] lifts to [ptr, 3] with correct memory layout', () => {
         const rctx = createMinimalRctx();
         const { ctx, buffer } = createMockMemoryContext();
-        const lifter = createLifting(rctx, listU32Model);
+        const lifter = createLifting(rctx.resolved, listU32Model);
         const result = lifter(ctx, [1, 2, 3]);
 
         expect(result).toHaveLength(2);
@@ -407,14 +409,14 @@ describe('list lifting (JS → WASM)', () => {
     test('empty array lifts to [0, 0]', () => {
         const rctx = createMinimalRctx();
         const { ctx } = createMockMemoryContext();
-        const lifter = createLifting(rctx, listU32Model);
+        const lifter = createLifting(rctx.resolved, listU32Model);
         expect(lifter(ctx, [])).toEqual([0, 0]);
     });
 
     test('single-element list lifts correctly', () => {
         const rctx = createMinimalRctx();
         const { ctx, buffer } = createMockMemoryContext();
-        const lifter = createLifting(rctx, listU32Model);
+        const lifter = createLifting(rctx.resolved, listU32Model);
         const result = lifter(ctx, [99]);
 
         expect(result).toHaveLength(2);
@@ -428,7 +430,7 @@ describe('list lifting (JS → WASM)', () => {
     test('list<bool> [true, false, true] stores [1, 0, 1] in memory', () => {
         const rctx = createMinimalRctx();
         const { ctx, buffer } = createMockMemoryContext();
-        const lifter = createLifting(rctx, listBoolModel);
+        const lifter = createLifting(rctx.resolved, listBoolModel);
         const result = lifter(ctx, [true, false, true]);
 
         expect(result).toHaveLength(2);
@@ -466,14 +468,14 @@ describe('list lowering (WASM → JS)', () => {
         dv.setUint32(4, 2, true);
         dv.setUint32(8, 3, true);
 
-        const lowerer = createLowering(rctx, listU32Model);
+        const lowerer = createLowering(rctx.resolved, listU32Model);
         expect(lowerer(ctx, 0, 3)).toEqual([1, 2, 3]);
     });
 
     test('[ptr, 0] lowers to empty array', () => {
         const rctx = createMinimalRctx();
         const { ctx } = createMockMemoryContext();
-        const lowerer = createLowering(rctx, listU32Model);
+        const lowerer = createLowering(rctx.resolved, listU32Model);
         expect(lowerer(ctx, 0, 0)).toEqual([]);
     });
 
@@ -487,13 +489,13 @@ describe('list lowering (WASM → JS)', () => {
         view[1] = 0;
         view[2] = 1;
 
-        const lowerer = createLowering(rctx, listBoolModel);
+        const lowerer = createLowering(rctx.resolved, listBoolModel);
         expect(lowerer(ctx, 0, 3)).toEqual([true, false, true]);
     });
 
     test('spill is 2 (ptr + len)', () => {
         const rctx = createMinimalRctx();
-        const lowerer = createLowering(rctx, listU32Model);
+        const lowerer = createLowering(rctx.resolved, listU32Model);
         expect((lowerer as any).spill).toBe(2);
     });
 });
@@ -508,17 +510,17 @@ describe('compound type spill counts', () => {
     });
 
     test('option<u32> spill = 2', () => {
-        const lowerer = createLowering(rctx, optionModel(prim(PrimitiveValType.U32)));
+        const lowerer = createLowering(rctx.resolved, optionModel(prim(PrimitiveValType.U32)));
         expect((lowerer as any).spill).toBe(2);
     });
 
     test('option<bool> spill = 2', () => {
-        const lowerer = createLowering(rctx, optionModel(prim(PrimitiveValType.Bool)));
+        const lowerer = createLowering(rctx.resolved, optionModel(prim(PrimitiveValType.Bool)));
         expect((lowerer as any).spill).toBe(2);
     });
 
     test('option<f64> spill = 2', () => {
-        const lowerer = createLowering(rctx, optionModel(prim(PrimitiveValType.Float64)));
+        const lowerer = createLowering(rctx.resolved, optionModel(prim(PrimitiveValType.Float64)));
         expect((lowerer as any).spill).toBe(2);
     });
 
@@ -528,7 +530,7 @@ describe('compound type spill counts', () => {
             ok: prim(PrimitiveValType.U32),
             err: prim(PrimitiveValType.S32),
         };
-        const lowerer = createLowering(rctx, model);
+        const lowerer = createLowering(rctx.resolved, model);
         expect((lowerer as any).spill).toBe(2);
     });
 
@@ -537,7 +539,7 @@ describe('compound type spill counts', () => {
             tag: ModelTag.ComponentTypeDefinedResult as const,
             err: prim(PrimitiveValType.S32),
         };
-        const lowerer = createLowering(rctx, model);
+        const lowerer = createLowering(rctx.resolved, model);
         expect((lowerer as any).spill).toBe(2);
     });
 
@@ -546,7 +548,7 @@ describe('compound type spill counts', () => {
             tag: ModelTag.ComponentTypeDefinedResult as const,
             ok: prim(PrimitiveValType.U32),
         };
-        const lowerer = createLowering(rctx, model);
+        const lowerer = createLowering(rctx.resolved, model);
         expect((lowerer as any).spill).toBe(2);
     });
 
@@ -555,7 +557,7 @@ describe('compound type spill counts', () => {
             tag: ModelTag.ComponentTypeDefinedList as const,
             value: prim(PrimitiveValType.U32),
         };
-        const lowerer = createLowering(rctx, model);
+        const lowerer = createLowering(rctx.resolved, model);
         expect((lowerer as any).spill).toBe(2);
     });
 });
@@ -571,10 +573,10 @@ describe('list round-trip', () => {
             value: prim(PrimitiveValType.U32),
         };
 
-        const lifter = createLifting(rctx, listU32Model);
+        const lifter = createLifting(rctx.resolved, listU32Model);
         // Need a separate rctx to avoid memoization returning the same object
         const rctx2 = createMinimalRctx();
-        const lowerer = createLowering(rctx2, listU32Model);
+        const lowerer = createLowering(rctx2.resolved, listU32Model);
 
         const original = [10, 20, 30, 40, 50];
         const [ptr, len] = lifter(ctx, original);
@@ -604,22 +606,22 @@ describe('variant lifting', () => {
     });
 
     test('{tag:"none"} lifts to [0, 0]', () => {
-        const lifter = createLifting(rctx, variantModel);
+        const lifter = createLifting(rctx.resolved, variantModel);
         expect(lifter(bctx, { tag: 'none' })).toEqual([0, 0]);
     });
 
     test('{tag:"some-int", val:42} lifts to [1, 42]', () => {
-        const lifter = createLifting(rctx, variantModel);
+        const lifter = createLifting(rctx.resolved, variantModel);
         expect(lifter(bctx, { tag: 'some-int', val: 42 })).toEqual([1, 42]);
     });
 
     test('{tag:"some-bool", val:true} lifts to [2, 1]', () => {
-        const lifter = createLifting(rctx, variantModel);
+        const lifter = createLifting(rctx.resolved, variantModel);
         expect(lifter(bctx, { tag: 'some-bool', val: true })).toEqual([2, 1]);
     });
 
     test('unknown tag throws', () => {
-        const lifter = createLifting(rctx, variantModel);
+        const lifter = createLifting(rctx.resolved, variantModel);
         expect(() => lifter(bctx, { tag: 'unknown' })).toThrow('Unknown variant case: unknown');
     });
 });
@@ -645,22 +647,22 @@ describe('variant lowering', () => {
     });
 
     test('discriminant 0 lowers to {tag:"none"}', () => {
-        const lowerer = createLowering(rctx, variantModel);
+        const lowerer = createLowering(rctx.resolved, variantModel);
         expect(lowerer(bctx, 0, 0)).toEqual({ tag: 'none' });
     });
 
     test('discriminant 1 with 42 lowers to {tag:"some-int", val:42}', () => {
-        const lowerer = createLowering(rctx, variantModel);
+        const lowerer = createLowering(rctx.resolved, variantModel);
         expect(lowerer(bctx, 1, 42)).toEqual({ tag: 'some-int', val: 42 });
     });
 
     test('discriminant 2 with 1 lowers to {tag:"some-bool", val:true}', () => {
-        const lowerer = createLowering(rctx, variantModel);
+        const lowerer = createLowering(rctx.resolved, variantModel);
         expect(lowerer(bctx, 2, 1)).toEqual({ tag: 'some-bool', val: true });
     });
 
     test('spill is 2 (1 discriminant + max 1 payload)', () => {
-        const lowerer = createLowering(rctx, variantModel);
+        const lowerer = createLowering(rctx.resolved, variantModel);
         expect((lowerer as any).spill).toBe(2);
     });
 });
@@ -682,22 +684,22 @@ describe('enum lifting', () => {
     });
 
     test('"red" lifts to [0]', () => {
-        const lifter = createLifting(rctx, enumModel);
+        const lifter = createLifting(rctx.resolved, enumModel);
         expect(lifter(bctx, 'red')).toEqual([0]);
     });
 
     test('"green" lifts to [1]', () => {
-        const lifter = createLifting(rctx, enumModel);
+        const lifter = createLifting(rctx.resolved, enumModel);
         expect(lifter(bctx, 'green')).toEqual([1]);
     });
 
     test('"blue" lifts to [2]', () => {
-        const lifter = createLifting(rctx, enumModel);
+        const lifter = createLifting(rctx.resolved, enumModel);
         expect(lifter(bctx, 'blue')).toEqual([2]);
     });
 
     test('unknown name throws', () => {
-        const lifter = createLifting(rctx, enumModel);
+        const lifter = createLifting(rctx.resolved, enumModel);
         expect(() => lifter(bctx, 'yellow')).toThrow('Unknown enum value: yellow');
     });
 });
@@ -719,22 +721,22 @@ describe('enum lowering', () => {
     });
 
     test('discriminant 0 lowers to "red"', () => {
-        const lowerer = createLowering(rctx, enumModel);
+        const lowerer = createLowering(rctx.resolved, enumModel);
         expect(lowerer(bctx, 0)).toBe('red');
     });
 
     test('discriminant 1 lowers to "green"', () => {
-        const lowerer = createLowering(rctx, enumModel);
+        const lowerer = createLowering(rctx.resolved, enumModel);
         expect(lowerer(bctx, 1)).toBe('green');
     });
 
     test('discriminant 2 lowers to "blue"', () => {
-        const lowerer = createLowering(rctx, enumModel);
+        const lowerer = createLowering(rctx.resolved, enumModel);
         expect(lowerer(bctx, 2)).toBe('blue');
     });
 
     test('spill is 1', () => {
-        const lowerer = createLowering(rctx, enumModel);
+        const lowerer = createLowering(rctx.resolved, enumModel);
         expect((lowerer as any).spill).toBe(1);
     });
 });
@@ -756,22 +758,22 @@ describe('flags lifting', () => {
     });
 
     test('{readable:true, writable:false, executable:true} lifts to [5]', () => {
-        const lifter = createLifting(rctx, flagsModel);
+        const lifter = createLifting(rctx.resolved, flagsModel);
         expect(lifter(bctx, { readable: true, writable: false, executable: true })).toEqual([5]);
     });
 
     test('all false lifts to [0]', () => {
-        const lifter = createLifting(rctx, flagsModel);
+        const lifter = createLifting(rctx.resolved, flagsModel);
         expect(lifter(bctx, { readable: false, writable: false, executable: false })).toEqual([0]);
     });
 
     test('all true lifts to [7]', () => {
-        const lifter = createLifting(rctx, flagsModel);
+        const lifter = createLifting(rctx.resolved, flagsModel);
         expect(lifter(bctx, { readable: true, writable: true, executable: true })).toEqual([7]);
     });
 
     test('empty object lifts to [0] (missing flags are false)', () => {
-        const lifter = createLifting(rctx, flagsModel);
+        const lifter = createLifting(rctx.resolved, flagsModel);
         expect(lifter(bctx, {})).toEqual([0]);
     });
 
@@ -780,7 +782,7 @@ describe('flags lifting', () => {
             tag: ModelTag.ComponentTypeDefinedFlags as const,
             members: Array.from({ length: 33 }, (_, i) => `flag${i}`),
         };
-        const lifter = createLifting(rctx, bigFlagsModel);
+        const lifter = createLifting(rctx.resolved, bigFlagsModel);
         // Set flag0 (bit 0 of word 0) and flag32 (bit 0 of word 1)
         const flags: Record<string, boolean> = {};
         for (let i = 0; i < 33; i++) flags[`flag${i}`] = false;
@@ -807,22 +809,22 @@ describe('flags lowering', () => {
     });
 
     test('5 lowers to {readable:true, writable:false, executable:true}', () => {
-        const lowerer = createLowering(rctx, flagsModel);
+        const lowerer = createLowering(rctx.resolved, flagsModel);
         expect(lowerer(bctx, 5)).toEqual({ readable: true, writable: false, executable: true });
     });
 
     test('0 lowers to all false', () => {
-        const lowerer = createLowering(rctx, flagsModel);
+        const lowerer = createLowering(rctx.resolved, flagsModel);
         expect(lowerer(bctx, 0)).toEqual({ readable: false, writable: false, executable: false });
     });
 
     test('7 lowers to all true', () => {
-        const lowerer = createLowering(rctx, flagsModel);
+        const lowerer = createLowering(rctx.resolved, flagsModel);
         expect(lowerer(bctx, 7)).toEqual({ readable: true, writable: true, executable: true });
     });
 
     test('spill is 1', () => {
-        const lowerer = createLowering(rctx, flagsModel);
+        const lowerer = createLowering(rctx.resolved, flagsModel);
         expect((lowerer as any).spill).toBe(1);
     });
 
@@ -831,7 +833,7 @@ describe('flags lowering', () => {
             tag: ModelTag.ComponentTypeDefinedFlags as const,
             members: Array.from({ length: 33 }, (_, i) => `flag${i}`),
         };
-        const lowerer = createLowering(rctx, bigFlagsModel);
+        const lowerer = createLowering(rctx.resolved, bigFlagsModel);
         expect((lowerer as any).spill).toBe(2);
         // word0 = 1 (flag0 set), word1 = 1 (flag32 set)
         const result = lowerer(bctx, 1, 1);
@@ -861,12 +863,12 @@ describe('tuple lifting', () => {
     });
 
     test('[-5, 200] lifts to [-5, 200]', () => {
-        const lifter = createLifting(rctx, tupleModel);
+        const lifter = createLifting(rctx.resolved, tupleModel);
         expect(lifter(bctx, [-5, 200])).toEqual([-5, 200]);
     });
 
     test('[0, 0] lifts to [0, 0]', () => {
-        const lifter = createLifting(rctx, tupleModel);
+        const lifter = createLifting(rctx.resolved, tupleModel);
         expect(lifter(bctx, [0, 0])).toEqual([0, 0]);
     });
 });
@@ -891,12 +893,12 @@ describe('tuple lowering', () => {
     });
 
     test('(-5, 200) lowers to [-5, 200]', () => {
-        const lowerer = createLowering(rctx, tupleModel);
+        const lowerer = createLowering(rctx.resolved, tupleModel);
         expect(lowerer(bctx, -5, 200)).toEqual([-5, 200]);
     });
 
     test('spill is 2', () => {
-        const lowerer = createLowering(rctx, tupleModel);
+        const lowerer = createLowering(rctx.resolved, tupleModel);
         expect((lowerer as any).spill).toBe(2);
     });
 });

--- a/src/resolver/binding/edge-cases.test.ts
+++ b/src/resolver/binding/edge-cases.test.ts
@@ -3,10 +3,10 @@ setConfiguration('Debug');
 
 import { ModelTag } from '../../model/tags';
 import { ComponentValType, PrimitiveValType } from '../../model/types';
-import { ResolverContext, BindingContext } from '../types';
+import { ResolverContext, BindingContext, StringEncoding } from '../types';
 import { createResourceTable } from '../context';
-import { createLifting, storeToMemory } from './to-abi';
-import { createLowering, loadFromMemory } from './to-js';
+import { createLifting, createFunctionLifting, storeToMemory } from './to-abi';
+import { createLowering, createFunctionLowering, loadFromMemory } from './to-js';
 import { WasmPointer, WasmSize } from './types';
 
 function createMinimalRctx(usesNumberForInt64 = false): ResolverContext {
@@ -14,6 +14,7 @@ function createMinimalRctx(usesNumberForInt64 = false): ResolverContext {
         memoizeCache: new Map(),
         resolvedTypes: new Map(),
         usesNumberForInt64,
+        stringEncoding: StringEncoding.Utf8,
     } as any as ResolverContext;
 }
 
@@ -21,8 +22,8 @@ function createMinimalBctx(): BindingContext {
     return {} as any as BindingContext;
 }
 
-function createMockMemoryContext(): { ctx: BindingContext, buffer: ArrayBuffer } {
-    const buffer = new ArrayBuffer(4096);
+function createMockMemoryContext(bufferSize = 4096): { ctx: BindingContext, buffer: ArrayBuffer } {
+    const buffer = new ArrayBuffer(bufferSize);
     let nextAlloc = 16; // start at 16 so ptr is never 0 for valid allocations
 
     const memory = {
@@ -2117,5 +2118,281 @@ describe('nested types via memory round-trips', () => {
         expect(new DataView(buffer, 200).getUint8(0)).toBe(1);
         const errResult = loadFromMemory(ctx, rctx, 200, model as any);
         expect(errResult).toEqual({ tag: 'err', val: 7 });
+    });
+});
+
+// ─── Function trampoline edge cases ────────────────────────────────────────
+
+describe('function trampoline edge cases', () => {
+    function createFuncRctx(): ResolverContext {
+        return {
+            memoizeCache: new Map(),
+            resolvedTypes: new Map(),
+            usesNumberForInt64: false,
+            stringEncoding: StringEncoding.Utf8,
+            indexes: {
+                coreModules: [],
+                coreInstances: [],
+                coreFunctions: [],
+                coreMemories: [],
+                coreGlobals: [],
+                coreTables: [],
+                componentImports: [],
+                componentExports: [],
+                componentInstances: [],
+                componentTypeResource: [],
+                componentFunctions: [],
+                componentTypes: [],
+                componentSections: [],
+            },
+        } as any as ResolverContext;
+    }
+
+    function createFuncBctx(): { ctx: BindingContext, buffer: ArrayBuffer } {
+        const buffer = new ArrayBuffer(4096);
+        let nextAlloc = 64;
+        const memory = {
+            initialize() { },
+            getMemory: () => ({ buffer } as any),
+            getView(ptr: WasmPointer, len: WasmSize): DataView { return new DataView(buffer, ptr as number, len as number); },
+            getViewU8(ptr: WasmPointer, len: WasmSize): Uint8Array { return new Uint8Array(buffer, ptr as number, len as number); },
+            readI32(ptr: WasmPointer): number { return new DataView(buffer).getInt32(ptr as number, true); },
+            writeI32(ptr: WasmPointer, val: number): void { new DataView(buffer).setInt32(ptr as number, val, true); },
+        };
+        const allocator = {
+            initialize() { },
+            alloc(newSize: WasmSize, align: WasmSize): WasmPointer {
+                const aligned = ((nextAlloc + (align as number) - 1) & ~((align as number) - 1));
+                nextAlloc = aligned + (newSize as number);
+                return aligned as WasmPointer;
+            },
+            realloc(oldPtr: WasmPointer, oldSize: WasmSize, align: WasmSize, newSize: WasmSize): WasmPointer {
+                if ((newSize as number) === 0) return 0 as WasmPointer;
+                const aligned = ((nextAlloc + (align as number) - 1) & ~((align as number) - 1));
+                nextAlloc = aligned + (newSize as number);
+                if ((oldPtr as number) !== 0 && (oldSize as number) > 0) {
+                    const copyLen = Math.min(oldSize as number, newSize as number);
+                    new Uint8Array(buffer, aligned, copyLen).set(new Uint8Array(buffer, oldPtr as number, copyLen));
+                }
+                return aligned as WasmPointer;
+            },
+        };
+        const ctx = {
+            memory,
+            allocator,
+            utf8Encoder: new TextEncoder(),
+            utf8Decoder: new TextDecoder(),
+            instances: { coreInstances: [], componentInstances: [] },
+            componentImports: {},
+            abort: () => { },
+        } as any as BindingContext;
+        return { ctx, buffer };
+    }
+
+    test('lowering trampoline with named results (empty values = void)', () => {
+        const rctx = createFuncRctx();
+        const { ctx } = createFuncBctx();
+        const func = {
+            tag: ModelTag.ComponentTypeFunc,
+            params: [{ name: 'a', type: prim(PrimitiveValType.U32) }],
+            results: { tag: ModelTag.ComponentFuncResultNamed, values: [] },
+        } as any;
+        const lowerer = createFunctionLowering(rctx, func);
+
+        let received: number | undefined;
+        const mockJs = (x: number) => { received = x; };
+        const wasmFunc = lowerer(ctx, mockJs as any);
+        const result = wasmFunc(42);
+        expect(received).toBe(42);
+        expect(result).toBeUndefined();
+    });
+
+    test('lifting trampoline: exception poisons instance', () => {
+        const rctx = createFuncRctx();
+        const { ctx } = createFuncBctx();
+        const func = {
+            tag: ModelTag.ComponentTypeFunc,
+            params: [],
+            results: { tag: ModelTag.ComponentFuncResultUnnamed, type: prim(PrimitiveValType.U32) },
+        } as any;
+        const lifter = createFunctionLifting(rctx, func);
+
+        const mockWasm = () => { throw new Error('trap!'); };
+        const jsFunc = lifter(ctx, mockWasm as any);
+        expect(() => jsFunc()).toThrow('trap!');
+        expect(ctx.poisoned).toBe(true);
+    });
+
+    test('lifting trampoline: poisoned instance blocks further calls', () => {
+        const rctx = createFuncRctx();
+        const { ctx } = createFuncBctx();
+        const func = {
+            tag: ModelTag.ComponentTypeFunc,
+            params: [],
+            results: { tag: ModelTag.ComponentFuncResultNamed, values: [] },
+        } as any;
+        const lifter = createFunctionLifting(rctx, func);
+
+        ctx.poisoned = true;
+        const mockWasm = () => { };
+        const jsFunc = lifter(ctx, mockWasm as any);
+        expect(() => jsFunc()).toThrow('poisoned');
+    });
+
+    test('lifting trampoline: reentrant call is trapped', () => {
+        const rctx = createFuncRctx();
+        const { ctx } = createFuncBctx();
+        const func = {
+            tag: ModelTag.ComponentTypeFunc,
+            params: [],
+            results: { tag: ModelTag.ComponentFuncResultNamed, values: [] },
+        } as any;
+        const lifter = createFunctionLifting(rctx, func);
+
+        ctx.inExport = true; // simulate already in export
+        const mockWasm = () => { };
+        const jsFunc = lifter(ctx, mockWasm as any);
+        expect(() => jsFunc()).toThrow('reenter');
+    });
+
+    test('lowering trampoline with bool params and result', () => {
+        const rctx = createFuncRctx();
+        const { ctx } = createFuncBctx();
+        const func = {
+            tag: ModelTag.ComponentTypeFunc,
+            params: [
+                { name: 'a', type: prim(PrimitiveValType.Bool) },
+                { name: 'b', type: prim(PrimitiveValType.Bool) },
+            ],
+            results: { tag: ModelTag.ComponentFuncResultUnnamed, type: prim(PrimitiveValType.Bool) },
+        } as any;
+        const lowerer = createFunctionLowering(rctx, func);
+
+        const mockJs = (a: boolean, b: boolean) => a && b;
+        const wasmFunc = lowerer(ctx, mockJs as any);
+        // WASM passes i32 values, JS receives booleans
+        expect(wasmFunc(1, 1)).toEqual([1]); // true && true = true → lifted back to 1
+        expect(wasmFunc(1, 0)).toEqual([0]); // true && false = false → lifted back to 0
+    });
+
+    test('lowering trampoline with 0-param function', () => {
+        const rctx = createFuncRctx();
+        const { ctx } = createFuncBctx();
+        const func = {
+            tag: ModelTag.ComponentTypeFunc,
+            params: [],
+            results: { tag: ModelTag.ComponentFuncResultUnnamed, type: prim(PrimitiveValType.U32) },
+        } as any;
+        const lowerer = createFunctionLowering(rctx, func);
+
+        const mockJs = () => 42;
+        const wasmFunc = lowerer(ctx, mockJs as any);
+        expect(wasmFunc()).toEqual([42]);
+    });
+});
+
+// ─── Variant lowering edge cases ───────────────────────────────────────────
+
+describe('variant lowering validation', () => {
+    let rctx: ResolverContext;
+    let bctx: BindingContext;
+
+    beforeEach(() => {
+        rctx = createMinimalRctx();
+        bctx = createMinimalBctx();
+    });
+
+    test('variant lowering with out-of-range discriminant throws', () => {
+        const model = {
+            tag: ModelTag.ComponentTypeDefinedVariant as const,
+            variants: [
+                { name: 'a', ty: prim(PrimitiveValType.U32) },
+                { name: 'b' },
+            ],
+        };
+        const lowerer = createLowering(rctx, model);
+        // discriminant 5 is out of range — throws
+        expect(() => lowerer(bctx, 5, 42)).toThrow('Invalid variant discriminant');
+    });
+
+    test('variant lifting with unknown tag name throws', () => {
+        const model = {
+            tag: ModelTag.ComponentTypeDefinedVariant as const,
+            variants: [
+                { name: 'a', ty: prim(PrimitiveValType.U32) },
+                { name: 'b' },
+            ],
+        };
+        const lifter = createLifting(rctx, model);
+        expect(() => lifter(bctx, { tag: 'nonexistent', val: 0 })).toThrow();
+    });
+
+    test('variant with no-payload case lifts without val', () => {
+        const model = {
+            tag: ModelTag.ComponentTypeDefinedVariant as const,
+            variants: [
+                { name: 'empty' },
+                { name: 'data', ty: prim(PrimitiveValType.U32) },
+            ],
+        };
+        const lifter = createLifting(rctx, model);
+        const rctx2 = createMinimalRctx();
+        const lowerer = createLowering(rctx2, model);
+        const lifted = lifter(bctx, { tag: 'empty' });
+        const lowered = lowerer(bctx, ...lifted);
+        expect(lowered).toEqual({ tag: 'empty' });
+    });
+});
+
+// ─── CompactUTF-16 encoding error ──────────────────────────────────────────
+
+describe('CompactUTF-16 encoding', () => {
+    test('lifting with CompactUTF-16 throws not-supported', () => {
+        const rctx = {
+            memoizeCache: new Map(),
+            resolvedTypes: new Map(),
+            usesNumberForInt64: false,
+            stringEncoding: StringEncoding.CompactUtf16,
+        } as any as ResolverContext;
+        expect(() => createLifting(rctx, prim(PrimitiveValType.String)))
+            .toThrow('CompactUTF-16');
+    });
+
+    test('lowering with CompactUTF-16 throws not-supported', () => {
+        const rctx = {
+            memoizeCache: new Map(),
+            resolvedTypes: new Map(),
+            usesNumberForInt64: false,
+            stringEncoding: StringEncoding.CompactUtf16,
+        } as any as ResolverContext;
+        expect(() => createLowering(rctx, prim(PrimitiveValType.String)))
+            .toThrow('CompactUTF-16');
+    });
+});
+
+// ─── UTF-16 string out-of-bounds ───────────────────────────────────────────
+
+describe('UTF-16 string bounds checking', () => {
+    test('UTF-16 lowering out-of-bounds traps', () => {
+        const rctx = {
+            memoizeCache: new Map(),
+            resolvedTypes: new Map(),
+            usesNumberForInt64: false,
+            stringEncoding: StringEncoding.Utf16,
+        } as any as ResolverContext;
+        const { ctx } = createMockMemoryContext(64);
+        const lowerer = createLowering(rctx, prim(PrimitiveValType.String));
+        // 100 code units = 200 bytes, but buffer is only 64 bytes
+        expect(() => (lowerer as any)(ctx, 0, 100))
+            .toThrow('out of bounds');
+    });
+
+    test('UTF-8 lowering out-of-bounds traps', () => {
+        const rctx = createMinimalRctx();
+        const { ctx } = createMockMemoryContext(64);
+        const lowerer = createLowering(rctx, prim(PrimitiveValType.String));
+        // 100 bytes but buffer is only 64
+        expect(() => (lowerer as any)(ctx, 0, 100))
+            .toThrow('out of bounds');
     });
 });

--- a/src/resolver/binding/edge-cases.test.ts
+++ b/src/resolver/binding/edge-cases.test.ts
@@ -13,7 +13,7 @@ import { deepResolveType } from '../calling-convention';
 function createMinimalRctx(usesNumberForInt64 = false): ResolverContext {
     return {
         resolved: {
-            memoizeCache: new Map(),
+            liftingCache: new Map(), loweringCache: new Map(),
             resolvedTypes: new Map(),
             canonicalResourceIds: new Map(),
             usesNumberForInt64,
@@ -2131,7 +2131,7 @@ describe('function trampoline edge cases', () => {
     function createFuncRctx(): ResolverContext {
         return {
             resolved: {
-                memoizeCache: new Map(),
+                liftingCache: new Map(), loweringCache: new Map(),
                 resolvedTypes: new Map(),
                 usesNumberForInt64: false,
                 stringEncoding: StringEncoding.Utf8,
@@ -2356,7 +2356,7 @@ describe('CompactUTF-16 encoding', () => {
     test('lifting with CompactUTF-16 throws not-supported', () => {
         const rctx = {
             resolved: {
-                memoizeCache: new Map(),
+                liftingCache: new Map(), loweringCache: new Map(),
                 resolvedTypes: new Map(),
                 usesNumberForInt64: false,
                 stringEncoding: StringEncoding.CompactUtf16,
@@ -2369,7 +2369,7 @@ describe('CompactUTF-16 encoding', () => {
     test('lowering with CompactUTF-16 throws not-supported', () => {
         const rctx = {
             resolved: {
-                memoizeCache: new Map(),
+                liftingCache: new Map(), loweringCache: new Map(),
                 resolvedTypes: new Map(),
                 usesNumberForInt64: false,
                 stringEncoding: StringEncoding.CompactUtf16,
@@ -2386,7 +2386,7 @@ describe('UTF-16 string bounds checking', () => {
     test('UTF-16 lowering out-of-bounds traps', () => {
         const rctx = {
             resolved: {
-                memoizeCache: new Map(),
+                liftingCache: new Map(), loweringCache: new Map(),
                 resolvedTypes: new Map(),
                 usesNumberForInt64: false,
                 stringEncoding: StringEncoding.Utf16,

--- a/src/resolver/binding/edge-cases.test.ts
+++ b/src/resolver/binding/edge-cases.test.ts
@@ -8,11 +8,13 @@ import { createResourceTable } from '../context';
 import { createLifting, createFunctionLifting, storeToMemory } from './to-abi';
 import { createLowering, createFunctionLowering, loadFromMemory } from './to-js';
 import { WasmPointer, WasmSize } from './types';
+import { deepResolveType } from '../calling-convention';
 
 function createMinimalRctx(usesNumberForInt64 = false): ResolverContext {
     return {
         memoizeCache: new Map(),
         resolvedTypes: new Map(),
+        canonicalResourceIds: new Map(),
         usesNumberForInt64,
         stringEncoding: StringEncoding.Utf8,
     } as any as ResolverContext;
@@ -1711,7 +1713,7 @@ describe('bool from memory (non-0/1 values)', () => {
         };
         // Write 2 to memory
         new DataView(buffer).setUint8(100, 2);
-        const result = loadFromMemory(ctx, rctx, 100, boolType as any);
+        const result = loadFromMemory(ctx, 100, boolType as any, rctx.stringEncoding, rctx.canonicalResourceIds);
         expect(result).toBe(true);
     });
 
@@ -1723,7 +1725,7 @@ describe('bool from memory (non-0/1 values)', () => {
             value: PrimitiveValType.Bool,
         };
         new DataView(buffer).setUint8(100, 255);
-        const result = loadFromMemory(ctx, rctx, 100, boolType as any);
+        const result = loadFromMemory(ctx, 100, boolType as any, rctx.stringEncoding, rctx.canonicalResourceIds);
         expect(result).toBe(true);
     });
 
@@ -1735,7 +1737,7 @@ describe('bool from memory (non-0/1 values)', () => {
             value: PrimitiveValType.Bool,
         };
         new DataView(buffer).setUint8(100, 0);
-        const result = loadFromMemory(ctx, rctx, 100, boolType as any);
+        const result = loadFromMemory(ctx, 100, boolType as any, rctx.stringEncoding, rctx.canonicalResourceIds);
         expect(result).toBe(false);
     });
 
@@ -1746,10 +1748,10 @@ describe('bool from memory (non-0/1 values)', () => {
             tag: ModelTag.ComponentTypeDefinedPrimitive as const,
             value: PrimitiveValType.Bool,
         };
-        storeToMemory(ctx, rctx, 200, boolType as any, true);
+        storeToMemory(ctx, 200, boolType as any, true, rctx.stringEncoding, rctx.canonicalResourceIds);
         expect(new DataView(buffer).getUint8(200)).toBe(1);
 
-        storeToMemory(ctx, rctx, 204, boolType as any, false);
+        storeToMemory(ctx, 204, boolType as any, false, rctx.stringEncoding, rctx.canonicalResourceIds);
         expect(new DataView(buffer).getUint8(204)).toBe(0);
     });
 });
@@ -1765,8 +1767,8 @@ describe('discriminant in memory round-trips', () => {
             tag: ModelTag.ComponentTypeDefinedVariant as const,
             variants: cases,
         };
-        storeToMemory(ctx, rctx, 100, model as any, { tag: 'c255' });
-        const result = loadFromMemory(ctx, rctx, 100, model as any);
+        storeToMemory(ctx, 100, model as any, { tag: 'c255' }, rctx.stringEncoding, rctx.canonicalResourceIds);
+        const result = loadFromMemory(ctx, 100, model as any, rctx.stringEncoding, rctx.canonicalResourceIds);
         expect(result).toEqual({ tag: 'c255' });
     });
 
@@ -1778,8 +1780,8 @@ describe('discriminant in memory round-trips', () => {
             tag: ModelTag.ComponentTypeDefinedEnum as const,
             members,
         };
-        storeToMemory(ctx, rctx, 100, model as any, 'e255');
-        const result = loadFromMemory(ctx, rctx, 100, model as any);
+        storeToMemory(ctx, 100, model as any, 'e255', rctx.stringEncoding, rctx.canonicalResourceIds);
+        const result = loadFromMemory(ctx, 100, model as any, rctx.stringEncoding, rctx.canonicalResourceIds);
         expect(result).toBe('e255');
     });
 
@@ -1793,8 +1795,8 @@ describe('discriminant in memory round-trips', () => {
                 { name: 'big', ty: prim(PrimitiveValType.U32) },
             ],
         };
-        storeToMemory(ctx, rctx, 100, model as any, { tag: 'big', val: 100000 });
-        const result = loadFromMemory(ctx, rctx, 100, model as any);
+        storeToMemory(ctx, 100, model as any, { tag: 'big', val: 100000 }, rctx.stringEncoding, rctx.canonicalResourceIds);
+        const result = loadFromMemory(ctx, 100, model as any, rctx.stringEncoding, rctx.canonicalResourceIds);
         expect(result).toEqual({ tag: 'big', val: 100000 });
     });
 
@@ -1808,8 +1810,8 @@ describe('discriminant in memory round-trips', () => {
             tag: ModelTag.ComponentTypeDefinedEnum as const,
             members,
         };
-        storeToMemory(ctx, rctx, 100, model as any, 'e299');
-        const result = loadFromMemory(ctx, rctx, 100, model as any);
+        storeToMemory(ctx, 100, model as any, 'e299', rctx.stringEncoding, rctx.canonicalResourceIds);
+        const result = loadFromMemory(ctx, 100, model as any, rctx.stringEncoding, rctx.canonicalResourceIds);
         expect(result).toBe('e299');
     });
 
@@ -1821,8 +1823,8 @@ describe('discriminant in memory round-trips', () => {
             tag: ModelTag.ComponentTypeDefinedFlags as const,
             members,
         };
-        storeToMemory(ctx, rctx, 100, model as any, { a: true, b: false, c: true, d: false });
-        const result = loadFromMemory(ctx, rctx, 100, model as any);
+        storeToMemory(ctx, 100, model as any, { a: true, b: false, c: true, d: false }, rctx.stringEncoding, rctx.canonicalResourceIds);
+        const result = loadFromMemory(ctx, 100, model as any, rctx.stringEncoding, rctx.canonicalResourceIds);
         expect(result).toEqual({ a: true, b: false, c: true, d: false });
     });
 
@@ -1838,8 +1840,8 @@ describe('discriminant in memory round-trips', () => {
         for (const m of members) flags[m] = false;
         flags['f0'] = true;
         flags['f32'] = true;
-        storeToMemory(ctx, rctx, 100, model as any, flags);
-        const result = loadFromMemory(ctx, rctx, 100, model as any);
+        storeToMemory(ctx, 100, model as any, flags, rctx.stringEncoding, rctx.canonicalResourceIds);
+        const result = loadFromMemory(ctx, 100, model as any, rctx.stringEncoding, rctx.canonicalResourceIds);
         expect(result['f0']).toBe(true);
         expect(result['f1']).toBe(false);
         expect(result['f32']).toBe(true);
@@ -1852,12 +1854,12 @@ describe('discriminant in memory round-trips', () => {
             tag: ModelTag.ComponentTypeDefinedOption as const,
             value: prim(PrimitiveValType.U32),
         };
-        storeToMemory(ctx, rctx, 100, model as any, 42);
-        const some = loadFromMemory(ctx, rctx, 100, model as any);
+        storeToMemory(ctx, 100, model as any, 42, rctx.stringEncoding, rctx.canonicalResourceIds);
+        const some = loadFromMemory(ctx, 100, model as any, rctx.stringEncoding, rctx.canonicalResourceIds);
         expect(some).toBe(42);
 
-        storeToMemory(ctx, rctx, 200, model as any, null);
-        const none = loadFromMemory(ctx, rctx, 200, model as any);
+        storeToMemory(ctx, 200, model as any, null, rctx.stringEncoding, rctx.canonicalResourceIds);
+        const none = loadFromMemory(ctx, 200, model as any, rctx.stringEncoding, rctx.canonicalResourceIds);
         expect(none).toBeNull();
     });
 
@@ -1869,12 +1871,12 @@ describe('discriminant in memory round-trips', () => {
             ok: prim(PrimitiveValType.U32),
             err: prim(PrimitiveValType.U8),
         };
-        storeToMemory(ctx, rctx, 100, model as any, { tag: 'ok', val: 99 });
-        const okResult = loadFromMemory(ctx, rctx, 100, model as any);
+        storeToMemory(ctx, 100, model as any, { tag: 'ok', val: 99 }, rctx.stringEncoding, rctx.canonicalResourceIds);
+        const okResult = loadFromMemory(ctx, 100, model as any, rctx.stringEncoding, rctx.canonicalResourceIds);
         expect(okResult).toEqual({ tag: 'ok', val: 99 });
 
-        storeToMemory(ctx, rctx, 200, model as any, { tag: 'err', val: 7 });
-        const errResult = loadFromMemory(ctx, rctx, 200, model as any);
+        storeToMemory(ctx, 200, model as any, { tag: 'err', val: 7 }, rctx.stringEncoding, rctx.canonicalResourceIds);
+        const errResult = loadFromMemory(ctx, 200, model as any, rctx.stringEncoding, rctx.canonicalResourceIds);
         expect(errResult).toEqual({ tag: 'err', val: 7 });
     });
 
@@ -1889,8 +1891,8 @@ describe('discriminant in memory round-trips', () => {
                 prim(PrimitiveValType.Bool),
             ],
         };
-        storeToMemory(ctx, rctx, 100, model as any, [255, 100000, true]);
-        const result = loadFromMemory(ctx, rctx, 100, model as any);
+        storeToMemory(ctx, 100, model as any, [255, 100000, true], rctx.stringEncoding, rctx.canonicalResourceIds);
+        const result = loadFromMemory(ctx, 100, model as any, rctx.stringEncoding, rctx.canonicalResourceIds);
         expect(result).toEqual([255, 100000, true]);
     });
 
@@ -1905,8 +1907,8 @@ describe('discriminant in memory round-trips', () => {
                 { name: 'c', type: prim(PrimitiveValType.Bool) },
             ],
         };
-        storeToMemory(ctx, rctx, 100, model as any, { a: 42, b: 100000, c: true });
-        const result = loadFromMemory(ctx, rctx, 100, model as any);
+        storeToMemory(ctx, 100, model as any, { a: 42, b: 100000, c: true }, rctx.stringEncoding, rctx.canonicalResourceIds);
+        const result = loadFromMemory(ctx, 100, model as any, rctx.stringEncoding, rctx.canonicalResourceIds);
         expect(result).toEqual({ a: 42, b: 100000, c: true });
     });
 
@@ -1921,15 +1923,15 @@ describe('discriminant in memory round-trips', () => {
             ],
         };
         rctx.resolvedTypes.set(0 as any, innerRecord as any);
-        const outerRecord = {
+        const outerRecord = deepResolveType(rctx, {
             tag: ModelTag.ComponentTypeDefinedRecord as const,
             members: [
                 { name: 'name', type: prim(PrimitiveValType.U8) },
                 { name: 'point', type: { tag: ModelTag.ComponentValTypeType, value: 0 } as ComponentValType },
             ],
-        };
-        storeToMemory(ctx, rctx, 100, outerRecord as any, { name: 5, point: { x: 10, y: 20 } });
-        const result = loadFromMemory(ctx, rctx, 100, outerRecord as any);
+        } as any);
+        storeToMemory(ctx, 100, outerRecord as any, { name: 5, point: { x: 10, y: 20 } }, rctx.stringEncoding, rctx.canonicalResourceIds);
+        const result = loadFromMemory(ctx, 100, outerRecord as any, rctx.stringEncoding, rctx.canonicalResourceIds);
         expect(result).toEqual({ name: 5, point: { x: 10, y: 20 } });
     });
 
@@ -1953,8 +1955,8 @@ describe('discriminant in memory round-trips', () => {
                 tag: ModelTag.ComponentTypeDefinedPrimitive as const,
                 value: primType,
             };
-            storeToMemory(ctx, rctx, offset, model as any, value);
-            const result = loadFromMemory(ctx, rctx, offset, model as any);
+            storeToMemory(ctx, offset, model as any, value, rctx.stringEncoding, rctx.canonicalResourceIds);
+            const result = loadFromMemory(ctx, offset, model as any, rctx.stringEncoding, rctx.canonicalResourceIds);
             if (primType === PrimitiveValType.Float32) {
                 expect(result).toBeCloseTo(value, 5);
             } else {
@@ -1975,10 +1977,10 @@ describe('resource handle additional edge cases', () => {
         // Add a resource and get a handle
         const _handle = ctx.resources.add(0, 'test-resource');
         // Store handle in memory
-        storeToMemory(ctx, rctx, 100, ownModel as any, 'test-resource');
+        storeToMemory(ctx, 100, ownModel as any, 'test-resource', rctx.stringEncoding, rctx.canonicalResourceIds);
         // The handle was stored by lifting (add), not directly
         // Load removes from table (own semantics)
-        const result = loadFromMemory(ctx, rctx, 100, ownModel as any);
+        const result = loadFromMemory(ctx, 100, ownModel as any, rctx.stringEncoding, rctx.canonicalResourceIds);
         expect(typeof result).toBe('string');
     });
 
@@ -1991,7 +1993,7 @@ describe('resource handle additional edge cases', () => {
         // Write handle to memory
         new DataView(ctx.memory.getView(100 as WasmPointer, 4 as WasmSize).buffer, 100).setInt32(0, handle, true);
         // Load borrow from memory (doesn't remove)
-        const result = loadFromMemory(ctx, rctx, 100, borrowModel as any);
+        const result = loadFromMemory(ctx, 100, borrowModel as any, rctx.stringEncoding, rctx.canonicalResourceIds);
         expect(result).toBe('borrowed-data');
         // Resource should still be in table (borrow doesn't remove)
         expect(ctx.resources.has(0, handle)).toBe(true);
@@ -2089,12 +2091,12 @@ describe('nested types via memory round-trips', () => {
             value: prim(PrimitiveValType.U32),
         };
         // Some(42)
-        storeToMemory(ctx, rctx, 100, model as any, 42);
-        expect(loadFromMemory(ctx, rctx, 100, model as any)).toBe(42);
+        storeToMemory(ctx, 100, model as any, 42, rctx.stringEncoding, rctx.canonicalResourceIds);
+        expect(loadFromMemory(ctx, 100, model as any, rctx.stringEncoding, rctx.canonicalResourceIds)).toBe(42);
 
         // None
-        storeToMemory(ctx, rctx, 200, model as any, null);
-        expect(loadFromMemory(ctx, rctx, 200, model as any)).toBeNull();
+        storeToMemory(ctx, 200, model as any, null, rctx.stringEncoding, rctx.canonicalResourceIds);
+        expect(loadFromMemory(ctx, 200, model as any, rctx.stringEncoding, rctx.canonicalResourceIds)).toBeNull();
     });
 
     test('result<u32, u8> via memory stores discriminant correctly', () => {
@@ -2107,16 +2109,16 @@ describe('nested types via memory round-trips', () => {
         };
 
         // Ok(42)
-        storeToMemory(ctx, rctx, 100, model as any, { tag: 'ok', val: 42 });
+        storeToMemory(ctx, 100, model as any, { tag: 'ok', val: 42 }, rctx.stringEncoding, rctx.canonicalResourceIds);
         // discriminant at byte 0 should be 0 (ok)
         expect(new DataView(buffer, 100).getUint8(0)).toBe(0);
-        const okResult = loadFromMemory(ctx, rctx, 100, model as any);
+        const okResult = loadFromMemory(ctx, 100, model as any, rctx.stringEncoding, rctx.canonicalResourceIds);
         expect(okResult).toEqual({ tag: 'ok', val: 42 });
 
         // Err(7)
-        storeToMemory(ctx, rctx, 200, model as any, { tag: 'err', val: 7 });
+        storeToMemory(ctx, 200, model as any, { tag: 'err', val: 7 }, rctx.stringEncoding, rctx.canonicalResourceIds);
         expect(new DataView(buffer, 200).getUint8(0)).toBe(1);
-        const errResult = loadFromMemory(ctx, rctx, 200, model as any);
+        const errResult = loadFromMemory(ctx, 200, model as any, rctx.stringEncoding, rctx.canonicalResourceIds);
         expect(errResult).toEqual({ tag: 'err', val: 7 });
     });
 });

--- a/src/resolver/binding/edge-cases.test.ts
+++ b/src/resolver/binding/edge-cases.test.ts
@@ -12,11 +12,13 @@ import { deepResolveType } from '../calling-convention';
 
 function createMinimalRctx(usesNumberForInt64 = false): ResolverContext {
     return {
-        memoizeCache: new Map(),
-        resolvedTypes: new Map(),
-        canonicalResourceIds: new Map(),
-        usesNumberForInt64,
-        stringEncoding: StringEncoding.Utf8,
+        resolved: {
+            memoizeCache: new Map(),
+            resolvedTypes: new Map(),
+            canonicalResourceIds: new Map(),
+            usesNumberForInt64,
+            stringEncoding: StringEncoding.Utf8,
+        },
     } as any as ResolverContext;
 }
 
@@ -90,175 +92,175 @@ describe('primitive lifting edge cases', () => {
 
     describe('bool coercion', () => {
         test('null coerces to [0]', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.Bool));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.Bool));
             expect(lifter(bctx, null)).toEqual([0]);
         });
 
         test('undefined coerces to [0]', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.Bool));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.Bool));
             expect(lifter(bctx, undefined)).toEqual([0]);
         });
 
         test('empty string coerces to [0]', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.Bool));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.Bool));
             expect(lifter(bctx, '')).toEqual([0]);
         });
 
         test('non-empty string coerces to [1]', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.Bool));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.Bool));
             expect(lifter(bctx, 'hello')).toEqual([1]);
         });
 
         test('-1 coerces to [1]', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.Bool));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.Bool));
             expect(lifter(bctx, -1)).toEqual([1]);
         });
     });
 
     describe('integer overflow/underflow', () => {
         test('s8: 128 wraps to -128', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.S8));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.S8));
             expect(lifter(bctx, 128)).toEqual([-128]);
         });
 
         test('s8: -129 wraps to 127', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.S8));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.S8));
             expect(lifter(bctx, -129)).toEqual([127]);
         });
 
         test('u8: -1 wraps to 255', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.U8));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.U8));
             expect(lifter(bctx, -1)).toEqual([255]);
         });
 
         test('u8: 512 truncates to 0', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.U8));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.U8));
             expect(lifter(bctx, 512)).toEqual([0]);
         });
 
         test('s16: 32768 wraps to -32768', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.S16));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.S16));
             expect(lifter(bctx, 32768)).toEqual([-32768]);
         });
 
         test('s16: -32769 wraps to 32767', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.S16));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.S16));
             expect(lifter(bctx, -32769)).toEqual([32767]);
         });
 
         test('u16: -1 wraps to 65535', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.U16));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.U16));
             expect(lifter(bctx, -1)).toEqual([65535]);
         });
 
         test('u16: 65536 truncates to 0', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.U16));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.U16));
             expect(lifter(bctx, 65536)).toEqual([0]);
         });
 
         test('s32: 2147483648 wraps to -2147483648', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.S32));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.S32));
             expect(lifter(bctx, 2147483648)).toEqual([-2147483648]);
         });
 
         test('u32: -1 wraps to 4294967295', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.U32));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.U32));
             expect(lifter(bctx, -1)).toEqual([4294967295]);
         });
 
         test('u32: 4294967296 wraps to 0', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.U32));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.U32));
             expect(lifter(bctx, 4294967296)).toEqual([0]);
         });
     });
 
     describe('floating point special values', () => {
         test('f32: NaN lifts to NaN', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.Float32));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.Float32));
             const result = lifter(bctx, NaN);
             expect(result).toHaveLength(1);
             expect(Number.isNaN(result[0])).toBe(true);
         });
 
         test('f32: Infinity lifts to Infinity', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.Float32));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.Float32));
             expect(lifter(bctx, Infinity)).toEqual([Infinity]);
         });
 
         test('f32: -Infinity lifts to -Infinity', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.Float32));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.Float32));
             expect(lifter(bctx, -Infinity)).toEqual([-Infinity]);
         });
 
         test('f32: -0 lifts to -0', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.Float32));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.Float32));
             const result = lifter(bctx, -0);
             expect(Object.is(result[0], -0)).toBe(true);
         });
 
         test('f32: very small subnormal', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.Float32));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.Float32));
             const result = lifter(bctx, 1e-45);
             expect(result).toHaveLength(1);
             expect(result[0]).toBe(Math.fround(1e-45));
         });
 
         test('f64: NaN lifts to NaN', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.Float64));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.Float64));
             const result = lifter(bctx, NaN);
             expect(Number.isNaN(result[0])).toBe(true);
         });
 
         test('f64: Infinity lifts to Infinity', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.Float64));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.Float64));
             expect(lifter(bctx, Infinity)).toEqual([Infinity]);
         });
 
         test('f64: -0 lifts to -0', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.Float64));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.Float64));
             const result = lifter(bctx, -0);
             expect(Object.is(result[0], -0)).toBe(true);
         });
 
         test('f64: Number.MAX_VALUE lifts correctly', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.Float64));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.Float64));
             expect(lifter(bctx, Number.MAX_VALUE)).toEqual([Number.MAX_VALUE]);
         });
 
         test('f64: Number.MIN_VALUE (smallest positive subnormal) lifts correctly', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.Float64));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.Float64));
             expect(lifter(bctx, Number.MIN_VALUE)).toEqual([Number.MIN_VALUE]);
         });
 
         test('f64: Number.EPSILON lifts correctly', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.Float64));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.Float64));
             expect(lifter(bctx, Number.EPSILON)).toEqual([Number.EPSILON]);
         });
     });
 
     describe('char edge cases', () => {
         test('null character \\0 lifts to [0]', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.Char));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.Char));
             expect(lifter(bctx, '\0')).toEqual([0]);
         });
 
         test('maximum BMP character \\uFFFF lifts to [65535]', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.Char));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.Char));
             expect(lifter(bctx, '\uFFFF')).toEqual([65535]);
         });
 
         test('surrogate pair emoji 😀 lifts to correct codepoint', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.Char));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.Char));
             expect(lifter(bctx, '😀')).toEqual([128512]);
         });
 
         test('multi-char string only takes first codepoint', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.Char));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.Char));
             expect(lifter(bctx, 'ABC')).toEqual([65]);
         });
 
         test('lone surrogate traps per spec', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.Char));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.Char));
             // 0xD800 is a lone high surrogate — not a valid Unicode scalar value
             expect(() => lifter(bctx, '\uD800')).toThrow('surrogate');
         });
@@ -266,18 +268,18 @@ describe('primitive lifting edge cases', () => {
 
     describe('s64/u64 edge cases (BigInt mode)', () => {
         test('s64: large positive lifts via asIntN(52)', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.S64));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.S64));
             // BigInt.asIntN(52, n) — truncates to 52 bits for safe JS number range
             expect(lifter(bctx, 42n)).toEqual([42n]);
         });
 
         test('u64: negative bigint wraps via asUintN', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.U64));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.U64));
             expect(lifter(bctx, -1n)).toEqual([18446744073709551615n]);
         });
 
         test('u64: 0n lifts to [0n]', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.U64));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.U64));
             expect(lifter(bctx, 0n)).toEqual([0n]);
         });
     });
@@ -285,13 +287,13 @@ describe('primitive lifting edge cases', () => {
     describe('s64/u64 edge cases (Number mode)', () => {
         test('s64: number lifts correctly', () => {
             const rctxNum = createMinimalRctx(true);
-            const lifter = createLifting(rctxNum, prim(PrimitiveValType.S64));
+            const lifter = createLifting(rctxNum.resolved, prim(PrimitiveValType.S64));
             expect(lifter(bctx, 42n)).toEqual([42]);
         });
 
         test('u64: number lifts correctly', () => {
             const rctxNum = createMinimalRctx(true);
-            const lifter = createLifting(rctxNum, prim(PrimitiveValType.U64));
+            const lifter = createLifting(rctxNum.resolved, prim(PrimitiveValType.U64));
             expect(lifter(bctx, 42n)).toEqual([42]);
         });
     });
@@ -308,110 +310,110 @@ describe('primitive lowering edge cases', () => {
 
     describe('bool edge cases', () => {
         test('-1 lowers to true', () => {
-            const lowerer = createLowering(rctx, prim(PrimitiveValType.Bool));
+            const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.Bool));
             expect(lowerer(bctx, -1)).toBe(true);
         });
 
         test('0.5 lowers to true (non-zero)', () => {
-            const lowerer = createLowering(rctx, prim(PrimitiveValType.Bool));
+            const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.Bool));
             expect(lowerer(bctx, 0.5)).toBe(true);
         });
     });
 
     describe('integer overflow in lowering', () => {
         test('s8: 128 wraps to -128', () => {
-            const lowerer = createLowering(rctx, prim(PrimitiveValType.S8));
+            const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.S8));
             expect(lowerer(bctx, 128)).toBe(-128);
         });
 
         test('s8: 256 wraps to 0', () => {
-            const lowerer = createLowering(rctx, prim(PrimitiveValType.S8));
+            const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.S8));
             expect(lowerer(bctx, 256)).toBe(0);
         });
 
         test('u8: -1 wraps to 255', () => {
-            const lowerer = createLowering(rctx, prim(PrimitiveValType.U8));
+            const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.U8));
             expect(lowerer(bctx, -1)).toBe(255);
         });
 
         test('s16: 32768 wraps to -32768', () => {
-            const lowerer = createLowering(rctx, prim(PrimitiveValType.S16));
+            const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.S16));
             expect(lowerer(bctx, 32768)).toBe(-32768);
         });
 
         test('u16: -1 wraps to 65535', () => {
-            const lowerer = createLowering(rctx, prim(PrimitiveValType.U16));
+            const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.U16));
             expect(lowerer(bctx, -1)).toBe(65535);
         });
 
         test('s32: 2147483648.0 wraps to -2147483648', () => {
-            const lowerer = createLowering(rctx, prim(PrimitiveValType.S32));
+            const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.S32));
             expect(lowerer(bctx, 2147483648)).toBe(-2147483648);
         });
 
         test('u32: 4294967296 wraps to 0', () => {
-            const lowerer = createLowering(rctx, prim(PrimitiveValType.U32));
+            const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.U32));
             expect(lowerer(bctx, 4294967296)).toBe(0);
         });
     });
 
     describe('float special values in lowering', () => {
         test('f32: NaN lowers to NaN', () => {
-            const lowerer = createLowering(rctx, prim(PrimitiveValType.Float32));
+            const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.Float32));
             expect(Number.isNaN(lowerer(bctx, NaN))).toBe(true);
         });
 
         test('f32: Infinity lowers to Infinity', () => {
-            const lowerer = createLowering(rctx, prim(PrimitiveValType.Float32));
+            const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.Float32));
             expect(lowerer(bctx, Infinity)).toBe(Infinity);
         });
 
         test('f32: -0 lowers to -0', () => {
-            const lowerer = createLowering(rctx, prim(PrimitiveValType.Float32));
+            const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.Float32));
             expect(Object.is(lowerer(bctx, -0), -0)).toBe(true);
         });
 
         test('f64: NaN lowers to NaN', () => {
-            const lowerer = createLowering(rctx, prim(PrimitiveValType.Float64));
+            const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.Float64));
             expect(Number.isNaN(lowerer(bctx, NaN))).toBe(true);
         });
 
         test('f64: -0 lowers to -0', () => {
-            const lowerer = createLowering(rctx, prim(PrimitiveValType.Float64));
+            const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.Float64));
             expect(Object.is(lowerer(bctx, -0), -0)).toBe(true);
         });
     });
 
     describe('char edge cases in lowering', () => {
         test('0 lowers to null character', () => {
-            const lowerer = createLowering(rctx, prim(PrimitiveValType.Char));
+            const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.Char));
             expect(lowerer(bctx, 0)).toBe('\0');
         });
 
         test('128512 lowers to 😀', () => {
-            const lowerer = createLowering(rctx, prim(PrimitiveValType.Char));
+            const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.Char));
             expect(lowerer(bctx, 128512)).toBe('😀');
         });
 
         test('0x10FFFF (max unicode) lowers to valid char', () => {
-            const lowerer = createLowering(rctx, prim(PrimitiveValType.Char));
+            const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.Char));
             const result = lowerer(bctx, 0x10FFFF);
             expect(typeof result).toBe('string');
             expect(result.codePointAt(0)).toBe(0x10FFFF);
         });
 
         test('surrogate codepoint 0xD800 traps per spec', () => {
-            const lowerer = createLowering(rctx, prim(PrimitiveValType.Char));
+            const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.Char));
             expect(() => lowerer(bctx, 0xD800)).toThrow('surrogate');
         });
 
         test('surrogate codepoint 0xDFFF traps per spec', () => {
-            const lowerer = createLowering(rctx, prim(PrimitiveValType.Char));
+            const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.Char));
             expect(() => lowerer(bctx, 0xDFFF)).toThrow('surrogate');
         });
 
         test('codepoint >= 0x110000 traps per spec', () => {
-            const lowerer = createLowering(rctx, prim(PrimitiveValType.Char));
+            const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.Char));
             expect(() => lowerer(bctx, 0x110000)).toThrow('0x110000');
         });
     });
@@ -419,14 +421,14 @@ describe('primitive lowering edge cases', () => {
     describe('s64/u64 number mode lowering', () => {
         test('s64 number mode returns JS number', () => {
             const rctxNum = createMinimalRctx(true);
-            const lowerer = createLowering(rctxNum, prim(PrimitiveValType.S64));
+            const lowerer = createLowering(rctxNum.resolved, prim(PrimitiveValType.S64));
             expect(lowerer(bctx, 42n)).toBe(42);
             expect(typeof lowerer(bctx, 42n)).toBe('number');
         });
 
         test('u64 number mode returns JS number', () => {
             const rctxNum = createMinimalRctx(true);
-            const lowerer = createLowering(rctxNum, prim(PrimitiveValType.U64));
+            const lowerer = createLowering(rctxNum.resolved, prim(PrimitiveValType.U64));
             expect(lowerer(bctx, 42n)).toBe(42);
             expect(typeof lowerer(bctx, 42n)).toBe('number');
         });
@@ -439,21 +441,21 @@ describe('string edge cases', () => {
     test('empty string lifts to [0, 0]', () => {
         const rctx = createMinimalRctx();
         const { ctx } = createMockMemoryContext();
-        const lifter = createLifting(rctx, prim(PrimitiveValType.String));
+        const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.String));
         expect(lifter(ctx, '')).toEqual([0, 0]);
     });
 
     test('non-string throws TypeError', () => {
         const rctx = createMinimalRctx();
         const { ctx } = createMockMemoryContext();
-        const lifter = createLifting(rctx, prim(PrimitiveValType.String));
+        const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.String));
         expect(() => lifter(ctx, 42 as any)).toThrow('expected a string');
     });
 
     test('multi-byte UTF-8 string lifts correctly', () => {
         const rctx = createMinimalRctx();
         const { ctx } = createMockMemoryContext();
-        const lifter = createLifting(rctx, prim(PrimitiveValType.String));
+        const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.String));
 
         const original = '日本語テスト';
         const [ptr, len] = lifter(ctx, original);
@@ -464,7 +466,7 @@ describe('string edge cases', () => {
     test('emoji string lifts correctly', () => {
         const rctx = createMinimalRctx();
         const { ctx } = createMockMemoryContext();
-        const lifter = createLifting(rctx, prim(PrimitiveValType.String));
+        const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.String));
 
         const original = '🎉🚀💻';
         const [ptr, len] = lifter(ctx, original);
@@ -476,9 +478,9 @@ describe('string edge cases', () => {
     test('string with null byte round-trips', () => {
         const rctx = createMinimalRctx();
         const { ctx } = createMockMemoryContext();
-        const lifter = createLifting(rctx, prim(PrimitiveValType.String));
+        const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.String));
         const rctx2 = createMinimalRctx();
-        const lowerer = createLowering(rctx2, prim(PrimitiveValType.String));
+        const lowerer = createLowering(rctx2.resolved, prim(PrimitiveValType.String));
 
         const original = 'hello\0world';
         const [ptr, len] = lifter(ctx, original);
@@ -489,7 +491,7 @@ describe('string edge cases', () => {
     test('very long string lifts correctly', () => {
         const rctx = createMinimalRctx();
         const { ctx } = createMockMemoryContext();
-        const lifter = createLifting(rctx, prim(PrimitiveValType.String));
+        const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.String));
         const original = 'x'.repeat(1000);
         const [ptr, len] = lifter(ctx, original);
         expect(len).toBe(1000);
@@ -513,7 +515,7 @@ describe('option edge cases', () => {
             tag: ModelTag.ComponentTypeDefinedOption as const,
             value: prim(PrimitiveValType.Bool),
         };
-        const lifter = createLifting(rctx, model);
+        const lifter = createLifting(rctx.resolved, model);
         expect(lifter(bctx, false)).toEqual([1, 0]); // Some(false)
     });
 
@@ -522,7 +524,7 @@ describe('option edge cases', () => {
             tag: ModelTag.ComponentTypeDefinedOption as const,
             value: prim(PrimitiveValType.U32),
         };
-        const lifter = createLifting(rctx, model);
+        const lifter = createLifting(rctx.resolved, model);
         expect(lifter(bctx, 0)).toEqual([1, 0]); // Some(0)
     });
 
@@ -532,7 +534,7 @@ describe('option edge cases', () => {
             value: prim(PrimitiveValType.String),
         };
         const { ctx } = createMockMemoryContext();
-        const lifter = createLifting(rctx, model);
+        const lifter = createLifting(rctx.resolved, model);
         const result = lifter(ctx, '');
         expect(result[0]).toBe(1); // discriminant = Some
         // ptr=0, len=0 for empty string
@@ -545,7 +547,7 @@ describe('option edge cases', () => {
             tag: ModelTag.ComponentTypeDefinedOption as const,
             value: prim(PrimitiveValType.U32),
         };
-        const lowerer = createLowering(rctx, model);
+        const lowerer = createLowering(rctx.resolved, model);
         // Per CM spec, option is variant with 2 cases — discriminant must be 0 or 1
         expect(() => lowerer(bctx, 2, 42)).toThrow('Invalid option discriminant');
     });
@@ -565,7 +567,7 @@ describe('result edge cases', () => {
             tag: ModelTag.ComponentTypeDefinedResult as const,
             // neither ok nor err specified
         };
-        const lifter = createLifting(rctx, model);
+        const lifter = createLifting(rctx.resolved, model);
         // No ok/err → discriminant only, no payload slot
         expect(lifter(bctx, { tag: 'ok' })).toEqual([0]);
         expect(lifter(bctx, { tag: 'err' })).toEqual([1]);
@@ -575,7 +577,7 @@ describe('result edge cases', () => {
         const model = {
             tag: ModelTag.ComponentTypeDefinedResult as const,
         };
-        const lowerer = createLowering(rctx, model);
+        const lowerer = createLowering(rctx.resolved, model);
         expect(lowerer(bctx, 0, 0)).toEqual({ tag: 'ok', val: undefined });
         expect(lowerer(bctx, 1, 0)).toEqual({ tag: 'err', val: undefined });
     });
@@ -585,7 +587,7 @@ describe('result edge cases', () => {
             tag: ModelTag.ComponentTypeDefinedResult as const,
             ok: prim(PrimitiveValType.U32),
         };
-        const lowerer = createLowering(rctx, model);
+        const lowerer = createLowering(rctx.resolved, model);
         expect(() => lowerer(bctx, 2, 0)).toThrow('Invalid result discriminant');
     });
 });
@@ -606,7 +608,7 @@ describe('variant edge cases', () => {
                 { name: 'only', ty: prim(PrimitiveValType.U32) },
             ],
         };
-        const lifter = createLifting(rctx, model);
+        const lifter = createLifting(rctx.resolved, model);
         expect(lifter(bctx, { tag: 'only', val: 99 })).toEqual([0, 99]);
     });
 
@@ -618,7 +620,7 @@ describe('variant edge cases', () => {
                 { name: 'something', ty: prim(PrimitiveValType.U32) },
             ],
         };
-        const lifter = createLifting(rctx, model);
+        const lifter = createLifting(rctx.resolved, model);
         expect(lifter(bctx, { tag: 'nothing' })).toEqual([0, 0]);
     });
 
@@ -630,7 +632,7 @@ describe('variant edge cases', () => {
                 { name: 'b' },
             ],
         };
-        const lifter = createLifting(rctx, model);
+        const lifter = createLifting(rctx.resolved, model);
         expect(() => lifter(bctx, { tag: 'c' })).toThrow('Unknown variant case: c');
     });
 
@@ -640,7 +642,7 @@ describe('variant edge cases', () => {
             tag: ModelTag.ComponentTypeDefinedVariant as const,
             variants: cases,
         };
-        const lifter = createLifting(rctx, model);
+        const lifter = createLifting(rctx.resolved, model);
         expect(lifter(bctx, { tag: 'case299' })[0]).toBe(299);
     });
 });
@@ -659,7 +661,7 @@ describe('enum edge cases', () => {
             tag: ModelTag.ComponentTypeDefinedEnum as const,
             members: ['only'],
         };
-        const lifter = createLifting(rctx, model);
+        const lifter = createLifting(rctx.resolved, model);
         expect(lifter(bctx, 'only')).toEqual([0]);
     });
 
@@ -668,7 +670,7 @@ describe('enum edge cases', () => {
             tag: ModelTag.ComponentTypeDefinedEnum as const,
             members: ['a', 'b'],
         };
-        const lifter = createLifting(rctx, model);
+        const lifter = createLifting(rctx.resolved, model);
         expect(() => lifter(bctx, 'c')).toThrow('Unknown enum value: c');
     });
 
@@ -678,7 +680,7 @@ describe('enum edge cases', () => {
             tag: ModelTag.ComponentTypeDefinedEnum as const,
             members,
         };
-        const lifter = createLifting(rctx, model);
+        const lifter = createLifting(rctx.resolved, model);
         expect(lifter(bctx, 'val299')).toEqual([299]);
     });
 
@@ -687,7 +689,7 @@ describe('enum edge cases', () => {
             tag: ModelTag.ComponentTypeDefinedEnum as const,
             members: ['a', 'b'],
         };
-        const lowerer = createLowering(rctx, model);
+        const lowerer = createLowering(rctx.resolved, model);
         expect(() => lowerer(bctx, 5)).toThrow('Invalid enum discriminant');
     });
 });
@@ -706,7 +708,7 @@ describe('flags edge cases', () => {
             tag: ModelTag.ComponentTypeDefinedFlags as const,
             members: ['a'],
         };
-        const lifter = createLifting(rctx, model);
+        const lifter = createLifting(rctx.resolved, model);
         expect(lifter(bctx, { a: true })).toEqual([1]);
     });
 
@@ -715,7 +717,7 @@ describe('flags edge cases', () => {
             tag: ModelTag.ComponentTypeDefinedFlags as const,
             members: [],
         };
-        const lifter = createLifting(rctx, model);
+        const lifter = createLifting(rctx.resolved, model);
         expect(lifter(bctx, {})).toEqual([0]);
     });
 
@@ -725,10 +727,10 @@ describe('flags edge cases', () => {
             tag: ModelTag.ComponentTypeDefinedFlags as const,
             members,
         };
-        const lifter = createLifting(rctx, model);
+        const lifter = createLifting(rctx.resolved, model);
         // Use a separate rctx to avoid memoize cache collision with lifter
         const rctx2 = createMinimalRctx();
-        const lowerer = createLowering(rctx2, {
+        const lowerer = createLowering(rctx2.resolved, {
             tag: ModelTag.ComponentTypeDefinedFlags as const,
             members,
         });
@@ -747,7 +749,7 @@ describe('flags edge cases', () => {
             tag: ModelTag.ComponentTypeDefinedFlags as const,
             members,
         };
-        const lowerer = createLowering(rctx, model);
+        const lowerer = createLowering(rctx.resolved, model);
         expect((lowerer as any).spill).toBe(2);
     });
 
@@ -756,7 +758,7 @@ describe('flags edge cases', () => {
             tag: ModelTag.ComponentTypeDefinedFlags as const,
             members: ['a', 'b'],
         };
-        const lifter = createLifting(rctx, model);
+        const lifter = createLifting(rctx.resolved, model);
         expect(lifter(bctx, { a: true, b: false, c: true } as any)).toEqual([1]);
     });
 
@@ -766,7 +768,7 @@ describe('flags edge cases', () => {
             tag: ModelTag.ComponentTypeDefinedFlags as const,
             members,
         };
-        const lowerer = createLowering(rctx, model);
+        const lowerer = createLowering(rctx.resolved, model);
         const result = lowerer(bctx, -1); // 0xFFFFFFFF as signed i32
         for (const m of members) {
             expect(result[m]).toBe(true);
@@ -788,7 +790,7 @@ describe('tuple edge cases', () => {
             tag: ModelTag.ComponentTypeDefinedTuple as const,
             members: [],
         };
-        const lifter = createLifting(rctx, model);
+        const lifter = createLifting(rctx.resolved, model);
         expect(lifter(bctx, [])).toEqual([]);
     });
 
@@ -797,7 +799,7 @@ describe('tuple edge cases', () => {
             tag: ModelTag.ComponentTypeDefinedTuple as const,
             members: [],
         };
-        const lowerer = createLowering(rctx, model);
+        const lowerer = createLowering(rctx.resolved, model);
         expect(lowerer(bctx)).toEqual([]);
     });
 
@@ -806,7 +808,7 @@ describe('tuple edge cases', () => {
             tag: ModelTag.ComponentTypeDefinedTuple as const,
             members: [],
         };
-        const lowerer = createLowering(rctx, model);
+        const lowerer = createLowering(rctx.resolved, model);
         expect((lowerer as any).spill).toBe(0);
     });
 
@@ -815,7 +817,7 @@ describe('tuple edge cases', () => {
             tag: ModelTag.ComponentTypeDefinedTuple as const,
             members: [prim(PrimitiveValType.U32)],
         };
-        const lifter = createLifting(rctx, model);
+        const lifter = createLifting(rctx.resolved, model);
         expect(lifter(bctx, [42])).toEqual([42]);
     });
 
@@ -828,7 +830,7 @@ describe('tuple edge cases', () => {
                 prim(PrimitiveValType.Bool),
             ],
         };
-        const lifter = createLifting(rctx, model);
+        const lifter = createLifting(rctx.resolved, model);
         expect(lifter(bctx, [true, 42, false])).toEqual([1, 42, 0]);
     });
 });
@@ -849,7 +851,7 @@ describe('record edge cases', () => {
             tag: ModelTag.ComponentTypeDefinedRecord as const,
             members: [],
         };
-        const lifter = createLifting(rctx, model);
+        const lifter = createLifting(rctx.resolved, model);
         expect(lifter(bctx, {})).toEqual([]);
     });
 
@@ -858,7 +860,7 @@ describe('record edge cases', () => {
             tag: ModelTag.ComponentTypeDefinedRecord as const,
             members: [],
         };
-        const lowerer = createLowering(rctx, model);
+        const lowerer = createLowering(rctx.resolved, model);
         expect(lowerer(bctx)).toEqual({});
     });
 
@@ -870,7 +872,7 @@ describe('record edge cases', () => {
                 { name: 'b', type: prim(PrimitiveValType.U32) },
             ],
         };
-        const lifter = createLifting(rctx, model);
+        const lifter = createLifting(rctx.resolved, model);
         // Missing field 'b' → undefined is cast to number → 0 via u32 mask
         const result = lifter(bctx, { a: 42 } as any);
         expect(result).toEqual([42, 0]);
@@ -883,7 +885,7 @@ describe('record edge cases', () => {
                 { name: 'x', type: prim(PrimitiveValType.U32) },
             ],
         };
-        const lifter = createLifting(rctx, model);
+        const lifter = createLifting(rctx.resolved, model);
         expect(lifter(bctx, { x: 1, y: 2 })).toEqual([1]);
     });
 
@@ -895,9 +897,9 @@ describe('record edge cases', () => {
                 { name: 'value', type: prim(PrimitiveValType.Bool) },
             ],
         };
-        const lifter = createLifting(rctx, model);
+        const lifter = createLifting(rctx.resolved, model);
         const rctx2 = createMinimalRctx();
-        const lowerer = createLowering(rctx2, model);
+        const lowerer = createLowering(rctx2.resolved, model);
         const original = { name: 99, value: true };
         const lifted = lifter(bctx, original);
         const lowered = lowerer(bctx, ...lifted);
@@ -915,7 +917,7 @@ describe('list edge cases', () => {
             tag: ModelTag.ComponentTypeDefinedList as const,
             value: prim(PrimitiveValType.U8),
         };
-        const lifter = createLifting(rctx, model);
+        const lifter = createLifting(rctx.resolved, model);
         const result = lifter(ctx, [255]);
         expect(result).toHaveLength(2);
         const [ptr, len] = result;
@@ -931,9 +933,9 @@ describe('list edge cases', () => {
             tag: ModelTag.ComponentTypeDefinedList as const,
             value: prim(PrimitiveValType.Bool),
         };
-        const lifter = createLifting(rctx, model);
+        const lifter = createLifting(rctx.resolved, model);
         const rctx2 = createMinimalRctx();
-        const lowerer = createLowering(rctx2, model);
+        const lowerer = createLowering(rctx2.resolved, model);
         const [ptr, len] = lifter(ctx, [false, false, false]);
         const result = lowerer(ctx, ptr, len);
         expect(result).toEqual([false, false, false]);
@@ -946,7 +948,7 @@ describe('list edge cases', () => {
             tag: ModelTag.ComponentTypeDefinedList as const,
             value: prim(PrimitiveValType.U32),
         };
-        const lowerer = createLowering(rctx, model);
+        const lowerer = createLowering(rctx.resolved, model);
         expect(lowerer(ctx, 999, 0)).toEqual([]);
     });
 
@@ -957,15 +959,15 @@ describe('list edge cases', () => {
             tag: ModelTag.ComponentTypeDefinedList as const,
             value: prim(PrimitiveValType.U8),
         };
-        rctx.resolvedTypes.set(0 as any, innerModel as any);
+        rctx.resolved.resolvedTypes.set(0 as any, innerModel as any);
         const outerModel = {
             tag: ModelTag.ComponentTypeDefinedList as const,
             value: { tag: ModelTag.ComponentValTypeType, value: 0 } as ComponentValType,
         };
-        const lifter = createLifting(rctx, outerModel);
+        const lifter = createLifting(rctx.resolved, outerModel);
         const rctx2 = createMinimalRctx();
-        rctx2.resolvedTypes.set(0 as any, innerModel as any);
-        const lowerer = createLowering(rctx2, outerModel);
+        rctx2.resolved.resolvedTypes.set(0 as any, innerModel as any);
+        const lowerer = createLowering(rctx2.resolved, outerModel);
 
         const original = [[1, 2], [3, 4, 5], []];
         const [ptr, len] = lifter(ctx, original);
@@ -982,7 +984,7 @@ describe('resource edge cases', () => {
         const rctx = createMinimalRctx();
         const bctx = { resources: createResourceTable() } as any as BindingContext;
         const ownModel = { tag: ModelTag.ComponentTypeDefinedOwn, value: 0 };
-        const lifter = createLifting(rctx, ownModel as any);
+        const lifter = createLifting(rctx.resolved, ownModel as any);
         const [handle] = lifter(bctx, null);
         expect(handle).toBeGreaterThan(0);
         expect(bctx.resources.get(0, handle as number)).toBeNull();
@@ -992,7 +994,7 @@ describe('resource edge cases', () => {
         const rctx = createMinimalRctx();
         const bctx = { resources: createResourceTable() } as any as BindingContext;
         const ownModel = { tag: ModelTag.ComponentTypeDefinedOwn, value: 0 };
-        const lifter = createLifting(rctx, ownModel as any);
+        const lifter = createLifting(rctx.resolved, ownModel as any);
         const [handle] = lifter(bctx, 42);
         expect(handle).toBeGreaterThan(0);
         expect(bctx.resources.get(0, handle as number)).toBe(42);
@@ -1002,7 +1004,7 @@ describe('resource edge cases', () => {
         const rctx = createMinimalRctx();
         const bctx = { resources: createResourceTable() } as any as BindingContext;
         const borrowModel = { tag: ModelTag.ComponentTypeDefinedBorrow, value: 0 };
-        const lowerer = createLowering(rctx, borrowModel as any);
+        const lowerer = createLowering(rctx.resolved, borrowModel as any);
         expect(() => lowerer(bctx, 999)).toThrow('Invalid resource handle');
     });
 
@@ -1042,9 +1044,9 @@ describe('storeToMemory/loadFromMemory round-trips', () => {
             ],
         };
 
-        const lifter = createLifting(rctx, model);
+        const lifter = createLifting(rctx.resolved, model);
         const rctx2 = createMinimalRctx();
-        const lowerer = createLowering(rctx2, model);
+        const lowerer = createLowering(rctx2.resolved, model);
         const original = { a: 255, b: 4294967295 };
         const lifted = lifter(ctx, original);
         const lowered = lowerer(ctx, ...lifted);
@@ -1060,9 +1062,9 @@ describe('storeToMemory/loadFromMemory round-trips', () => {
             value: prim(PrimitiveValType.String),
         };
 
-        const lifter = createLifting(rctx, model);
+        const lifter = createLifting(rctx.resolved, model);
         const rctx2 = createMinimalRctx();
-        createLowering(rctx2, model);
+        createLowering(rctx2.resolved, model);
 
         // Some("hello")
         const liftedSome = lifter(ctx, 'hello');
@@ -1088,9 +1090,9 @@ describe('storeToMemory/loadFromMemory round-trips', () => {
             ],
         };
 
-        const lifter = createLifting(rctx, model);
+        const lifter = createLifting(rctx.resolved, model);
         const rctx2 = createMinimalRctx();
-        const lowerer = createLowering(rctx2, model);
+        const lowerer = createLowering(rctx2.resolved, model);
 
         const liftedTiny = lifter(bctx, { tag: 'tiny', val: 42 });
         const loweredTiny = lowerer(bctx, ...liftedTiny);
@@ -1110,13 +1112,13 @@ describe('type reference (ComponentValTypeType) edge cases', () => {
         const rctx = createMinimalRctx();
         const bctx = createMinimalBctx();
         // Register u32 as type index 5
-        rctx.resolvedTypes.set(5 as any, {
+        rctx.resolved.resolvedTypes.set(5 as any, {
             tag: ModelTag.ComponentTypeDefinedPrimitive,
             value: PrimitiveValType.U32,
         } as any);
 
         const typeRef = { tag: ModelTag.ComponentValTypeType, value: 5 } as ComponentValType;
-        const lifter = createLifting(rctx, typeRef);
+        const lifter = createLifting(rctx.resolved, typeRef);
         expect(lifter(bctx, 42)).toEqual([42]);
     });
 
@@ -1129,10 +1131,10 @@ describe('type reference (ComponentValTypeType) edge cases', () => {
                 { name: 'x', type: prim(PrimitiveValType.U32) },
             ],
         };
-        rctx.resolvedTypes.set(10 as any, recordModel as any);
+        rctx.resolved.resolvedTypes.set(10 as any, recordModel as any);
 
         const typeRef = { tag: ModelTag.ComponentValTypeType, value: 10 } as ComponentValType;
-        const lifter = createLifting(rctx, typeRef);
+        const lifter = createLifting(rctx.resolved, typeRef);
         expect(lifter(bctx, { x: 7 })).toEqual([7]);
     });
 });
@@ -1152,42 +1154,42 @@ describe('discriminant size boundaries', () => {
         test('255 cases → u8 discriminant, last case = 254', () => {
             const cases = Array.from({ length: 255 }, (_, i) => ({ name: `c${i}` }));
             const model = { tag: ModelTag.ComponentTypeDefinedVariant as const, variants: cases };
-            const lifter = createLifting(rctx, model);
+            const lifter = createLifting(rctx.resolved, model);
             expect(lifter(bctx, { tag: 'c254' })[0]).toBe(254);
         });
 
         test('256 cases → u16 discriminant, case 255 correct', () => {
             const cases = Array.from({ length: 256 }, (_, i) => ({ name: `c${i}` }));
             const model = { tag: ModelTag.ComponentTypeDefinedVariant as const, variants: cases };
-            const lifter = createLifting(rctx, model);
+            const lifter = createLifting(rctx.resolved, model);
             expect(lifter(bctx, { tag: 'c255' })[0]).toBe(255);
         });
 
         test('256 cases lowering: discriminant 255 round-trips', () => {
             const cases = Array.from({ length: 256 }, (_, i) => ({ name: `c${i}` }));
             const model = { tag: ModelTag.ComponentTypeDefinedVariant as const, variants: cases };
-            const lowerer = createLowering(rctx, model);
+            const lowerer = createLowering(rctx.resolved, model);
             expect(lowerer(bctx, 255)).toEqual({ tag: 'c255' });
         });
 
         test('65535 cases → u16 discriminant, last case = 65534', () => {
             const cases = Array.from({ length: 65535 }, (_, i) => ({ name: `c${i}` }));
             const model = { tag: ModelTag.ComponentTypeDefinedVariant as const, variants: cases };
-            const lifter = createLifting(rctx, model);
+            const lifter = createLifting(rctx.resolved, model);
             expect(lifter(bctx, { tag: 'c65534' })[0]).toBe(65534);
         });
 
         test('65536 cases → u32 discriminant, case 65535 correct', () => {
             const cases = Array.from({ length: 65536 }, (_, i) => ({ name: `c${i}` }));
             const model = { tag: ModelTag.ComponentTypeDefinedVariant as const, variants: cases };
-            const lifter = createLifting(rctx, model);
+            const lifter = createLifting(rctx.resolved, model);
             expect(lifter(bctx, { tag: 'c65535' })[0]).toBe(65535);
         });
 
         test('65536 cases lowering: discriminant 65535 round-trips', () => {
             const cases = Array.from({ length: 65536 }, (_, i) => ({ name: `c${i}` }));
             const model = { tag: ModelTag.ComponentTypeDefinedVariant as const, variants: cases };
-            const lowerer = createLowering(rctx, model);
+            const lowerer = createLowering(rctx.resolved, model);
             expect(lowerer(bctx, 65535)).toEqual({ tag: 'c65535' });
         });
     });
@@ -1196,42 +1198,42 @@ describe('discriminant size boundaries', () => {
         test('255 members → u8 discriminant, last = 254', () => {
             const members = Array.from({ length: 255 }, (_, i) => `e${i}`);
             const model = { tag: ModelTag.ComponentTypeDefinedEnum as const, members };
-            const lifter = createLifting(rctx, model);
+            const lifter = createLifting(rctx.resolved, model);
             expect(lifter(bctx, 'e254')).toEqual([254]);
         });
 
         test('256 members → u16 discriminant, member 255 correct', () => {
             const members = Array.from({ length: 256 }, (_, i) => `e${i}`);
             const model = { tag: ModelTag.ComponentTypeDefinedEnum as const, members };
-            const lifter = createLifting(rctx, model);
+            const lifter = createLifting(rctx.resolved, model);
             expect(lifter(bctx, 'e255')).toEqual([255]);
         });
 
         test('256 members lowering: discriminant 255 round-trips', () => {
             const members = Array.from({ length: 256 }, (_, i) => `e${i}`);
             const model = { tag: ModelTag.ComponentTypeDefinedEnum as const, members };
-            const lowerer = createLowering(rctx, model);
+            const lowerer = createLowering(rctx.resolved, model);
             expect(lowerer(bctx, 255)).toBe('e255');
         });
 
         test('65535 members → u16 discriminant, last = 65534', () => {
             const members = Array.from({ length: 65535 }, (_, i) => `e${i}`);
             const model = { tag: ModelTag.ComponentTypeDefinedEnum as const, members };
-            const lifter = createLifting(rctx, model);
+            const lifter = createLifting(rctx.resolved, model);
             expect(lifter(bctx, 'e65534')).toEqual([65534]);
         });
 
         test('65536 members → u32 discriminant', () => {
             const members = Array.from({ length: 65536 }, (_, i) => `e${i}`);
             const model = { tag: ModelTag.ComponentTypeDefinedEnum as const, members };
-            const lifter = createLifting(rctx, model);
+            const lifter = createLifting(rctx.resolved, model);
             expect(lifter(bctx, 'e65535')).toEqual([65535]);
         });
 
         test('65536 members lowering: discriminant 65535 round-trips', () => {
             const members = Array.from({ length: 65536 }, (_, i) => `e${i}`);
             const model = { tag: ModelTag.ComponentTypeDefinedEnum as const, members };
-            const lowerer = createLowering(rctx, model);
+            const lowerer = createLowering(rctx.resolved, model);
             expect(lowerer(bctx, 65535)).toBe('e65535');
         });
     });
@@ -1253,13 +1255,13 @@ describe('nested compound types', () => {
             tag: ModelTag.ComponentTypeDefinedOption as const,
             value: prim(PrimitiveValType.U8),
         };
-        rctx.resolvedTypes.set(0 as any, innerOption as any);
+        rctx.resolved.resolvedTypes.set(0 as any, innerOption as any);
         const innerRef = { tag: ModelTag.ComponentValTypeType, value: 0 } as ComponentValType;
         const outerOption = {
             tag: ModelTag.ComponentTypeDefinedOption as const,
             value: innerRef,
         };
-        const lifter = createLifting(rctx, outerOption as any);
+        const lifter = createLifting(rctx.resolved, outerOption as any);
         // Some(Some(42)): outer disc=1, inner disc=1, value=42
         const result = lifter(bctx, 42);
         expect(result[0]).toBe(1); // outer Some
@@ -1272,13 +1274,13 @@ describe('nested compound types', () => {
             tag: ModelTag.ComponentTypeDefinedOption as const,
             value: prim(PrimitiveValType.U8),
         };
-        rctx.resolvedTypes.set(0 as any, innerOption as any);
+        rctx.resolved.resolvedTypes.set(0 as any, innerOption as any);
         const innerRef = { tag: ModelTag.ComponentValTypeType, value: 0 } as ComponentValType;
         const outerOption = {
             tag: ModelTag.ComponentTypeDefinedOption as const,
             value: innerRef,
         };
-        const lifter = createLifting(rctx, outerOption as any);
+        const lifter = createLifting(rctx.resolved, outerOption as any);
         // null → outer None (disc=0), because JS null is the sentinel for None
         const result = lifter(bctx, null);
         expect(result[0]).toBe(0); // outer None
@@ -1289,16 +1291,16 @@ describe('nested compound types', () => {
             tag: ModelTag.ComponentTypeDefinedOption as const,
             value: prim(PrimitiveValType.U8),
         };
-        rctx.resolvedTypes.set(0 as any, innerOption as any);
+        rctx.resolved.resolvedTypes.set(0 as any, innerOption as any);
         const innerRef = { tag: ModelTag.ComponentValTypeType, value: 0 } as ComponentValType;
         const outerOption = {
             tag: ModelTag.ComponentTypeDefinedOption as const,
             value: innerRef,
         };
-        const _lifter = createLifting(rctx, outerOption as any);
+        const _lifter = createLifting(rctx.resolved, outerOption as any);
         const rctx2 = createMinimalRctx();
-        rctx2.resolvedTypes.set(0 as any, innerOption as any);
-        const lowerer = createLowering(rctx2, outerOption as any);
+        rctx2.resolved.resolvedTypes.set(0 as any, innerOption as any);
+        const lowerer = createLowering(rctx2.resolved, outerOption as any);
         // Lowering None: disc=0, rest padding
         const noneResult = lowerer(bctx, 0, 0, 0);
         expect(noneResult).toBeNull();
@@ -1309,15 +1311,15 @@ describe('nested compound types', () => {
             tag: ModelTag.ComponentTypeDefinedOption as const,
             value: prim(PrimitiveValType.U8),
         };
-        rctx.resolvedTypes.set(0 as any, innerOption as any);
+        rctx.resolved.resolvedTypes.set(0 as any, innerOption as any);
         const innerRef = { tag: ModelTag.ComponentValTypeType, value: 0 } as ComponentValType;
         const outerOption = {
             tag: ModelTag.ComponentTypeDefinedOption as const,
             value: innerRef,
         };
         const rctx2 = createMinimalRctx();
-        rctx2.resolvedTypes.set(0 as any, innerOption as any);
-        const lowerer = createLowering(rctx2, outerOption as any);
+        rctx2.resolved.resolvedTypes.set(0 as any, innerOption as any);
+        const lowerer = createLowering(rctx2.resolved, outerOption as any);
         // Some(Some(99)): disc=1, inner_disc=1, value=99
         const result = lowerer(bctx, 1, 1, 99);
         expect(result).toBe(99); // inner option unwraps to 99
@@ -1329,14 +1331,14 @@ describe('nested compound types', () => {
             ok: prim(PrimitiveValType.U8),
             err: prim(PrimitiveValType.U8),
         };
-        rctx.resolvedTypes.set(0 as any, innerResult as any);
+        rctx.resolved.resolvedTypes.set(0 as any, innerResult as any);
         const innerRef = { tag: ModelTag.ComponentValTypeType, value: 0 } as ComponentValType;
         const outerResult = {
             tag: ModelTag.ComponentTypeDefinedResult as const,
             ok: innerRef,
             err: prim(PrimitiveValType.U8),
         };
-        const lifter = createLifting(rctx, outerResult as any);
+        const lifter = createLifting(rctx.resolved, outerResult as any);
         const result = lifter(bctx, { tag: 'ok', val: { tag: 'ok', val: 42 } });
         expect(result[0]).toBe(0); // outer ok
     });
@@ -1347,7 +1349,7 @@ describe('nested compound types', () => {
             ok: prim(PrimitiveValType.U8),
             err: prim(PrimitiveValType.U8),
         };
-        rctx.resolvedTypes.set(0 as any, innerResult as any);
+        rctx.resolved.resolvedTypes.set(0 as any, innerResult as any);
         const innerRef = { tag: ModelTag.ComponentValTypeType, value: 0 } as ComponentValType;
         const outerResult = {
             tag: ModelTag.ComponentTypeDefinedResult as const,
@@ -1355,8 +1357,8 @@ describe('nested compound types', () => {
             err: prim(PrimitiveValType.U8),
         };
         const rctx2 = createMinimalRctx();
-        rctx2.resolvedTypes.set(0 as any, innerResult as any);
-        const lowerer = createLowering(rctx2, outerResult as any);
+        rctx2.resolved.resolvedTypes.set(0 as any, innerResult as any);
+        const lowerer = createLowering(rctx2.resolved, outerResult as any);
         // Ok(Err(77)): outer disc=0, inner disc=1, inner payload=77
         const result = lowerer(bctx, 0, 1, 77);
         expect(result).toEqual({ tag: 'ok', val: { tag: 'err', val: 77 } });
@@ -1367,24 +1369,24 @@ describe('nested compound types', () => {
             tag: ModelTag.ComponentTypeDefinedOption as const,
             value: prim(PrimitiveValType.U8),
         };
-        rctx.resolvedTypes.set(0 as any, optU8 as any);
+        rctx.resolved.resolvedTypes.set(0 as any, optU8 as any);
         const optRef = { tag: ModelTag.ComponentValTypeType, value: 0 } as ComponentValType;
         const resU32Bool = {
             tag: ModelTag.ComponentTypeDefinedResult as const,
             ok: prim(PrimitiveValType.U32),
             err: prim(PrimitiveValType.Bool),
         };
-        rctx.resolvedTypes.set(1 as any, resU32Bool as any);
+        rctx.resolved.resolvedTypes.set(1 as any, resU32Bool as any);
         const resRef = { tag: ModelTag.ComponentValTypeType, value: 1 } as ComponentValType;
         const tuple = {
             tag: ModelTag.ComponentTypeDefinedTuple as const,
             members: [optRef, resRef],
         };
-        const lifter = createLifting(rctx, tuple as any);
+        const lifter = createLifting(rctx.resolved, tuple as any);
         const rctx2 = createMinimalRctx();
-        rctx2.resolvedTypes.set(0 as any, optU8 as any);
-        rctx2.resolvedTypes.set(1 as any, resU32Bool as any);
-        const lowerer = createLowering(rctx2, tuple as any);
+        rctx2.resolved.resolvedTypes.set(0 as any, optU8 as any);
+        rctx2.resolved.resolvedTypes.set(1 as any, resU32Bool as any);
+        const lowerer = createLowering(rctx2.resolved, tuple as any);
 
         const lifted = lifter(bctx, [42, { tag: 'ok', val: 100 }]);
         const lowered = lowerer(bctx, ...lifted);
@@ -1396,24 +1398,24 @@ describe('nested compound types', () => {
             tag: ModelTag.ComponentTypeDefinedOption as const,
             value: prim(PrimitiveValType.U8),
         };
-        rctx.resolvedTypes.set(0 as any, optU8 as any);
+        rctx.resolved.resolvedTypes.set(0 as any, optU8 as any);
         const optRef = { tag: ModelTag.ComponentValTypeType, value: 0 } as ComponentValType;
         const resU32Bool = {
             tag: ModelTag.ComponentTypeDefinedResult as const,
             ok: prim(PrimitiveValType.U32),
             err: prim(PrimitiveValType.Bool),
         };
-        rctx.resolvedTypes.set(1 as any, resU32Bool as any);
+        rctx.resolved.resolvedTypes.set(1 as any, resU32Bool as any);
         const resRef = { tag: ModelTag.ComponentValTypeType, value: 1 } as ComponentValType;
         const tuple = {
             tag: ModelTag.ComponentTypeDefinedTuple as const,
             members: [optRef, resRef],
         };
-        const lifter = createLifting(rctx, tuple as any);
+        const lifter = createLifting(rctx.resolved, tuple as any);
         const rctx2 = createMinimalRctx();
-        rctx2.resolvedTypes.set(0 as any, optU8 as any);
-        rctx2.resolvedTypes.set(1 as any, resU32Bool as any);
-        const lowerer = createLowering(rctx2, tuple as any);
+        rctx2.resolved.resolvedTypes.set(0 as any, optU8 as any);
+        rctx2.resolved.resolvedTypes.set(1 as any, resU32Bool as any);
+        const lowerer = createLowering(rctx2.resolved, tuple as any);
 
         const lifted = lifter(bctx, [null, { tag: 'err', val: true }]);
         const lowered = lowerer(bctx, ...lifted);
@@ -1425,7 +1427,7 @@ describe('nested compound types', () => {
             tag: ModelTag.ComponentTypeDefinedOption as const,
             value: prim(PrimitiveValType.U32),
         };
-        rctx.resolvedTypes.set(0 as any, optU32 as any);
+        rctx.resolved.resolvedTypes.set(0 as any, optU32 as any);
         const optRef = { tag: ModelTag.ComponentValTypeType, value: 0 } as ComponentValType;
         const variant = {
             tag: ModelTag.ComponentTypeDefinedVariant as const,
@@ -1434,10 +1436,10 @@ describe('nested compound types', () => {
                 { name: 'maybe', ty: optRef },
             ],
         };
-        const lifter = createLifting(rctx, variant as any);
+        const lifter = createLifting(rctx.resolved, variant as any);
         const rctx2 = createMinimalRctx();
-        rctx2.resolvedTypes.set(0 as any, optU32 as any);
-        const lowerer = createLowering(rctx2, variant as any);
+        rctx2.resolved.resolvedTypes.set(0 as any, optU32 as any);
+        const lowerer = createLowering(rctx2.resolved, variant as any);
 
         // maybe(Some(42))
         const lifted = lifter(bctx, { tag: 'maybe', val: 42 });
@@ -1450,7 +1452,7 @@ describe('nested compound types', () => {
             tag: ModelTag.ComponentTypeDefinedOption as const,
             value: prim(PrimitiveValType.U32),
         };
-        rctx.resolvedTypes.set(0 as any, optU32 as any);
+        rctx.resolved.resolvedTypes.set(0 as any, optU32 as any);
         const optRef = { tag: ModelTag.ComponentValTypeType, value: 0 } as ComponentValType;
         const variant = {
             tag: ModelTag.ComponentTypeDefinedVariant as const,
@@ -1459,10 +1461,10 @@ describe('nested compound types', () => {
                 { name: 'maybe', ty: optRef },
             ],
         };
-        const lifter = createLifting(rctx, variant as any);
+        const lifter = createLifting(rctx.resolved, variant as any);
         const rctx2 = createMinimalRctx();
-        rctx2.resolvedTypes.set(0 as any, optU32 as any);
-        const lowerer = createLowering(rctx2, variant as any);
+        rctx2.resolved.resolvedTypes.set(0 as any, optU32 as any);
+        const lowerer = createLowering(rctx2.resolved, variant as any);
 
         const lifted = lifter(bctx, { tag: 'maybe', val: null });
         const lowered = lowerer(bctx, ...lifted);
@@ -1474,13 +1476,13 @@ describe('nested compound types', () => {
             tag: ModelTag.ComponentTypeDefinedOption as const,
             value: prim(PrimitiveValType.Bool),
         };
-        rctx.resolvedTypes.set(0 as any, optBool as any);
+        rctx.resolved.resolvedTypes.set(0 as any, optBool as any);
         const optRef = { tag: ModelTag.ComponentValTypeType, value: 0 } as ComponentValType;
         const enumModel = {
             tag: ModelTag.ComponentTypeDefinedEnum as const,
             members: ['red', 'green', 'blue'],
         };
-        rctx.resolvedTypes.set(1 as any, enumModel as any);
+        rctx.resolved.resolvedTypes.set(1 as any, enumModel as any);
         const enumRef = { tag: ModelTag.ComponentValTypeType, value: 1 } as ComponentValType;
         const record = {
             tag: ModelTag.ComponentTypeDefinedRecord as const,
@@ -1490,11 +1492,11 @@ describe('nested compound types', () => {
                 { name: 'count', type: prim(PrimitiveValType.U32) },
             ],
         };
-        const lifter = createLifting(rctx, record as any);
+        const lifter = createLifting(rctx.resolved, record as any);
         const rctx2 = createMinimalRctx();
-        rctx2.resolvedTypes.set(0 as any, optBool as any);
-        rctx2.resolvedTypes.set(1 as any, enumModel as any);
-        const lowerer = createLowering(rctx2, record as any);
+        rctx2.resolved.resolvedTypes.set(0 as any, optBool as any);
+        rctx2.resolved.resolvedTypes.set(1 as any, enumModel as any);
+        const lowerer = createLowering(rctx2.resolved, record as any);
 
         const original = { flag: true, color: 'green', count: 7 };
         const lifted = lifter(bctx, original);
@@ -1516,87 +1518,87 @@ describe('char boundary values (spec-exact)', () => {
 
     describe('lifting boundaries', () => {
         test('0xD7FF (last valid before surrogate range) lifts correctly', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.Char));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.Char));
             expect(lifter(bctx, String.fromCodePoint(0xD7FF))).toEqual([0xD7FF]);
         });
 
         test('0xE000 (first valid after surrogate range) lifts correctly', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.Char));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.Char));
             expect(lifter(bctx, String.fromCodePoint(0xE000))).toEqual([0xE000]);
         });
 
         test('0x10FFFF (maximum valid codepoint) lifts correctly', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.Char));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.Char));
             expect(lifter(bctx, String.fromCodePoint(0x10FFFF))).toEqual([0x10FFFF]);
         });
 
         test('0x0001 (SOH control char) lifts correctly', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.Char));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.Char));
             expect(lifter(bctx, '\x01')).toEqual([1]);
         });
 
         test('0x007F (DEL) lifts correctly', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.Char));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.Char));
             expect(lifter(bctx, '\x7F')).toEqual([0x7F]);
         });
 
         test('0x0080 (first 2-byte UTF-8 char) lifts correctly', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.Char));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.Char));
             expect(lifter(bctx, String.fromCodePoint(0x80))).toEqual([0x80]);
         });
 
         test('0x10000 (first supplementary plane char) lifts correctly', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.Char));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.Char));
             expect(lifter(bctx, String.fromCodePoint(0x10000))).toEqual([0x10000]);
         });
     });
 
     describe('lowering boundaries', () => {
         test('0xD7FF lowers to valid character', () => {
-            const lowerer = createLowering(rctx, prim(PrimitiveValType.Char));
+            const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.Char));
             const result = lowerer(bctx, 0xD7FF);
             expect(result.codePointAt(0)).toBe(0xD7FF);
         });
 
         test('0xD800 (start of surrogate range) traps', () => {
-            const lowerer = createLowering(rctx, prim(PrimitiveValType.Char));
+            const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.Char));
             expect(() => lowerer(bctx, 0xD800)).toThrow('surrogate');
         });
 
         test('0xDBFF (last high surrogate) traps', () => {
-            const lowerer = createLowering(rctx, prim(PrimitiveValType.Char));
+            const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.Char));
             expect(() => lowerer(bctx, 0xDBFF)).toThrow('surrogate');
         });
 
         test('0xDC00 (first low surrogate) traps', () => {
-            const lowerer = createLowering(rctx, prim(PrimitiveValType.Char));
+            const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.Char));
             expect(() => lowerer(bctx, 0xDC00)).toThrow('surrogate');
         });
 
         test('0xDFFF (last low surrogate) traps', () => {
-            const lowerer = createLowering(rctx, prim(PrimitiveValType.Char));
+            const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.Char));
             expect(() => lowerer(bctx, 0xDFFF)).toThrow('surrogate');
         });
 
         test('0xE000 (first valid after surrogates) lowers correctly', () => {
-            const lowerer = createLowering(rctx, prim(PrimitiveValType.Char));
+            const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.Char));
             const result = lowerer(bctx, 0xE000);
             expect(result.codePointAt(0)).toBe(0xE000);
         });
 
         test('0x10FFFF (max codepoint) lowers correctly', () => {
-            const lowerer = createLowering(rctx, prim(PrimitiveValType.Char));
+            const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.Char));
             const result = lowerer(bctx, 0x10FFFF);
             expect(result.codePointAt(0)).toBe(0x10FFFF);
         });
 
         test('0x110000 (just above max) traps', () => {
-            const lowerer = createLowering(rctx, prim(PrimitiveValType.Char));
+            const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.Char));
             expect(() => lowerer(bctx, 0x110000)).toThrow('0x110000');
         });
 
         test('0xFFFFFFFF (very large) traps', () => {
-            const lowerer = createLowering(rctx, prim(PrimitiveValType.Char));
+            const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.Char));
             expect(() => lowerer(bctx, 0xFFFFFFFF)).toThrow('0x110000');
         });
     });
@@ -1616,7 +1618,7 @@ describe('multi-word flags (>32 members)', () => {
     test('33 flags: flag 32 (first in second word) lifts correctly', () => {
         const members = Array.from({ length: 33 }, (_, i) => `f${i}`);
         const model = { tag: ModelTag.ComponentTypeDefinedFlags as const, members };
-        const lifter = createLifting(rctx, model);
+        const lifter = createLifting(rctx.resolved, model);
         const flags: Record<string, boolean> = {};
         for (const m of members) flags[m] = false;
         flags['f32'] = true;
@@ -1629,7 +1631,7 @@ describe('multi-word flags (>32 members)', () => {
     test('64 flags: all set in both words', () => {
         const members = Array.from({ length: 64 }, (_, i) => `f${i}`);
         const model = { tag: ModelTag.ComponentTypeDefinedFlags as const, members };
-        const lifter = createLifting(rctx, model);
+        const lifter = createLifting(rctx.resolved, model);
         const flags: Record<string, boolean> = {};
         for (const m of members) flags[m] = true;
         const result = lifter(bctx, flags);
@@ -1642,7 +1644,7 @@ describe('multi-word flags (>32 members)', () => {
         const members = Array.from({ length: 64 }, (_, i) => `f${i}`);
         const model = { tag: ModelTag.ComponentTypeDefinedFlags as const, members };
         const rctx2 = createMinimalRctx();
-        const lowerer = createLowering(rctx2, model);
+        const lowerer = createLowering(rctx2.resolved, model);
         // word0: bit 0 and bit 31, word1: bit 0 (f32)
         const result = lowerer(bctx, (1 | (1 << 31)), 1);
         expect(result['f0']).toBe(true);
@@ -1656,9 +1658,9 @@ describe('multi-word flags (>32 members)', () => {
     test('33 flags full round-trip', () => {
         const members = Array.from({ length: 33 }, (_, i) => `f${i}`);
         const model = { tag: ModelTag.ComponentTypeDefinedFlags as const, members };
-        const lifter = createLifting(rctx, model);
+        const lifter = createLifting(rctx.resolved, model);
         const rctx2 = createMinimalRctx();
-        const lowerer = createLowering(rctx2, {
+        const lowerer = createLowering(rctx2.resolved, {
             tag: ModelTag.ComponentTypeDefinedFlags as const, members,
         });
 
@@ -1682,14 +1684,14 @@ describe('multi-word flags (>32 members)', () => {
     test('96 flags (3 words): spill is 3', () => {
         const members = Array.from({ length: 96 }, (_, i) => `f${i}`);
         const model = { tag: ModelTag.ComponentTypeDefinedFlags as const, members };
-        const lowerer = createLowering(rctx, model);
+        const lowerer = createLowering(rctx.resolved, model);
         expect((lowerer as any).spill).toBe(3);
     });
 
     test('96 flags: flag 64 (first in third word) lifts correctly', () => {
         const members = Array.from({ length: 96 }, (_, i) => `f${i}`);
         const model = { tag: ModelTag.ComponentTypeDefinedFlags as const, members };
-        const lifter = createLifting(rctx, model);
+        const lifter = createLifting(rctx.resolved, model);
         const flags: Record<string, boolean> = {};
         for (const m of members) flags[m] = false;
         flags['f64'] = true;
@@ -1713,7 +1715,7 @@ describe('bool from memory (non-0/1 values)', () => {
         };
         // Write 2 to memory
         new DataView(buffer).setUint8(100, 2);
-        const result = loadFromMemory(ctx, 100, boolType as any, rctx.stringEncoding, rctx.canonicalResourceIds);
+        const result = loadFromMemory(ctx, 100, boolType as any, rctx.resolved.stringEncoding, rctx.resolved.canonicalResourceIds);
         expect(result).toBe(true);
     });
 
@@ -1725,7 +1727,7 @@ describe('bool from memory (non-0/1 values)', () => {
             value: PrimitiveValType.Bool,
         };
         new DataView(buffer).setUint8(100, 255);
-        const result = loadFromMemory(ctx, 100, boolType as any, rctx.stringEncoding, rctx.canonicalResourceIds);
+        const result = loadFromMemory(ctx, 100, boolType as any, rctx.resolved.stringEncoding, rctx.resolved.canonicalResourceIds);
         expect(result).toBe(true);
     });
 
@@ -1737,7 +1739,7 @@ describe('bool from memory (non-0/1 values)', () => {
             value: PrimitiveValType.Bool,
         };
         new DataView(buffer).setUint8(100, 0);
-        const result = loadFromMemory(ctx, 100, boolType as any, rctx.stringEncoding, rctx.canonicalResourceIds);
+        const result = loadFromMemory(ctx, 100, boolType as any, rctx.resolved.stringEncoding, rctx.resolved.canonicalResourceIds);
         expect(result).toBe(false);
     });
 
@@ -1748,10 +1750,10 @@ describe('bool from memory (non-0/1 values)', () => {
             tag: ModelTag.ComponentTypeDefinedPrimitive as const,
             value: PrimitiveValType.Bool,
         };
-        storeToMemory(ctx, 200, boolType as any, true, rctx.stringEncoding, rctx.canonicalResourceIds);
+        storeToMemory(ctx, 200, boolType as any, true, rctx.resolved.stringEncoding, rctx.resolved.canonicalResourceIds);
         expect(new DataView(buffer).getUint8(200)).toBe(1);
 
-        storeToMemory(ctx, 204, boolType as any, false, rctx.stringEncoding, rctx.canonicalResourceIds);
+        storeToMemory(ctx, 204, boolType as any, false, rctx.resolved.stringEncoding, rctx.resolved.canonicalResourceIds);
         expect(new DataView(buffer).getUint8(204)).toBe(0);
     });
 });
@@ -1767,8 +1769,8 @@ describe('discriminant in memory round-trips', () => {
             tag: ModelTag.ComponentTypeDefinedVariant as const,
             variants: cases,
         };
-        storeToMemory(ctx, 100, model as any, { tag: 'c255' }, rctx.stringEncoding, rctx.canonicalResourceIds);
-        const result = loadFromMemory(ctx, 100, model as any, rctx.stringEncoding, rctx.canonicalResourceIds);
+        storeToMemory(ctx, 100, model as any, { tag: 'c255' }, rctx.resolved.stringEncoding, rctx.resolved.canonicalResourceIds);
+        const result = loadFromMemory(ctx, 100, model as any, rctx.resolved.stringEncoding, rctx.resolved.canonicalResourceIds);
         expect(result).toEqual({ tag: 'c255' });
     });
 
@@ -1780,8 +1782,8 @@ describe('discriminant in memory round-trips', () => {
             tag: ModelTag.ComponentTypeDefinedEnum as const,
             members,
         };
-        storeToMemory(ctx, 100, model as any, 'e255', rctx.stringEncoding, rctx.canonicalResourceIds);
-        const result = loadFromMemory(ctx, 100, model as any, rctx.stringEncoding, rctx.canonicalResourceIds);
+        storeToMemory(ctx, 100, model as any, 'e255', rctx.resolved.stringEncoding, rctx.resolved.canonicalResourceIds);
+        const result = loadFromMemory(ctx, 100, model as any, rctx.resolved.stringEncoding, rctx.resolved.canonicalResourceIds);
         expect(result).toBe('e255');
     });
 
@@ -1795,8 +1797,8 @@ describe('discriminant in memory round-trips', () => {
                 { name: 'big', ty: prim(PrimitiveValType.U32) },
             ],
         };
-        storeToMemory(ctx, 100, model as any, { tag: 'big', val: 100000 }, rctx.stringEncoding, rctx.canonicalResourceIds);
-        const result = loadFromMemory(ctx, 100, model as any, rctx.stringEncoding, rctx.canonicalResourceIds);
+        storeToMemory(ctx, 100, model as any, { tag: 'big', val: 100000 }, rctx.resolved.stringEncoding, rctx.resolved.canonicalResourceIds);
+        const result = loadFromMemory(ctx, 100, model as any, rctx.resolved.stringEncoding, rctx.resolved.canonicalResourceIds);
         expect(result).toEqual({ tag: 'big', val: 100000 });
     });
 
@@ -1810,8 +1812,8 @@ describe('discriminant in memory round-trips', () => {
             tag: ModelTag.ComponentTypeDefinedEnum as const,
             members,
         };
-        storeToMemory(ctx, 100, model as any, 'e299', rctx.stringEncoding, rctx.canonicalResourceIds);
-        const result = loadFromMemory(ctx, 100, model as any, rctx.stringEncoding, rctx.canonicalResourceIds);
+        storeToMemory(ctx, 100, model as any, 'e299', rctx.resolved.stringEncoding, rctx.resolved.canonicalResourceIds);
+        const result = loadFromMemory(ctx, 100, model as any, rctx.resolved.stringEncoding, rctx.resolved.canonicalResourceIds);
         expect(result).toBe('e299');
     });
 
@@ -1823,8 +1825,8 @@ describe('discriminant in memory round-trips', () => {
             tag: ModelTag.ComponentTypeDefinedFlags as const,
             members,
         };
-        storeToMemory(ctx, 100, model as any, { a: true, b: false, c: true, d: false }, rctx.stringEncoding, rctx.canonicalResourceIds);
-        const result = loadFromMemory(ctx, 100, model as any, rctx.stringEncoding, rctx.canonicalResourceIds);
+        storeToMemory(ctx, 100, model as any, { a: true, b: false, c: true, d: false }, rctx.resolved.stringEncoding, rctx.resolved.canonicalResourceIds);
+        const result = loadFromMemory(ctx, 100, model as any, rctx.resolved.stringEncoding, rctx.resolved.canonicalResourceIds);
         expect(result).toEqual({ a: true, b: false, c: true, d: false });
     });
 
@@ -1840,8 +1842,8 @@ describe('discriminant in memory round-trips', () => {
         for (const m of members) flags[m] = false;
         flags['f0'] = true;
         flags['f32'] = true;
-        storeToMemory(ctx, 100, model as any, flags, rctx.stringEncoding, rctx.canonicalResourceIds);
-        const result = loadFromMemory(ctx, 100, model as any, rctx.stringEncoding, rctx.canonicalResourceIds);
+        storeToMemory(ctx, 100, model as any, flags, rctx.resolved.stringEncoding, rctx.resolved.canonicalResourceIds);
+        const result = loadFromMemory(ctx, 100, model as any, rctx.resolved.stringEncoding, rctx.resolved.canonicalResourceIds);
         expect(result['f0']).toBe(true);
         expect(result['f1']).toBe(false);
         expect(result['f32']).toBe(true);
@@ -1854,12 +1856,12 @@ describe('discriminant in memory round-trips', () => {
             tag: ModelTag.ComponentTypeDefinedOption as const,
             value: prim(PrimitiveValType.U32),
         };
-        storeToMemory(ctx, 100, model as any, 42, rctx.stringEncoding, rctx.canonicalResourceIds);
-        const some = loadFromMemory(ctx, 100, model as any, rctx.stringEncoding, rctx.canonicalResourceIds);
+        storeToMemory(ctx, 100, model as any, 42, rctx.resolved.stringEncoding, rctx.resolved.canonicalResourceIds);
+        const some = loadFromMemory(ctx, 100, model as any, rctx.resolved.stringEncoding, rctx.resolved.canonicalResourceIds);
         expect(some).toBe(42);
 
-        storeToMemory(ctx, 200, model as any, null, rctx.stringEncoding, rctx.canonicalResourceIds);
-        const none = loadFromMemory(ctx, 200, model as any, rctx.stringEncoding, rctx.canonicalResourceIds);
+        storeToMemory(ctx, 200, model as any, null, rctx.resolved.stringEncoding, rctx.resolved.canonicalResourceIds);
+        const none = loadFromMemory(ctx, 200, model as any, rctx.resolved.stringEncoding, rctx.resolved.canonicalResourceIds);
         expect(none).toBeNull();
     });
 
@@ -1871,12 +1873,12 @@ describe('discriminant in memory round-trips', () => {
             ok: prim(PrimitiveValType.U32),
             err: prim(PrimitiveValType.U8),
         };
-        storeToMemory(ctx, 100, model as any, { tag: 'ok', val: 99 }, rctx.stringEncoding, rctx.canonicalResourceIds);
-        const okResult = loadFromMemory(ctx, 100, model as any, rctx.stringEncoding, rctx.canonicalResourceIds);
+        storeToMemory(ctx, 100, model as any, { tag: 'ok', val: 99 }, rctx.resolved.stringEncoding, rctx.resolved.canonicalResourceIds);
+        const okResult = loadFromMemory(ctx, 100, model as any, rctx.resolved.stringEncoding, rctx.resolved.canonicalResourceIds);
         expect(okResult).toEqual({ tag: 'ok', val: 99 });
 
-        storeToMemory(ctx, 200, model as any, { tag: 'err', val: 7 }, rctx.stringEncoding, rctx.canonicalResourceIds);
-        const errResult = loadFromMemory(ctx, 200, model as any, rctx.stringEncoding, rctx.canonicalResourceIds);
+        storeToMemory(ctx, 200, model as any, { tag: 'err', val: 7 }, rctx.resolved.stringEncoding, rctx.resolved.canonicalResourceIds);
+        const errResult = loadFromMemory(ctx, 200, model as any, rctx.resolved.stringEncoding, rctx.resolved.canonicalResourceIds);
         expect(errResult).toEqual({ tag: 'err', val: 7 });
     });
 
@@ -1891,8 +1893,8 @@ describe('discriminant in memory round-trips', () => {
                 prim(PrimitiveValType.Bool),
             ],
         };
-        storeToMemory(ctx, 100, model as any, [255, 100000, true], rctx.stringEncoding, rctx.canonicalResourceIds);
-        const result = loadFromMemory(ctx, 100, model as any, rctx.stringEncoding, rctx.canonicalResourceIds);
+        storeToMemory(ctx, 100, model as any, [255, 100000, true], rctx.resolved.stringEncoding, rctx.resolved.canonicalResourceIds);
+        const result = loadFromMemory(ctx, 100, model as any, rctx.resolved.stringEncoding, rctx.resolved.canonicalResourceIds);
         expect(result).toEqual([255, 100000, true]);
     });
 
@@ -1907,8 +1909,8 @@ describe('discriminant in memory round-trips', () => {
                 { name: 'c', type: prim(PrimitiveValType.Bool) },
             ],
         };
-        storeToMemory(ctx, 100, model as any, { a: 42, b: 100000, c: true }, rctx.stringEncoding, rctx.canonicalResourceIds);
-        const result = loadFromMemory(ctx, 100, model as any, rctx.stringEncoding, rctx.canonicalResourceIds);
+        storeToMemory(ctx, 100, model as any, { a: 42, b: 100000, c: true }, rctx.resolved.stringEncoding, rctx.resolved.canonicalResourceIds);
+        const result = loadFromMemory(ctx, 100, model as any, rctx.resolved.stringEncoding, rctx.resolved.canonicalResourceIds);
         expect(result).toEqual({ a: 42, b: 100000, c: true });
     });
 
@@ -1922,16 +1924,16 @@ describe('discriminant in memory round-trips', () => {
                 { name: 'y', type: prim(PrimitiveValType.U32) },
             ],
         };
-        rctx.resolvedTypes.set(0 as any, innerRecord as any);
-        const outerRecord = deepResolveType(rctx, {
+        rctx.resolved.resolvedTypes.set(0 as any, innerRecord as any);
+        const outerRecord = deepResolveType(rctx.resolved, {
             tag: ModelTag.ComponentTypeDefinedRecord as const,
             members: [
                 { name: 'name', type: prim(PrimitiveValType.U8) },
                 { name: 'point', type: { tag: ModelTag.ComponentValTypeType, value: 0 } as ComponentValType },
             ],
         } as any);
-        storeToMemory(ctx, 100, outerRecord as any, { name: 5, point: { x: 10, y: 20 } }, rctx.stringEncoding, rctx.canonicalResourceIds);
-        const result = loadFromMemory(ctx, 100, outerRecord as any, rctx.stringEncoding, rctx.canonicalResourceIds);
+        storeToMemory(ctx, 100, outerRecord as any, { name: 5, point: { x: 10, y: 20 } }, rctx.resolved.stringEncoding, rctx.resolved.canonicalResourceIds);
+        const result = loadFromMemory(ctx, 100, outerRecord as any, rctx.resolved.stringEncoding, rctx.resolved.canonicalResourceIds);
         expect(result).toEqual({ name: 5, point: { x: 10, y: 20 } });
     });
 
@@ -1955,8 +1957,8 @@ describe('discriminant in memory round-trips', () => {
                 tag: ModelTag.ComponentTypeDefinedPrimitive as const,
                 value: primType,
             };
-            storeToMemory(ctx, offset, model as any, value, rctx.stringEncoding, rctx.canonicalResourceIds);
-            const result = loadFromMemory(ctx, offset, model as any, rctx.stringEncoding, rctx.canonicalResourceIds);
+            storeToMemory(ctx, offset, model as any, value, rctx.resolved.stringEncoding, rctx.resolved.canonicalResourceIds);
+            const result = loadFromMemory(ctx, offset, model as any, rctx.resolved.stringEncoding, rctx.resolved.canonicalResourceIds);
             if (primType === PrimitiveValType.Float32) {
                 expect(result).toBeCloseTo(value, 5);
             } else {
@@ -1977,10 +1979,10 @@ describe('resource handle additional edge cases', () => {
         // Add a resource and get a handle
         const _handle = ctx.resources.add(0, 'test-resource');
         // Store handle in memory
-        storeToMemory(ctx, 100, ownModel as any, 'test-resource', rctx.stringEncoding, rctx.canonicalResourceIds);
+        storeToMemory(ctx, 100, ownModel as any, 'test-resource', rctx.resolved.stringEncoding, rctx.resolved.canonicalResourceIds);
         // The handle was stored by lifting (add), not directly
         // Load removes from table (own semantics)
-        const result = loadFromMemory(ctx, 100, ownModel as any, rctx.stringEncoding, rctx.canonicalResourceIds);
+        const result = loadFromMemory(ctx, 100, ownModel as any, rctx.resolved.stringEncoding, rctx.resolved.canonicalResourceIds);
         expect(typeof result).toBe('string');
     });
 
@@ -1993,7 +1995,7 @@ describe('resource handle additional edge cases', () => {
         // Write handle to memory
         new DataView(ctx.memory.getView(100 as WasmPointer, 4 as WasmSize).buffer, 100).setInt32(0, handle, true);
         // Load borrow from memory (doesn't remove)
-        const result = loadFromMemory(ctx, 100, borrowModel as any, rctx.stringEncoding, rctx.canonicalResourceIds);
+        const result = loadFromMemory(ctx, 100, borrowModel as any, rctx.resolved.stringEncoding, rctx.resolved.canonicalResourceIds);
         expect(result).toBe('borrowed-data');
         // Resource should still be in table (borrow doesn't remove)
         expect(ctx.resources.has(0, handle)).toBe(true);
@@ -2066,15 +2068,15 @@ describe('nested types via memory round-trips', () => {
                 { name: 'b', type: prim(PrimitiveValType.U32) },
             ],
         };
-        rctx.resolvedTypes.set(0 as any, record as any);
+        rctx.resolved.resolvedTypes.set(0 as any, record as any);
         const list = {
             tag: ModelTag.ComponentTypeDefinedList as const,
             value: { tag: ModelTag.ComponentValTypeType, value: 0 } as ComponentValType,
         };
-        const lifter = createLifting(rctx, list);
+        const lifter = createLifting(rctx.resolved, list);
         const rctx2 = createMinimalRctx();
-        rctx2.resolvedTypes.set(0 as any, record as any);
-        const lowerer = createLowering(rctx2, list);
+        rctx2.resolved.resolvedTypes.set(0 as any, record as any);
+        const lowerer = createLowering(rctx2.resolved, list);
 
         const original = [{ a: 1, b: 100 }, { a: 2, b: 200 }, { a: 3, b: 300 }];
         const [ptr, len] = lifter(ctx, original);
@@ -2091,12 +2093,12 @@ describe('nested types via memory round-trips', () => {
             value: prim(PrimitiveValType.U32),
         };
         // Some(42)
-        storeToMemory(ctx, 100, model as any, 42, rctx.stringEncoding, rctx.canonicalResourceIds);
-        expect(loadFromMemory(ctx, 100, model as any, rctx.stringEncoding, rctx.canonicalResourceIds)).toBe(42);
+        storeToMemory(ctx, 100, model as any, 42, rctx.resolved.stringEncoding, rctx.resolved.canonicalResourceIds);
+        expect(loadFromMemory(ctx, 100, model as any, rctx.resolved.stringEncoding, rctx.resolved.canonicalResourceIds)).toBe(42);
 
         // None
-        storeToMemory(ctx, 200, model as any, null, rctx.stringEncoding, rctx.canonicalResourceIds);
-        expect(loadFromMemory(ctx, 200, model as any, rctx.stringEncoding, rctx.canonicalResourceIds)).toBeNull();
+        storeToMemory(ctx, 200, model as any, null, rctx.resolved.stringEncoding, rctx.resolved.canonicalResourceIds);
+        expect(loadFromMemory(ctx, 200, model as any, rctx.resolved.stringEncoding, rctx.resolved.canonicalResourceIds)).toBeNull();
     });
 
     test('result<u32, u8> via memory stores discriminant correctly', () => {
@@ -2109,16 +2111,16 @@ describe('nested types via memory round-trips', () => {
         };
 
         // Ok(42)
-        storeToMemory(ctx, 100, model as any, { tag: 'ok', val: 42 }, rctx.stringEncoding, rctx.canonicalResourceIds);
+        storeToMemory(ctx, 100, model as any, { tag: 'ok', val: 42 }, rctx.resolved.stringEncoding, rctx.resolved.canonicalResourceIds);
         // discriminant at byte 0 should be 0 (ok)
         expect(new DataView(buffer, 100).getUint8(0)).toBe(0);
-        const okResult = loadFromMemory(ctx, 100, model as any, rctx.stringEncoding, rctx.canonicalResourceIds);
+        const okResult = loadFromMemory(ctx, 100, model as any, rctx.resolved.stringEncoding, rctx.resolved.canonicalResourceIds);
         expect(okResult).toEqual({ tag: 'ok', val: 42 });
 
         // Err(7)
-        storeToMemory(ctx, 200, model as any, { tag: 'err', val: 7 }, rctx.stringEncoding, rctx.canonicalResourceIds);
+        storeToMemory(ctx, 200, model as any, { tag: 'err', val: 7 }, rctx.resolved.stringEncoding, rctx.resolved.canonicalResourceIds);
         expect(new DataView(buffer, 200).getUint8(0)).toBe(1);
-        const errResult = loadFromMemory(ctx, 200, model as any, rctx.stringEncoding, rctx.canonicalResourceIds);
+        const errResult = loadFromMemory(ctx, 200, model as any, rctx.resolved.stringEncoding, rctx.resolved.canonicalResourceIds);
         expect(errResult).toEqual({ tag: 'err', val: 7 });
     });
 });
@@ -2128,10 +2130,12 @@ describe('nested types via memory round-trips', () => {
 describe('function trampoline edge cases', () => {
     function createFuncRctx(): ResolverContext {
         return {
-            memoizeCache: new Map(),
-            resolvedTypes: new Map(),
-            usesNumberForInt64: false,
-            stringEncoding: StringEncoding.Utf8,
+            resolved: {
+                memoizeCache: new Map(),
+                resolvedTypes: new Map(),
+                usesNumberForInt64: false,
+                stringEncoding: StringEncoding.Utf8,
+            },
             indexes: {
                 coreModules: [],
                 coreInstances: [],
@@ -2199,7 +2203,7 @@ describe('function trampoline edge cases', () => {
             params: [{ name: 'a', type: prim(PrimitiveValType.U32) }],
             results: { tag: ModelTag.ComponentFuncResultNamed, values: [] },
         } as any;
-        const lowerer = createFunctionLowering(rctx, func);
+        const lowerer = createFunctionLowering(rctx.resolved, func);
 
         let received: number | undefined;
         const mockJs = (x: number) => { received = x; };
@@ -2217,7 +2221,7 @@ describe('function trampoline edge cases', () => {
             params: [],
             results: { tag: ModelTag.ComponentFuncResultUnnamed, type: prim(PrimitiveValType.U32) },
         } as any;
-        const lifter = createFunctionLifting(rctx, func);
+        const lifter = createFunctionLifting(rctx.resolved, func);
 
         const mockWasm = () => { throw new Error('trap!'); };
         const jsFunc = lifter(ctx, mockWasm as any);
@@ -2233,7 +2237,7 @@ describe('function trampoline edge cases', () => {
             params: [],
             results: { tag: ModelTag.ComponentFuncResultNamed, values: [] },
         } as any;
-        const lifter = createFunctionLifting(rctx, func);
+        const lifter = createFunctionLifting(rctx.resolved, func);
 
         ctx.poisoned = true;
         const mockWasm = () => { };
@@ -2249,7 +2253,7 @@ describe('function trampoline edge cases', () => {
             params: [],
             results: { tag: ModelTag.ComponentFuncResultNamed, values: [] },
         } as any;
-        const lifter = createFunctionLifting(rctx, func);
+        const lifter = createFunctionLifting(rctx.resolved, func);
 
         ctx.inExport = true; // simulate already in export
         const mockWasm = () => { };
@@ -2268,7 +2272,7 @@ describe('function trampoline edge cases', () => {
             ],
             results: { tag: ModelTag.ComponentFuncResultUnnamed, type: prim(PrimitiveValType.Bool) },
         } as any;
-        const lowerer = createFunctionLowering(rctx, func);
+        const lowerer = createFunctionLowering(rctx.resolved, func);
 
         const mockJs = (a: boolean, b: boolean) => a && b;
         const wasmFunc = lowerer(ctx, mockJs as any);
@@ -2285,7 +2289,7 @@ describe('function trampoline edge cases', () => {
             params: [],
             results: { tag: ModelTag.ComponentFuncResultUnnamed, type: prim(PrimitiveValType.U32) },
         } as any;
-        const lowerer = createFunctionLowering(rctx, func);
+        const lowerer = createFunctionLowering(rctx.resolved, func);
 
         const mockJs = () => 42;
         const wasmFunc = lowerer(ctx, mockJs as any);
@@ -2312,7 +2316,7 @@ describe('variant lowering validation', () => {
                 { name: 'b' },
             ],
         };
-        const lowerer = createLowering(rctx, model);
+        const lowerer = createLowering(rctx.resolved, model);
         // discriminant 5 is out of range — throws
         expect(() => lowerer(bctx, 5, 42)).toThrow('Invalid variant discriminant');
     });
@@ -2325,7 +2329,7 @@ describe('variant lowering validation', () => {
                 { name: 'b' },
             ],
         };
-        const lifter = createLifting(rctx, model);
+        const lifter = createLifting(rctx.resolved, model);
         expect(() => lifter(bctx, { tag: 'nonexistent', val: 0 })).toThrow();
     });
 
@@ -2337,9 +2341,9 @@ describe('variant lowering validation', () => {
                 { name: 'data', ty: prim(PrimitiveValType.U32) },
             ],
         };
-        const lifter = createLifting(rctx, model);
+        const lifter = createLifting(rctx.resolved, model);
         const rctx2 = createMinimalRctx();
-        const lowerer = createLowering(rctx2, model);
+        const lowerer = createLowering(rctx2.resolved, model);
         const lifted = lifter(bctx, { tag: 'empty' });
         const lowered = lowerer(bctx, ...lifted);
         expect(lowered).toEqual({ tag: 'empty' });
@@ -2351,23 +2355,27 @@ describe('variant lowering validation', () => {
 describe('CompactUTF-16 encoding', () => {
     test('lifting with CompactUTF-16 throws not-supported', () => {
         const rctx = {
-            memoizeCache: new Map(),
-            resolvedTypes: new Map(),
-            usesNumberForInt64: false,
-            stringEncoding: StringEncoding.CompactUtf16,
+            resolved: {
+                memoizeCache: new Map(),
+                resolvedTypes: new Map(),
+                usesNumberForInt64: false,
+                stringEncoding: StringEncoding.CompactUtf16,
+            },
         } as any as ResolverContext;
-        expect(() => createLifting(rctx, prim(PrimitiveValType.String)))
+        expect(() => createLifting(rctx.resolved, prim(PrimitiveValType.String)))
             .toThrow('CompactUTF-16');
     });
 
     test('lowering with CompactUTF-16 throws not-supported', () => {
         const rctx = {
-            memoizeCache: new Map(),
-            resolvedTypes: new Map(),
-            usesNumberForInt64: false,
-            stringEncoding: StringEncoding.CompactUtf16,
+            resolved: {
+                memoizeCache: new Map(),
+                resolvedTypes: new Map(),
+                usesNumberForInt64: false,
+                stringEncoding: StringEncoding.CompactUtf16,
+            },
         } as any as ResolverContext;
-        expect(() => createLowering(rctx, prim(PrimitiveValType.String)))
+        expect(() => createLowering(rctx.resolved, prim(PrimitiveValType.String)))
             .toThrow('CompactUTF-16');
     });
 });
@@ -2377,13 +2385,15 @@ describe('CompactUTF-16 encoding', () => {
 describe('UTF-16 string bounds checking', () => {
     test('UTF-16 lowering out-of-bounds traps', () => {
         const rctx = {
-            memoizeCache: new Map(),
-            resolvedTypes: new Map(),
-            usesNumberForInt64: false,
-            stringEncoding: StringEncoding.Utf16,
+            resolved: {
+                memoizeCache: new Map(),
+                resolvedTypes: new Map(),
+                usesNumberForInt64: false,
+                stringEncoding: StringEncoding.Utf16,
+            },
         } as any as ResolverContext;
         const { ctx } = createMockMemoryContext(64);
-        const lowerer = createLowering(rctx, prim(PrimitiveValType.String));
+        const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.String));
         // 100 code units = 200 bytes, but buffer is only 64 bytes
         expect(() => (lowerer as any)(ctx, 0, 100))
             .toThrow('out of bounds');
@@ -2392,7 +2402,7 @@ describe('UTF-16 string bounds checking', () => {
     test('UTF-8 lowering out-of-bounds traps', () => {
         const rctx = createMinimalRctx();
         const { ctx } = createMockMemoryContext(64);
-        const lowerer = createLowering(rctx, prim(PrimitiveValType.String));
+        const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.String));
         // 100 bytes but buffer is only 64
         expect(() => (lowerer as any)(ctx, 0, 100))
             .toThrow('out of bounds');

--- a/src/resolver/binding/function-imports.test.ts
+++ b/src/resolver/binding/function-imports.test.ts
@@ -8,10 +8,12 @@ import { ComponentImport } from '../../model/imports';
 
 function createMinimalRctx(): ResolverContext {
     return {
-        memoizeCache: new Map(),
-        resolvedTypes: new Map(),
+        resolved: {
+            memoizeCache: new Map(),
+            resolvedTypes: new Map(),
+            usesNumberForInt64: false,
+        },
         importToInstanceIndex: new Map(),
-        usesNumberForInt64: false,
         indexes: {
             componentTypes: [],
             componentImports: [],

--- a/src/resolver/binding/function-imports.test.ts
+++ b/src/resolver/binding/function-imports.test.ts
@@ -9,7 +9,7 @@ import { ComponentImport } from '../../model/imports';
 function createMinimalRctx(): ResolverContext {
     return {
         resolved: {
-            memoizeCache: new Map(),
+            liftingCache: new Map(), loweringCache: new Map(),
             resolvedTypes: new Map(),
             usesNumberForInt64: false,
         },

--- a/src/resolver/binding/memoization.test.ts
+++ b/src/resolver/binding/memoization.test.ts
@@ -1,0 +1,244 @@
+import { ModelTag } from '../../model/tags';
+import { ComponentValType, PrimitiveValType, ComponentTypeFunc } from '../../model/types';
+import { ResolvedContext, BindingContext, StringEncoding } from '../types';
+import { createLifting, createFunctionLifting } from './to-abi';
+import { createLowering, createFunctionLowering } from './to-js';
+
+function createMinimalResolved(opts?: Partial<ResolvedContext>): ResolvedContext {
+    return {
+        liftingCache: new Map(),
+        loweringCache: new Map(),
+        resolvedTypes: new Map(),
+        canonicalResourceIds: new Map(),
+        usesNumberForInt64: false,
+        stringEncoding: StringEncoding.Utf8,
+        ...opts,
+    };
+}
+
+function prim(value: PrimitiveValType): ComponentValType {
+    return { tag: ModelTag.ComponentValTypePrimitive, value };
+}
+
+// ─── Memoization key identity tests ──────────────────────────────────────
+
+describe('memoization keys', () => {
+
+    describe('cache hit by object identity', () => {
+        test('createLifting returns same result for same object reference', () => {
+            const rctx = createMinimalResolved();
+            const typeModel = prim(PrimitiveValType.U32);
+            const lifter1 = createLifting(rctx, typeModel);
+            const lifter2 = createLifting(rctx, typeModel);
+            expect(lifter1).toBe(lifter2);
+        });
+
+        test('createLowering returns same result for same object reference', () => {
+            const rctx = createMinimalResolved();
+            const typeModel = prim(PrimitiveValType.U32);
+            const lowerer1 = createLowering(rctx, typeModel);
+            const lowerer2 = createLowering(rctx, typeModel);
+            expect(lowerer1).toBe(lowerer2);
+        });
+
+        test('createFunctionLifting returns same result for same ComponentTypeFunc', () => {
+            const rctx = createMinimalResolved();
+            const funcType: ComponentTypeFunc = {
+                tag: ModelTag.ComponentTypeFunc,
+                params: [{ name: 'a', type: prim(PrimitiveValType.U32) }],
+                results: { tag: ModelTag.ComponentFuncResultUnnamed, type: prim(PrimitiveValType.U32) },
+            } as any;
+            const lifter1 = createFunctionLifting(rctx, funcType);
+            const lifter2 = createFunctionLifting(rctx, funcType);
+            expect(lifter1).toBe(lifter2);
+        });
+
+        test('createFunctionLowering returns same result for same ComponentTypeFunc', () => {
+            const rctx = createMinimalResolved();
+            const funcType: ComponentTypeFunc = {
+                tag: ModelTag.ComponentTypeFunc,
+                params: [{ name: 'a', type: prim(PrimitiveValType.U32) }],
+                results: { tag: ModelTag.ComponentFuncResultUnnamed, type: prim(PrimitiveValType.U32) },
+            } as any;
+            const lowerer1 = createFunctionLowering(rctx, funcType);
+            const lowerer2 = createFunctionLowering(rctx, funcType);
+            expect(lowerer1).toBe(lowerer2);
+        });
+    });
+
+    describe('cache miss by different identity', () => {
+        test('createLifting returns different results for structurally equal but identity-different objects', () => {
+            const rctx = createMinimalResolved();
+            const type1 = prim(PrimitiveValType.U32);
+            const type2 = prim(PrimitiveValType.U32); // same structure, different object
+            const lifter1 = createLifting(rctx, type1);
+            const lifter2 = createLifting(rctx, type2);
+            // Both produce correct U32 lifters but are separately cached
+            expect(lifter1).not.toBe(lifter2);
+        });
+
+        test('createLowering returns different results for structurally equal but identity-different objects', () => {
+            const rctx = createMinimalResolved();
+            const type1 = prim(PrimitiveValType.U32);
+            const type2 = prim(PrimitiveValType.U32);
+            const lowerer1 = createLowering(rctx, type1);
+            const lowerer2 = createLowering(rctx, type2);
+            expect(lowerer1).not.toBe(lowerer2);
+        });
+    });
+
+    describe('lifting vs lowering cache isolation', () => {
+        test('same object produces different lifter and lowerer', () => {
+            const rctx = createMinimalResolved();
+            const typeModel = prim(PrimitiveValType.U32);
+            const lifter = createLifting(rctx, typeModel);
+            const lowerer = createLowering(rctx, typeModel);
+            // Must be different functions — lifter converts JS→WASM, lowerer converts WASM→JS
+            expect(lifter).not.toBe(lowerer);
+        });
+
+        test('resolved type used in both directions produces correct lifter and lowerer', () => {
+            const rctx = createMinimalResolved();
+
+            // A record type that will be the resolved target
+            const recordModel = {
+                tag: ModelTag.ComponentTypeDefinedRecord,
+                members: [
+                    { name: 'x', type: prim(PrimitiveValType.U32) },
+                ],
+            };
+
+            // Register it in resolvedTypes so ComponentValTypeType can resolve to it
+            rctx.resolvedTypes.set(0 as any, recordModel as any);
+
+            // Two different ComponentValTypeType references to the same resolved type
+            const typeRef1: ComponentValType = { tag: ModelTag.ComponentValTypeType, value: 0 };
+            const typeRef2: ComponentValType = { tag: ModelTag.ComponentValTypeType, value: 0 };
+
+            // Create lifter first, then lowerer — both resolve to same recordModel object
+            const lifter = createLifting(rctx, typeRef1);
+            const lowerer = createLowering(rctx, typeRef2);
+
+            // The lifter and lowerer should be functionally different
+            expect(lifter).not.toBe(lowerer);
+
+            // Verify they actually behave correctly (lifter: JS→flat, lowerer: flat→JS)
+            const ctx = createMinimalBctx();
+            // Lifter takes JS object, returns flat WASM args
+            const flatArgs = lifter(ctx, { x: 42 });
+            expect(flatArgs).toEqual([42]);
+
+            // Lowerer takes flat WASM args, returns JS object
+            const jsObj = lowerer(ctx, 42);
+            expect(jsObj).toEqual({ x: 42 });
+        });
+
+        test('string type with same identity cached independently for lift and lower', () => {
+            const rctx = createMinimalResolved();
+            const strType = prim(PrimitiveValType.String);
+            const lifter = createLifting(rctx, strType);
+            const lowerer = createLowering(rctx, strType);
+
+            expect(lifter).not.toBe(lowerer);
+            // Lowerer reads (ptr, len) so spill=2; lifter returns [ptr, len] but spill is not set on lifters
+            expect((lowerer as any).spill).toBe(2);
+        });
+    });
+
+    describe('stringEncoding baked at creation time', () => {
+        test('UTF-8 and UTF-16 string lifters differ even with same type identity', () => {
+            const utf8Rctx = createMinimalResolved({ stringEncoding: StringEncoding.Utf8 });
+            const utf16Rctx = createMinimalResolved({ stringEncoding: StringEncoding.Utf16 });
+            // Share the same type model object
+            const strType = prim(PrimitiveValType.String);
+
+            const utf8Lifter = createLifting(utf8Rctx, strType);
+            const utf16Lifter = createLifting(utf16Rctx, strType);
+
+            // Different rctx = different caches, so no collision
+            expect(utf8Lifter).not.toBe(utf16Lifter);
+        });
+
+        test('changing stringEncoding on same rctx after creation does not affect cached lifter', () => {
+            const rctx = createMinimalResolved({ stringEncoding: StringEncoding.Utf8 });
+            const strType = prim(PrimitiveValType.String);
+
+            // Create lifter with UTF-8 encoding
+            const lifter1 = createLifting(rctx, strType);
+
+            // Change encoding on same rctx
+            rctx.stringEncoding = StringEncoding.Utf16;
+
+            // Same object identity → cache hit → returns UTF-8 lifter (not UTF-16)
+            const lifter2 = createLifting(rctx, strType);
+            expect(lifter1).toBe(lifter2);
+        });
+
+        test('stringEncoding baked per canonical function via separate ComponentTypeFunc identity', () => {
+            const rctx = createMinimalResolved();
+
+            // func1 created with UTF-8
+            rctx.stringEncoding = StringEncoding.Utf8;
+            const func1: ComponentTypeFunc = {
+                tag: ModelTag.ComponentTypeFunc,
+                params: [{ name: 'msg', type: prim(PrimitiveValType.String) }],
+                results: { tag: ModelTag.ComponentFuncResultUnnamed, type: prim(PrimitiveValType.U32) },
+            } as any;
+            const lifting1 = createFunctionLifting(rctx, func1);
+
+            // func2 created with UTF-16 — different object
+            rctx.stringEncoding = StringEncoding.Utf16;
+            const func2: ComponentTypeFunc = {
+                tag: ModelTag.ComponentTypeFunc,
+                params: [{ name: 'msg', type: prim(PrimitiveValType.String) }],
+                results: { tag: ModelTag.ComponentFuncResultUnnamed, type: prim(PrimitiveValType.U32) },
+            } as any;
+            const lifting2 = createFunctionLifting(rctx, func2);
+
+            // Different keys → different cached results → correct per-function encoding
+            expect(lifting1).not.toBe(lifting2);
+        });
+    });
+
+    describe('usesNumberForInt64 baked at creation time', () => {
+        test('S64 lifters differ between BigInt and Number modes', () => {
+            const bigintRctx = createMinimalResolved({ usesNumberForInt64: false });
+            const numberRctx = createMinimalResolved({ usesNumberForInt64: true });
+            const s64Type = prim(PrimitiveValType.S64);
+
+            const bigintLifter = createLifting(bigintRctx, s64Type);
+            const numberLifter = createLifting(numberRctx, s64Type);
+
+            // Different rctx = different caches, never collide
+            expect(bigintLifter).not.toBe(numberLifter);
+
+            const ctx = createMinimalBctx();
+            // BigInt lifter should return BigInt args
+            const bigintResult = bigintLifter(ctx, 42n);
+            expect(typeof bigintResult[0]).toBe('bigint');
+
+            // Number lifter converts BigInt input to Number output
+            const numberResult = numberLifter(ctx, 42n);
+            expect(typeof numberResult[0]).toBe('number');
+        });
+    });
+
+    describe('cache per rctx instance', () => {
+        test('different rctx instances do not share cached results', () => {
+            const rctx1 = createMinimalResolved();
+            const rctx2 = createMinimalResolved();
+            // Share the exact same type model object
+            const typeModel = prim(PrimitiveValType.U32);
+
+            const lifter1 = createLifting(rctx1, typeModel);
+            const lifter2 = createLifting(rctx2, typeModel);
+
+            // Different caches → different results (even though functionally equivalent)
+            expect(lifter1).not.toBe(lifter2);
+        });
+    });
+});
+
+function createMinimalBctx(): BindingContext {
+    return {} as any as BindingContext;
+}

--- a/src/resolver/binding/primitives.test.ts
+++ b/src/resolver/binding/primitives.test.ts
@@ -10,7 +10,7 @@ import { createLowering } from './to-js';
 function createMinimalRctx(usesNumberForInt64 = false): ResolverContext {
     return {
         resolved: {
-            memoizeCache: new Map(),
+            liftingCache: new Map(), loweringCache: new Map(),
             resolvedTypes: new Map(),
             usesNumberForInt64,
         },

--- a/src/resolver/binding/primitives.test.ts
+++ b/src/resolver/binding/primitives.test.ts
@@ -9,9 +9,11 @@ import { createLowering } from './to-js';
 
 function createMinimalRctx(usesNumberForInt64 = false): ResolverContext {
     return {
-        memoizeCache: new Map(),
-        resolvedTypes: new Map(),
-        usesNumberForInt64,
+        resolved: {
+            memoizeCache: new Map(),
+            resolvedTypes: new Map(),
+            usesNumberForInt64,
+        },
     } as any as ResolverContext;
 }
 
@@ -34,119 +36,119 @@ describe('primitive lifting (JS → WASM)', () => {
 
     describe('bool', () => {
         test('true lifts to [1]', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.Bool));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.Bool));
             expect(lifter(bctx, true)).toEqual([1]);
         });
         test('false lifts to [0]', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.Bool));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.Bool));
             expect(lifter(bctx, false)).toEqual([0]);
         });
         test('0 lifts to [0]', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.Bool));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.Bool));
             expect(lifter(bctx, 0)).toEqual([0]);
         });
         test('1 lifts to [1]', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.Bool));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.Bool));
             expect(lifter(bctx, 1)).toEqual([1]);
         });
     });
 
     describe('s8', () => {
         test('127 lifts to [127]', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.S8));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.S8));
             expect(lifter(bctx, 127)).toEqual([127]);
         });
         test('-128 lifts to [-128]', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.S8));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.S8));
             expect(lifter(bctx, -128)).toEqual([-128]);
         });
         test('255 wraps to [-1]', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.S8));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.S8));
             expect(lifter(bctx, 255)).toEqual([-1]);
         });
     });
 
     describe('u8', () => {
         test('255 lifts to [255]', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.U8));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.U8));
             expect(lifter(bctx, 255)).toEqual([255]);
         });
         test('0 lifts to [0]', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.U8));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.U8));
             expect(lifter(bctx, 0)).toEqual([0]);
         });
         test('256 truncates to [0]', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.U8));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.U8));
             expect(lifter(bctx, 256)).toEqual([0]);
         });
     });
 
     describe('s16', () => {
         test('32767 lifts to [32767]', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.S16));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.S16));
             expect(lifter(bctx, 32767)).toEqual([32767]);
         });
         test('-32768 lifts to [-32768]', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.S16));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.S16));
             expect(lifter(bctx, -32768)).toEqual([-32768]);
         });
     });
 
     describe('u16', () => {
         test('65535 lifts to [65535]', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.U16));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.U16));
             expect(lifter(bctx, 65535)).toEqual([65535]);
         });
         test('0 lifts to [0]', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.U16));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.U16));
             expect(lifter(bctx, 0)).toEqual([0]);
         });
     });
 
     describe('s32', () => {
         test('2147483647 lifts to [2147483647]', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.S32));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.S32));
             expect(lifter(bctx, 2147483647)).toEqual([2147483647]);
         });
         test('-1 lifts to [-1]', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.S32));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.S32));
             expect(lifter(bctx, -1)).toEqual([-1]);
         });
     });
 
     describe('u32', () => {
         test('0 lifts to [0]', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.U32));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.U32));
             expect(lifter(bctx, 0)).toEqual([0]);
         });
         test('4294967295 lifts to [4294967295]', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.U32));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.U32));
             expect(lifter(bctx, 4294967295)).toEqual([4294967295]);
         });
         test('-1 lifts to [4294967295]', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.U32));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.U32));
             expect(lifter(bctx, -1)).toEqual([4294967295]);
         });
     });
 
     describe('s64 (BigInt mode)', () => {
         test('0n lifts to [0n]', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.S64));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.S64));
             expect(lifter(bctx, 0n)).toEqual([0n]);
         });
         test('-1n lifts to [-1n]', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.S64));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.S64));
             expect(lifter(bctx, -1n)).toEqual([-1n]);
         });
     });
 
     describe('u64 (BigInt mode)', () => {
         test('0n lifts to [0n]', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.U64));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.U64));
             expect(lifter(bctx, 0n)).toEqual([0n]);
         });
         test('max u64 lifts correctly', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.U64));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.U64));
             const maxU64 = BigInt(2) ** BigInt(64) - 1n;
             expect(lifter(bctx, maxU64)).toEqual([18446744073709551615n]);
         });
@@ -154,37 +156,37 @@ describe('primitive lifting (JS → WASM)', () => {
 
     describe('f32', () => {
         test('3.14 lifts to [Math.fround(3.14)]', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.Float32));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.Float32));
             expect(lifter(bctx, 3.14)).toEqual([Math.fround(3.14)]);
         });
         test('0 lifts to [0]', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.Float32));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.Float32));
             expect(lifter(bctx, 0)).toEqual([0]);
         });
     });
 
     describe('f64', () => {
         test('pi lifts to [pi]', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.Float64));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.Float64));
             expect(lifter(bctx, 3.141592653589793)).toEqual([3.141592653589793]);
         });
         test('0 lifts to [0]', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.Float64));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.Float64));
             expect(lifter(bctx, 0)).toEqual([0]);
         });
     });
 
     describe('char', () => {
         test('\'A\' lifts to [65]', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.Char));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.Char));
             expect(lifter(bctx, 'A')).toEqual([65]);
         });
         test('\'€\' lifts to [8364]', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.Char));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.Char));
             expect(lifter(bctx, '€')).toEqual([8364]);
         });
         test('\'🎉\' lifts to [127881]', () => {
-            const lifter = createLifting(rctx, prim(PrimitiveValType.Char));
+            const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.Char));
             expect(lifter(bctx, '🎉')).toEqual([127881]);
         });
     });
@@ -201,116 +203,116 @@ describe('primitive lowering (WASM → JS)', () => {
 
     describe('bool', () => {
         test('1 lowers to true', () => {
-            const lowerer = createLowering(rctx, prim(PrimitiveValType.Bool));
+            const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.Bool));
             expect(lowerer(bctx, 1)).toBe(true);
         });
         test('0 lowers to false', () => {
-            const lowerer = createLowering(rctx, prim(PrimitiveValType.Bool));
+            const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.Bool));
             expect(lowerer(bctx, 0)).toBe(false);
         });
         test('42 lowers to true', () => {
-            const lowerer = createLowering(rctx, prim(PrimitiveValType.Bool));
+            const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.Bool));
             expect(lowerer(bctx, 42)).toBe(true);
         });
     });
 
     describe('s8', () => {
         test('127 lowers to 127', () => {
-            const lowerer = createLowering(rctx, prim(PrimitiveValType.S8));
+            const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.S8));
             expect(lowerer(bctx, 127)).toBe(127);
         });
         test('0xFF lowers to -1', () => {
-            const lowerer = createLowering(rctx, prim(PrimitiveValType.S8));
+            const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.S8));
             expect(lowerer(bctx, 0xFF)).toBe(-1);
         });
     });
 
     describe('u8', () => {
         test('255 lowers to 255', () => {
-            const lowerer = createLowering(rctx, prim(PrimitiveValType.U8));
+            const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.U8));
             expect(lowerer(bctx, 255)).toBe(255);
         });
         test('0x1FF masks to 255', () => {
-            const lowerer = createLowering(rctx, prim(PrimitiveValType.U8));
+            const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.U8));
             expect(lowerer(bctx, 0x1FF)).toBe(255);
         });
     });
 
     describe('s16', () => {
         test('0xFFFF lowers to -1', () => {
-            const lowerer = createLowering(rctx, prim(PrimitiveValType.S16));
+            const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.S16));
             expect(lowerer(bctx, 0xFFFF)).toBe(-1);
         });
         test('32767 lowers to 32767', () => {
-            const lowerer = createLowering(rctx, prim(PrimitiveValType.S16));
+            const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.S16));
             expect(lowerer(bctx, 32767)).toBe(32767);
         });
     });
 
     describe('u16', () => {
         test('0x1FFFF masks to 65535', () => {
-            const lowerer = createLowering(rctx, prim(PrimitiveValType.U16));
+            const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.U16));
             expect(lowerer(bctx, 0x1FFFF)).toBe(65535);
         });
     });
 
     describe('s32', () => {
         test('0xFFFFFFFF lowers to -1', () => {
-            const lowerer = createLowering(rctx, prim(PrimitiveValType.S32));
+            const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.S32));
             expect(lowerer(bctx, 0xFFFFFFFF)).toBe(-1);
         });
     });
 
     describe('u32', () => {
         test('-1 lowers to 4294967295', () => {
-            const lowerer = createLowering(rctx, prim(PrimitiveValType.U32));
+            const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.U32));
             expect(lowerer(bctx, -1)).toBe(4294967295);
         });
     });
 
     describe('s64 (BigInt mode)', () => {
         test('0n lowers to 0n', () => {
-            const lowerer = createLowering(rctx, prim(PrimitiveValType.S64));
+            const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.S64));
             expect(lowerer(bctx, 0n)).toBe(0n);
         });
         test('-1n lowers to -1n', () => {
-            const lowerer = createLowering(rctx, prim(PrimitiveValType.S64));
+            const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.S64));
             expect(lowerer(bctx, -1n)).toBe(-1n);
         });
     });
 
     describe('u64 (BigInt mode)', () => {
         test('0n lowers to 0n', () => {
-            const lowerer = createLowering(rctx, prim(PrimitiveValType.U64));
+            const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.U64));
             expect(lowerer(bctx, 0n)).toBe(0n);
         });
     });
 
     describe('f32', () => {
         test('3.14 lowers to Math.fround(3.14)', () => {
-            const lowerer = createLowering(rctx, prim(PrimitiveValType.Float32));
+            const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.Float32));
             expect(lowerer(bctx, 3.14)).toBe(Math.fround(3.14));
         });
     });
 
     describe('f64', () => {
         test('Math.PI lowers to Math.PI', () => {
-            const lowerer = createLowering(rctx, prim(PrimitiveValType.Float64));
+            const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.Float64));
             expect(lowerer(bctx, Math.PI)).toBe(Math.PI);
         });
     });
 
     describe('char', () => {
         test('65 lowers to \'A\'', () => {
-            const lowerer = createLowering(rctx, prim(PrimitiveValType.Char));
+            const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.Char));
             expect(lowerer(bctx, 65)).toBe('A');
         });
         test('8364 lowers to \'€\'', () => {
-            const lowerer = createLowering(rctx, prim(PrimitiveValType.Char));
+            const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.Char));
             expect(lowerer(bctx, 8364)).toBe('€');
         });
         test('127881 lowers to \'🎉\'', () => {
-            const lowerer = createLowering(rctx, prim(PrimitiveValType.Char));
+            const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.Char));
             expect(lowerer(bctx, 127881)).toBe('🎉');
         });
     });
@@ -339,13 +341,13 @@ describe('lowerer spill counts', () => {
             PrimitiveValType.Char,
         ];
         for (const t of scalarTypes) {
-            const lowerer = createLowering(rctx, prim(t));
+            const lowerer = createLowering(rctx.resolved, prim(t));
             expect((lowerer as any).spill).toBe(1);
         }
     });
 
     test('string has spill=2', () => {
-        const lowerer = createLowering(rctx, prim(PrimitiveValType.String));
+        const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.String));
         expect((lowerer as any).spill).toBe(2);
     });
 });

--- a/src/resolver/binding/resources.test.ts
+++ b/src/resolver/binding/resources.test.ts
@@ -10,9 +10,11 @@ import { createLowering } from './to-js';
 
 function createMinimalRctx(): ResolverContext {
     return {
-        memoizeCache: new Map(),
-        resolvedTypes: new Map(),
-        usesNumberForInt64: false,
+        resolved: {
+            memoizeCache: new Map(),
+            resolvedTypes: new Map(),
+            usesNumberForInt64: false,
+        },
     } as any as ResolverContext;
 }
 
@@ -175,7 +177,7 @@ describe('own<T> lifting', () => {
 
     test('JS object lifts to [handle] where handle > 0', () => {
         const ownModel = { tag: ModelTag.ComponentTypeDefinedOwn, value: 0 };
-        const lifter = createLifting(rctx, ownModel as any);
+        const lifter = createLifting(rctx.resolved, ownModel as any);
         const obj = { name: 'stream' };
         const result = lifter(bctx, obj);
         expect(result).toHaveLength(1);
@@ -184,7 +186,7 @@ describe('own<T> lifting', () => {
 
     test('lifted object is stored in resource table', () => {
         const ownModel = { tag: ModelTag.ComponentTypeDefinedOwn, value: 0 };
-        const lifter = createLifting(rctx, ownModel as any);
+        const lifter = createLifting(rctx.resolved, ownModel as any);
         const obj = { name: 'stream' };
         const [handle] = lifter(bctx, obj);
         expect(bctx.resources.get(0, handle as number)).toBe(obj);
@@ -192,7 +194,7 @@ describe('own<T> lifting', () => {
 
     test('multiple lifts produce unique handles', () => {
         const ownModel = { tag: ModelTag.ComponentTypeDefinedOwn, value: 0 };
-        const lifter = createLifting(rctx, ownModel as any);
+        const lifter = createLifting(rctx.resolved, ownModel as any);
         const [h1] = lifter(bctx, { a: 1 });
         const [h2] = lifter(bctx, { a: 2 });
         expect(h1).not.toBe(h2);
@@ -210,7 +212,7 @@ describe('own<T> lowering', () => {
 
     test('handle lowers to original JS object', () => {
         const ownModel = { tag: ModelTag.ComponentTypeDefinedOwn, value: 0 };
-        const lowerer = createLowering(rctx, ownModel as any);
+        const lowerer = createLowering(rctx.resolved, ownModel as any);
         const obj = { name: 'stream' };
         const handle = bctx.resources.add(0, obj);
         const result = lowerer(bctx, handle);
@@ -219,7 +221,7 @@ describe('own<T> lowering', () => {
 
     test('handle is removed after lowering (ownership transferred)', () => {
         const ownModel = { tag: ModelTag.ComponentTypeDefinedOwn, value: 0 };
-        const lowerer = createLowering(rctx, ownModel as any);
+        const lowerer = createLowering(rctx.resolved, ownModel as any);
         const obj = { name: 'stream' };
         const handle = bctx.resources.add(0, obj);
         lowerer(bctx, handle);
@@ -228,7 +230,7 @@ describe('own<T> lowering', () => {
 
     test('lowering same handle twice throws', () => {
         const ownModel = { tag: ModelTag.ComponentTypeDefinedOwn, value: 0 };
-        const lowerer = createLowering(rctx, ownModel as any);
+        const lowerer = createLowering(rctx.resolved, ownModel as any);
         const handle = bctx.resources.add(0, { name: 'stream' });
         lowerer(bctx, handle);
         expect(() => lowerer(bctx, handle)).toThrow('Invalid resource handle');
@@ -236,7 +238,7 @@ describe('own<T> lowering', () => {
 
     test('spill is 1', () => {
         const ownModel = { tag: ModelTag.ComponentTypeDefinedOwn, value: 0 };
-        const lowerer = createLowering(rctx, ownModel as any);
+        const lowerer = createLowering(rctx.resolved, ownModel as any);
         expect((lowerer as any).spill).toBe(1);
     });
 });
@@ -252,7 +254,7 @@ describe('borrow<T> lifting', () => {
 
     test('JS object lifts to [handle]', () => {
         const borrowModel = { tag: ModelTag.ComponentTypeDefinedBorrow, value: 0 };
-        const lifter = createLifting(rctx, borrowModel as any);
+        const lifter = createLifting(rctx.resolved, borrowModel as any);
         const obj = { name: 'ref' };
         const result = lifter(bctx, obj);
         expect(result).toHaveLength(1);
@@ -261,7 +263,7 @@ describe('borrow<T> lifting', () => {
 
     test('lifted object is stored in resource table', () => {
         const borrowModel = { tag: ModelTag.ComponentTypeDefinedBorrow, value: 0 };
-        const lifter = createLifting(rctx, borrowModel as any);
+        const lifter = createLifting(rctx.resolved, borrowModel as any);
         const obj = { name: 'ref' };
         const [handle] = lifter(bctx, obj);
         expect(bctx.resources.get(0, handle as number)).toBe(obj);
@@ -279,7 +281,7 @@ describe('borrow<T> lowering', () => {
 
     test('handle lowers to JS object', () => {
         const borrowModel = { tag: ModelTag.ComponentTypeDefinedBorrow, value: 0 };
-        const lowerer = createLowering(rctx, borrowModel as any);
+        const lowerer = createLowering(rctx.resolved, borrowModel as any);
         const obj = { name: 'ref' };
         const handle = bctx.resources.add(0, obj);
         const result = lowerer(bctx, handle);
@@ -288,7 +290,7 @@ describe('borrow<T> lowering', () => {
 
     test('handle is NOT removed (borrow is temporary)', () => {
         const borrowModel = { tag: ModelTag.ComponentTypeDefinedBorrow, value: 0 };
-        const lowerer = createLowering(rctx, borrowModel as any);
+        const lowerer = createLowering(rctx.resolved, borrowModel as any);
         const obj = { name: 'ref' };
         const handle = bctx.resources.add(0, obj);
         lowerer(bctx, handle);
@@ -297,7 +299,7 @@ describe('borrow<T> lowering', () => {
 
     test('can lower same handle multiple times', () => {
         const borrowModel = { tag: ModelTag.ComponentTypeDefinedBorrow, value: 0 };
-        const lowerer = createLowering(rctx, borrowModel as any);
+        const lowerer = createLowering(rctx.resolved, borrowModel as any);
         const obj = { name: 'ref' };
         const handle = bctx.resources.add(0, obj);
         expect(lowerer(bctx, handle)).toBe(obj);
@@ -307,7 +309,7 @@ describe('borrow<T> lowering', () => {
 
     test('spill is 1', () => {
         const borrowModel = { tag: ModelTag.ComponentTypeDefinedBorrow, value: 0 };
-        const lowerer = createLowering(rctx, borrowModel as any);
+        const lowerer = createLowering(rctx.resolved, borrowModel as any);
         expect((lowerer as any).spill).toBe(1);
     });
 });
@@ -322,8 +324,8 @@ describe('own vs borrow semantics', () => {
     });
 
     test('lift own, lower own → handle removed', () => {
-        const lifter = createLifting(rctx, { tag: ModelTag.ComponentTypeDefinedOwn, value: 0 } as any);
-        const lowerer = createLowering(rctx, { tag: ModelTag.ComponentTypeDefinedOwn, value: 0 } as any);
+        const lifter = createLifting(rctx.resolved, { tag: ModelTag.ComponentTypeDefinedOwn, value: 0 } as any);
+        const lowerer = createLowering(rctx.resolved, { tag: ModelTag.ComponentTypeDefinedOwn, value: 0 } as any);
         const obj = { name: 'owned' };
         const [handle] = lifter(bctx, obj);
         const result = lowerer(bctx, handle);
@@ -332,8 +334,8 @@ describe('own vs borrow semantics', () => {
     });
 
     test('lift borrow, lower borrow → handle kept', () => {
-        const lifter = createLifting(rctx, { tag: ModelTag.ComponentTypeDefinedBorrow, value: 0 } as any);
-        const lowerer = createLowering(rctx, { tag: ModelTag.ComponentTypeDefinedBorrow, value: 0 } as any);
+        const lifter = createLifting(rctx.resolved, { tag: ModelTag.ComponentTypeDefinedBorrow, value: 0 } as any);
+        const lowerer = createLowering(rctx.resolved, { tag: ModelTag.ComponentTypeDefinedBorrow, value: 0 } as any);
         const obj = { name: 'borrowed' };
         const [handle] = lifter(bctx, obj);
         const result = lowerer(bctx, handle);
@@ -342,8 +344,8 @@ describe('own vs borrow semantics', () => {
     });
 
     test('lift own, lower borrow → object returned, handle still exists', () => {
-        const lifter = createLifting(rctx, { tag: ModelTag.ComponentTypeDefinedOwn, value: 0 } as any);
-        const borrowLowerer = createLowering(rctx, { tag: ModelTag.ComponentTypeDefinedBorrow, value: 0 } as any);
+        const lifter = createLifting(rctx.resolved, { tag: ModelTag.ComponentTypeDefinedOwn, value: 0 } as any);
+        const borrowLowerer = createLowering(rctx.resolved, { tag: ModelTag.ComponentTypeDefinedBorrow, value: 0 } as any);
         const obj = { name: 'owned-but-borrowed' };
         const [handle] = lifter(bctx, obj);
         const result = borrowLowerer(bctx, handle);
@@ -352,8 +354,8 @@ describe('own vs borrow semantics', () => {
     });
 
     test('lift own, lower own, try lower again → throws', () => {
-        const lifter = createLifting(rctx, { tag: ModelTag.ComponentTypeDefinedOwn, value: 0 } as any);
-        const lowerer = createLowering(rctx, { tag: ModelTag.ComponentTypeDefinedOwn, value: 0 } as any);
+        const lifter = createLifting(rctx.resolved, { tag: ModelTag.ComponentTypeDefinedOwn, value: 0 } as any);
+        const lowerer = createLowering(rctx.resolved, { tag: ModelTag.ComponentTypeDefinedOwn, value: 0 } as any);
         const obj = { name: 'consumed' };
         const [handle] = lifter(bctx, obj);
         lowerer(bctx, handle);

--- a/src/resolver/binding/resources.test.ts
+++ b/src/resolver/binding/resources.test.ts
@@ -11,7 +11,7 @@ import { createLowering } from './to-js';
 function createMinimalRctx(): ResolverContext {
     return {
         resolved: {
-            memoizeCache: new Map(),
+            liftingCache: new Map(), loweringCache: new Map(),
             resolvedTypes: new Map(),
             usesNumberForInt64: false,
         },

--- a/src/resolver/binding/spilling.test.ts
+++ b/src/resolver/binding/spilling.test.ts
@@ -12,9 +12,11 @@ import { WasmPointer, WasmSize } from './types';
 
 function createMockRctx(): ResolverContext {
     return {
-        memoizeCache: new Map(),
-        resolvedTypes: new Map(),
-        usesNumberForInt64: false,
+        resolved: {
+            memoizeCache: new Map(),
+            resolvedTypes: new Map(),
+            usesNumberForInt64: false,
+        },
         indexes: {
             coreModules: [],
             coreInstances: [],
@@ -117,7 +119,7 @@ describe('function trampolines', () => {
         test('lifting trampoline: JS args → flat WASM args → JS result', () => {
             const rctx = createMockRctx();
             const { ctx } = createMockBctx();
-            const lifter = createFunctionLifting(rctx, smallFunc);
+            const lifter = createFunctionLifting(rctx.resolved, smallFunc);
 
             // Mock WASM function that adds its two u32 args
             const mockWasm = (a: number, b: number) => a + b;
@@ -131,7 +133,7 @@ describe('function trampolines', () => {
             const rctx = createMockRctx();
             const { ctx } = createMockBctx();
             const singleParam = makeFunc(1, prim(PrimitiveValType.U32));
-            const lifter = createFunctionLifting(rctx, singleParam);
+            const lifter = createFunctionLifting(rctx.resolved, singleParam);
 
             const mockWasm = (x: number) => x * 3;
             const jsFunc = lifter(ctx, mockWasm as any);
@@ -142,7 +144,7 @@ describe('function trampolines', () => {
         test('lowering trampoline: flat WASM args → JS args → WASM result', () => {
             const rctx = createMockRctx();
             const { ctx } = createMockBctx();
-            const lowerer = createFunctionLowering(rctx, smallFunc);
+            const lowerer = createFunctionLowering(rctx.resolved, smallFunc);
 
             // Mock JS function
             const mockJs = (a: number, b: number) => a + b;
@@ -163,7 +165,7 @@ describe('function trampolines', () => {
         test('lifting trampoline: no result returns undefined', () => {
             const rctx = createMockRctx();
             const { ctx } = createMockBctx();
-            const lifter = createFunctionLifting(rctx, voidFunc);
+            const lifter = createFunctionLifting(rctx.resolved, voidFunc);
 
             let called = false;
             const mockWasm = (_x: number) => { called = true; };
@@ -177,7 +179,7 @@ describe('function trampolines', () => {
         test('lowering trampoline: void result returns undefined', () => {
             const rctx = createMockRctx();
             const { ctx } = createMockBctx();
-            const lowerer = createFunctionLowering(rctx, voidFunc);
+            const lowerer = createFunctionLowering(rctx.resolved, voidFunc);
 
             let received: number | undefined;
             const mockJs = (x: number) => { received = x; };
@@ -198,7 +200,7 @@ describe('function trampolines', () => {
         test('lifting trampoline: JS args → memory ptr → WASM reads from memory', () => {
             const rctx = createMockRctx();
             const { ctx, buffer } = createMockBctx();
-            const lifter = createFunctionLifting(rctx, largeFunc);
+            const lifter = createFunctionLifting(rctx.resolved, largeFunc);
 
             // Mock WASM function receives 1 arg (the pointer), reads 18 u32s from memory
             const mockWasm = (ptr: number) => {
@@ -221,7 +223,7 @@ describe('function trampolines', () => {
         test('lifting trampoline: spilled params are 4-byte aligned u32s', () => {
             const rctx = createMockRctx();
             const { ctx, buffer } = createMockBctx();
-            const lifter = createFunctionLifting(rctx, largeFunc);
+            const lifter = createFunctionLifting(rctx.resolved, largeFunc);
 
             // Verify individual values at their memory offsets
             const mockWasm = (ptr: number) => {
@@ -241,7 +243,7 @@ describe('function trampolines', () => {
         test('lowering trampoline: memory ptr → JS receives expanded args', () => {
             const rctx = createMockRctx();
             const { ctx, buffer } = createMockBctx();
-            const lowerer = createFunctionLowering(rctx, largeFunc);
+            const lowerer = createFunctionLowering(rctx.resolved, largeFunc);
 
             let receivedArgs: number[] = [];
             const mockJs = (...args: number[]) => {
@@ -282,7 +284,7 @@ describe('function trampolines', () => {
 
         function makeRecordResultFunc(rctx: ResolverContext): ComponentTypeFunc {
             // Put the record type at index 0 in resolvedTypes
-            rctx.resolvedTypes = new Map([[0, recordType]]) as any;
+            rctx.resolved.resolvedTypes = new Map([[0, recordType]]) as any;
             rctx.indexes.componentTypes = [recordType as any];
 
             return {
@@ -299,7 +301,7 @@ describe('function trampolines', () => {
             const rctx = createMockRctx();
             const { ctx, buffer } = createMockBctx();
             const func = makeRecordResultFunc(rctx);
-            const lifter = createFunctionLifting(rctx, func);
+            const lifter = createFunctionLifting(rctx.resolved, func);
 
             // Mock WASM function: writes record {x, y} to memory, returns pointer
             const mockWasm = (a: number) => {
@@ -319,7 +321,7 @@ describe('function trampolines', () => {
             const rctx = createMockRctx();
             const { ctx, buffer } = createMockBctx();
             const func = makeRecordResultFunc(rctx);
-            const lifter = createFunctionLifting(rctx, func);
+            const lifter = createFunctionLifting(rctx.resolved, func);
 
             const mockWasm = (_a: number) => {
                 const ptr = 256;
@@ -338,7 +340,7 @@ describe('function trampolines', () => {
             const rctx = createMockRctx();
             const { ctx, buffer } = createMockBctx();
             const func = makeRecordResultFunc(rctx);
-            const lowerer = createFunctionLowering(rctx, func);
+            const lowerer = createFunctionLowering(rctx.resolved, func);
 
             // Mock JS function returns a record
             const mockJs = (a: number) => ({ x: a + 1, y: a + 2 });
@@ -361,7 +363,7 @@ describe('function trampolines', () => {
             const rctx = createMockRctx();
             const { ctx, buffer } = createMockBctx();
             const func = makeRecordResultFunc(rctx);
-            const lowerer = createFunctionLowering(rctx, func);
+            const lowerer = createFunctionLowering(rctx.resolved, func);
 
             const mockJs = (_a: number) => ({ x: 0xDEADBEEF, y: 0xCAFEBABE });
             const wasmFunc = lowerer(ctx, mockJs as any);
@@ -387,7 +389,7 @@ describe('function trampolines', () => {
         } as any;
 
         function makeBothSpilledFunc(rctx: ResolverContext): ComponentTypeFunc {
-            rctx.resolvedTypes = new Map([[0, recordType]]) as any;
+            rctx.resolved.resolvedTypes = new Map([[0, recordType]]) as any;
             rctx.indexes.componentTypes = [recordType as any];
 
             // 18 u32 params (spilled) + record result (spilled)
@@ -408,7 +410,7 @@ describe('function trampolines', () => {
             const rctx = createMockRctx();
             const { ctx, buffer } = createMockBctx();
             const func = makeBothSpilledFunc(rctx);
-            const lifter = createFunctionLifting(rctx, func);
+            const lifter = createFunctionLifting(rctx.resolved, func);
 
             // Mock WASM: reads 18 u32s from params ptr, writes result record
             const mockWasm = (paramsPtr: number) => {
@@ -438,7 +440,7 @@ describe('function trampolines', () => {
             const rctx = createMockRctx();
             const { ctx } = createMockBctx();
             const func16 = makeFunc(16, prim(PrimitiveValType.U32));
-            const lifter = createFunctionLifting(rctx, func16);
+            const lifter = createFunctionLifting(rctx.resolved, func16);
 
             // Mock WASM receives 16 flat args (not a pointer)
             let argCount = 0;
@@ -458,7 +460,7 @@ describe('function trampolines', () => {
             const rctx = createMockRctx();
             const { ctx, buffer } = createMockBctx();
             const func17 = makeFunc(17, prim(PrimitiveValType.U32));
-            const lifter = createFunctionLifting(rctx, func17);
+            const lifter = createFunctionLifting(rctx.resolved, func17);
 
             let argCount = 0;
             const mockWasm = (...args: number[]) => {

--- a/src/resolver/binding/spilling.test.ts
+++ b/src/resolver/binding/spilling.test.ts
@@ -13,7 +13,7 @@ import { WasmPointer, WasmSize } from './types';
 function createMockRctx(): ResolverContext {
     return {
         resolved: {
-            memoizeCache: new Map(),
+            liftingCache: new Map(), loweringCache: new Map(),
             resolvedTypes: new Map(),
             usesNumberForInt64: false,
         },

--- a/src/resolver/binding/to-abi.ts
+++ b/src/resolver/binding/to-abi.ts
@@ -5,7 +5,7 @@ import { BindingContext, ResolverContext, StringEncoding } from '../types';
 import { jsco_assert } from '../../utils/assert';
 import type { ResolvedType } from '../type-resolution';
 import { getCanonicalResourceId } from '../context';
-import { CallingConvention, determineFunctionCallingConvention, sizeOf, alignOf, flatCount, alignOfValType, flatCountForValType, resolveValType, deepResolveType, discriminantSize } from '../calling-convention';
+import { CallingConvention, determineFunctionCallingConvention, sizeOf, alignOf, flatCount, alignOfValType, resolveValType, resolveValTypePure, deepResolveType, discriminantSize } from '../calling-convention';
 import { memoize } from './cache';
 import { createLowering, loadFromMemory } from './to-js';
 import { LiftingFromJs, WasmPointer, FnLiftingCallFromJs, JsFunction, WasmSize, WasmValue, WasmFunction, JsValue } from './types';
@@ -24,7 +24,7 @@ const canonicalNaN64: number = _f64[0];
 
 export function createFunctionLifting(rctx: ResolverContext, importModel: ComponentTypeFunc): FnLiftingCallFromJs {
     return memoize(rctx.memoizeCache, importModel, () => {
-        const callingConvention = determineFunctionCallingConvention(rctx, importModel);
+        const callingConvention = determineFunctionCallingConvention(deepResolveType(rctx, importModel) as ComponentTypeFunc);
         const paramLifters: Function[] = [];
         for (const param of importModel.params) {
             const lifter = createLifting(rctx, param.type);
@@ -51,6 +51,10 @@ export function createFunctionLifting(rctx: ResolverContext, importModel: Compon
         // storeToMemory/loadFromMemory can work without rctx.resolvedTypes lookups
         const paramResolvedTypes = importModel.params.map(p => deepResolveType(rctx, resolveValType(rctx, p.type)));
 
+        // Pre-capture rctx properties needed at call time — after this, rctx is not captured
+        const stringEncoding = rctx.stringEncoding;
+        const canonicalResourceIds = rctx.canonicalResourceIds;
+
         return (ctx: BindingContext, wasmFunction: WasmFunction): JsFunction => {
             function liftingTrampoline(...args: any[]): any {
                 // C4: Runtime behavioral guarantees
@@ -64,9 +68,9 @@ export function createFunctionLifting(rctx: ResolverContext, importModel: Compon
                         let totalSize = 0;
                         let maxAlign = 1;
                         for (const pt of paramResolvedTypes) {
-                            const a = alignOf(rctx, pt);
+                            const a = alignOf(pt);
                             totalSize = alignUp(totalSize, a);
-                            totalSize += sizeOf(rctx, pt);
+                            totalSize += sizeOf(pt);
                             maxAlign = Math.max(maxAlign, a);
                         }
                         const ptr = ctx.allocator.realloc(0 as WasmPointer, 0 as WasmSize,
@@ -75,10 +79,10 @@ export function createFunctionLifting(rctx: ResolverContext, importModel: Compon
                         let offset = 0;
                         for (let i = 0; i < args.length; i++) {
                             const pt = paramResolvedTypes[i];
-                            const a = alignOf(rctx, pt);
+                            const a = alignOf(pt);
                             offset = alignUp(offset, a);
-                            storeToMemory(ctx, rctx, ptr + offset, pt, args[i]);
-                            offset += sizeOf(rctx, pt);
+                            storeToMemory(ctx, ptr + offset, pt, args[i], stringEncoding, canonicalResourceIds);
+                            offset += sizeOf(pt);
                         }
                         wasmArgs = [ptr];
                     } else {
@@ -94,7 +98,7 @@ export function createFunctionLifting(rctx: ResolverContext, importModel: Compon
                     if (callingConvention.results === CallingConvention.Spilled) {
                         // canon_lift: WASM returns a pointer to results in memory
                         const resPtr = wasmFunction(...wasmArgs) as number;
-                        result = loadFromMemory(ctx, rctx, resPtr, resultType!);
+                        result = loadFromMemory(ctx, resPtr, resultType!, stringEncoding, canonicalResourceIds);
                     } else {
                         const resWasm = wasmFunction(...wasmArgs);
                         if (resultLowerers.length === 1) {
@@ -460,27 +464,27 @@ function storePrimitive(ctx: BindingContext, ptr: number, prim: PrimitiveValType
     }
 }
 
-export function storeToMemory(ctx: BindingContext, rctx: ResolverContext, ptr: number, type: ResolvedType, jsValue: JsValue): void {
+export function storeToMemory(ctx: BindingContext, ptr: number, type: ResolvedType, jsValue: JsValue, stringEncoding: StringEncoding, canonicalResourceIds: Map<number, number>): void {
     switch (type.tag) {
         case ModelTag.ComponentValTypePrimitive:
         case ModelTag.ComponentTypeDefinedPrimitive:
-            storePrimitive(ctx, ptr, type.value, jsValue, rctx.stringEncoding);
+            storePrimitive(ctx, ptr, type.value, jsValue, stringEncoding);
             break;
         case ModelTag.ComponentTypeDefinedRecord: {
             let offset = 0;
             for (const member of type.members) {
-                const fieldType = resolveValType(rctx, member.type);
-                const fieldAlign = alignOf(rctx, fieldType);
+                const fieldType = resolveValTypePure(member.type);
+                const fieldAlign = alignOf(fieldType);
                 offset = alignUp(offset, fieldAlign);
-                storeToMemory(ctx, rctx, ptr + offset, fieldType, jsValue[member.name]);
-                offset += sizeOf(rctx, fieldType);
+                storeToMemory(ctx, ptr + offset, fieldType, jsValue[member.name], stringEncoding, canonicalResourceIds);
+                offset += sizeOf(fieldType);
             }
             break;
         }
         case ModelTag.ComponentTypeDefinedList: {
-            const elemType = resolveValType(rctx, type.value);
-            const elemSize = sizeOf(rctx, elemType);
-            const elemAlign = alignOf(rctx, elemType);
+            const elemType = resolveValTypePure(type.value);
+            const elemSize = sizeOf(elemType);
+            const elemAlign = alignOf(elemType);
             const arr = jsValue as any[];
             const len = arr.length;
             let listPtr = 0;
@@ -489,7 +493,7 @@ export function storeToMemory(ctx: BindingContext, rctx: ResolverContext, ptr: n
                 listPtr = ctx.allocator.realloc(0 as WasmPointer, 0 as WasmSize, elemAlign as WasmSize, totalSize as WasmSize);
                 validateAllocResult(ctx, listPtr as WasmPointer, elemAlign, totalSize);
                 for (let i = 0; i < len; i++) {
-                    storeToMemory(ctx, rctx, listPtr + i * elemSize, elemType, arr[i]);
+                    storeToMemory(ctx, listPtr + i * elemSize, elemType, arr[i], stringEncoding, canonicalResourceIds);
                 }
             }
             const dv = ctx.memory.getView(ptr as WasmPointer, 8 as WasmSize);
@@ -498,34 +502,34 @@ export function storeToMemory(ctx: BindingContext, rctx: ResolverContext, ptr: n
             break;
         }
         case ModelTag.ComponentTypeDefinedOption: {
-            const payloadType = resolveValType(rctx, type.value);
-            const payloadAlign = alignOf(rctx, payloadType);
+            const payloadType = resolveValTypePure(type.value);
+            const payloadAlign = alignOf(payloadType);
             const payloadOffset = alignUp(1, payloadAlign);
             const dv = ctx.memory.getView(ptr as WasmPointer, 1 as WasmSize);
             if (jsValue === null || jsValue === undefined) {
                 dv.setUint8(0, 0);
             } else {
                 dv.setUint8(0, 1);
-                storeToMemory(ctx, rctx, ptr + payloadOffset, payloadType, jsValue);
+                storeToMemory(ctx, ptr + payloadOffset, payloadType, jsValue, stringEncoding, canonicalResourceIds);
             }
             break;
         }
         case ModelTag.ComponentTypeDefinedResult: {
             let payloadAlign = 1;
-            if (type.ok !== undefined) payloadAlign = Math.max(payloadAlign, alignOfValType(rctx, type.ok));
-            if (type.err !== undefined) payloadAlign = Math.max(payloadAlign, alignOfValType(rctx, type.err));
+            if (type.ok !== undefined) payloadAlign = Math.max(payloadAlign, alignOfValType(type.ok));
+            if (type.err !== undefined) payloadAlign = Math.max(payloadAlign, alignOfValType(type.err));
             const payloadOffset = alignUp(1, payloadAlign);
             const dv = ctx.memory.getView(ptr as WasmPointer, 1 as WasmSize);
             const { tag, val } = jsValue as { tag: string, val?: any };
             if (tag === 'ok') {
                 dv.setUint8(0, 0);
                 if (type.ok !== undefined && val !== undefined) {
-                    storeToMemory(ctx, rctx, ptr + payloadOffset, resolveValType(rctx, type.ok), val);
+                    storeToMemory(ctx, ptr + payloadOffset, resolveValTypePure(type.ok), val, stringEncoding, canonicalResourceIds);
                 }
             } else {
                 dv.setUint8(0, 1);
                 if (type.err !== undefined && val !== undefined) {
-                    storeToMemory(ctx, rctx, ptr + payloadOffset, resolveValType(rctx, type.err), val);
+                    storeToMemory(ctx, ptr + payloadOffset, resolveValTypePure(type.err), val, stringEncoding, canonicalResourceIds);
                 }
             }
             break;
@@ -536,9 +540,9 @@ export function storeToMemory(ctx: BindingContext, rctx: ResolverContext, ptr: n
             let maxPayloadAlign = 1;
             for (const c of type.variants) {
                 if (c.ty !== undefined) {
-                    const ct = resolveValType(rctx, c.ty);
-                    maxPayloadSize = Math.max(maxPayloadSize, sizeOf(rctx, ct));
-                    maxPayloadAlign = Math.max(maxPayloadAlign, alignOf(rctx, ct));
+                    const ct = resolveValTypePure(c.ty);
+                    maxPayloadSize = Math.max(maxPayloadSize, sizeOf(ct));
+                    maxPayloadAlign = Math.max(maxPayloadAlign, alignOf(ct));
                 }
             }
             const payloadOffset = alignUp(discSize, maxPayloadAlign);
@@ -550,7 +554,7 @@ export function storeToMemory(ctx: BindingContext, rctx: ResolverContext, ptr: n
             else dv.setUint32(0, caseIndex, true);
             const c = type.variants[caseIndex];
             if (c.ty !== undefined && val !== undefined) {
-                storeToMemory(ctx, rctx, ptr + payloadOffset, resolveValType(rctx, c.ty), val);
+                storeToMemory(ctx, ptr + payloadOffset, resolveValTypePure(c.ty), val, stringEncoding, canonicalResourceIds);
             }
             break;
         }
@@ -579,17 +583,17 @@ export function storeToMemory(ctx: BindingContext, rctx: ResolverContext, ptr: n
         case ModelTag.ComponentTypeDefinedTuple: {
             let offset = 0;
             for (let i = 0; i < type.members.length; i++) {
-                const memberType = resolveValType(rctx, type.members[i]);
-                const memberAlign = alignOf(rctx, memberType);
+                const memberType = resolveValTypePure(type.members[i]);
+                const memberAlign = alignOf(memberType);
                 offset = alignUp(offset, memberAlign);
-                storeToMemory(ctx, rctx, ptr + offset, memberType, (jsValue as any[])[i]);
-                offset += sizeOf(rctx, memberType);
+                storeToMemory(ctx, ptr + offset, memberType, (jsValue as any[])[i], stringEncoding, canonicalResourceIds);
+                offset += sizeOf(memberType);
             }
             break;
         }
         case ModelTag.ComponentTypeDefinedOwn:
         case ModelTag.ComponentTypeDefinedBorrow: {
-            const handle = ctx.resources.add(getCanonicalResourceId(rctx, type.value), jsValue);
+            const handle = ctx.resources.add(canonicalResourceIds?.get(type.value) ?? type.value, jsValue);
             const dv = ctx.memory.getView(ptr as WasmPointer, 4 as WasmSize);
             dv.setInt32(0, handle, true);
             break;
@@ -603,8 +607,10 @@ export function storeToMemory(ctx: BindingContext, rctx: ResolverContext, ptr: n
 
 function createListLifting(rctx: ResolverContext, listModel: ComponentTypeDefinedList): LiftingFromJs {
     const elementType = resolveValType(rctx, listModel.value);
-    const elemSize = sizeOf(rctx, elementType);
-    const elemAlign = alignOf(rctx, elementType);
+    const elemSize = sizeOf(elementType);
+    const elemAlign = alignOf(elementType);
+    const stringEncoding = rctx.stringEncoding;
+    const canonicalResourceIds = rctx.canonicalResourceIds;
 
     return (ctx: BindingContext, srcJsValue: JsValue): WasmValue[] => {
         const arr = srcJsValue as any[];
@@ -616,7 +622,7 @@ function createListLifting(rctx: ResolverContext, listModel: ComponentTypeDefine
         validateAllocResult(ctx, ptr, elemAlign, totalSize);
 
         for (let i = 0; i < len; i++) {
-            storeToMemory(ctx, rctx, ptr + i * elemSize, elementType, arr[i]);
+            storeToMemory(ctx, ptr + i * elemSize, elementType, arr[i], stringEncoding, canonicalResourceIds);
         }
 
         return [ptr, len];
@@ -628,7 +634,7 @@ function createListLifting(rctx: ResolverContext, listModel: ComponentTypeDefine
 function createOptionLifting(rctx: ResolverContext, optionModel: ComponentTypeDefinedOption): LiftingFromJs {
     const innerLifter = createLifting(rctx, optionModel.value);
     const innerType = resolveValType(rctx, optionModel.value);
-    const innerFlatN = flatCount(rctx, innerType);
+    const innerFlatN = flatCount(deepResolveType(rctx, innerType));
 
     return (ctx: BindingContext, srcJsValue: JsValue): WasmValue[] => {
         if (srcJsValue === null || srcJsValue === undefined) {
@@ -645,8 +651,8 @@ function createResultLifting(rctx: ResolverContext, resultModel: ComponentTypeDe
     const okLifter = resultModel.ok ? createLifting(rctx, resultModel.ok) : undefined;
     const errLifter = resultModel.err ? createLifting(rctx, resultModel.err) : undefined;
 
-    const okFlatN = resultModel.ok ? flatCountForValType(rctx, resultModel.ok) : 0;
-    const errFlatN = resultModel.err ? flatCountForValType(rctx, resultModel.err) : 0;
+    const okFlatN = resultModel.ok ? flatCount(deepResolveType(rctx, resolveValType(rctx, resultModel.ok))) : 0;
+    const errFlatN = resultModel.err ? flatCount(deepResolveType(rctx, resolveValType(rctx, resultModel.err))) : 0;
     const maxPayloadFlat = Math.max(okFlatN, errFlatN);
 
     return (ctx: BindingContext, srcJsValue: JsValue): WasmValue[] => {
@@ -670,7 +676,7 @@ function createVariantLifting(rctx: ResolverContext, variantModel: ComponentType
         name: c.name,
         index: i,
         lifter: c.ty ? createLifting(rctx, c.ty) : undefined,
-        flatCount: c.ty ? flatCountForValType(rctx, c.ty) : 0,
+        flatCount: c.ty ? flatCount(deepResolveType(rctx, resolveValType(rctx, c.ty))) : 0,
     }));
     const maxPayloadFlat = Math.max(0, ...cases.map(c => c.flatCount));
     const nameToCase = new Map(cases.map(c => [c.name, c]));

--- a/src/resolver/binding/to-abi.ts
+++ b/src/resolver/binding/to-abi.ts
@@ -1,7 +1,7 @@
 import { ComponentTypeIndex } from '../../model/indices';
 import { ModelTag } from '../../model/tags';
 import { ComponentTypeDefinedRecord, ComponentTypeDefinedList, ComponentTypeDefinedOption, ComponentTypeDefinedResult, ComponentTypeDefinedVariant, ComponentTypeDefinedEnum, ComponentTypeDefinedFlags, ComponentTypeDefinedTuple, ComponentTypeFunc, ComponentValType, PrimitiveValType, ComponentTypeDefinedOwn, ComponentTypeDefinedBorrow } from '../../model/types';
-import { BindingContext, ResolverContext, StringEncoding } from '../types';
+import { BindingContext, ResolvedContext, StringEncoding } from '../types';
 import { jsco_assert } from '../../utils/assert';
 import type { ResolvedType } from '../type-resolution';
 import { getCanonicalResourceId } from '../context';
@@ -22,7 +22,7 @@ _i64[0] = 0x7ff8000000000000n;
 const canonicalNaN64: number = _f64[0];
 
 
-export function createFunctionLifting(rctx: ResolverContext, importModel: ComponentTypeFunc): FnLiftingCallFromJs {
+export function createFunctionLifting(rctx: ResolvedContext, importModel: ComponentTypeFunc): FnLiftingCallFromJs {
     return memoize(rctx.memoizeCache, importModel, () => {
         const callingConvention = determineFunctionCallingConvention(deepResolveType(rctx, importModel) as ComponentTypeFunc);
         const paramLifters: Function[] = [];
@@ -127,7 +127,7 @@ export function createFunctionLifting(rctx: ResolverContext, importModel: Compon
 }
 
 
-export function createLifting(rctx: ResolverContext, typeModel: ComponentValType | ResolvedType): LiftingFromJs {
+export function createLifting(rctx: ResolvedContext, typeModel: ComponentValType | ResolvedType): LiftingFromJs {
     return memoize(rctx.memoizeCache, typeModel, () => {
         switch (typeModel.tag) {
             case ModelTag.ComponentValTypePrimitive:
@@ -197,7 +197,7 @@ export function createLifting(rctx: ResolverContext, typeModel: ComponentValType
     });
 }
 
-function createRecordLifting(rctx: ResolverContext, recordModel: ComponentTypeDefinedRecord): LiftingFromJs {
+function createRecordLifting(rctx: ResolvedContext, recordModel: ComponentTypeDefinedRecord): LiftingFromJs {
     const lifters: { name: string, lifter: LiftingFromJs }[] = [];
     for (const member of recordModel.members) {
         const lifter = createLifting(rctx, member.type);
@@ -605,7 +605,7 @@ export function storeToMemory(ctx: BindingContext, ptr: number, type: ResolvedTy
 
 // --- List lifting ---
 
-function createListLifting(rctx: ResolverContext, listModel: ComponentTypeDefinedList): LiftingFromJs {
+function createListLifting(rctx: ResolvedContext, listModel: ComponentTypeDefinedList): LiftingFromJs {
     const elementType = resolveValType(rctx, listModel.value);
     const elemSize = sizeOf(elementType);
     const elemAlign = alignOf(elementType);
@@ -631,7 +631,7 @@ function createListLifting(rctx: ResolverContext, listModel: ComponentTypeDefine
 
 // --- Option lifting ---
 
-function createOptionLifting(rctx: ResolverContext, optionModel: ComponentTypeDefinedOption): LiftingFromJs {
+function createOptionLifting(rctx: ResolvedContext, optionModel: ComponentTypeDefinedOption): LiftingFromJs {
     const innerLifter = createLifting(rctx, optionModel.value);
     const innerType = resolveValType(rctx, optionModel.value);
     const innerFlatN = flatCount(deepResolveType(rctx, innerType));
@@ -647,7 +647,7 @@ function createOptionLifting(rctx: ResolverContext, optionModel: ComponentTypeDe
 
 // --- Result lifting ---
 
-function createResultLifting(rctx: ResolverContext, resultModel: ComponentTypeDefinedResult): LiftingFromJs {
+function createResultLifting(rctx: ResolvedContext, resultModel: ComponentTypeDefinedResult): LiftingFromJs {
     const okLifter = resultModel.ok ? createLifting(rctx, resultModel.ok) : undefined;
     const errLifter = resultModel.err ? createLifting(rctx, resultModel.err) : undefined;
 
@@ -671,7 +671,7 @@ function createResultLifting(rctx: ResolverContext, resultModel: ComponentTypeDe
 
 // --- Variant lifting ---
 
-function createVariantLifting(rctx: ResolverContext, variantModel: ComponentTypeDefinedVariant): LiftingFromJs {
+function createVariantLifting(rctx: ResolvedContext, variantModel: ComponentTypeDefinedVariant): LiftingFromJs {
     const cases = variantModel.variants.map((c, i) => ({
         name: c.name,
         index: i,
@@ -696,7 +696,7 @@ function createVariantLifting(rctx: ResolverContext, variantModel: ComponentType
 
 // --- Enum lifting ---
 
-function createEnumLifting(_rctx: ResolverContext, enumModel: ComponentTypeDefinedEnum): LiftingFromJs {
+function createEnumLifting(_rctx: ResolvedContext, enumModel: ComponentTypeDefinedEnum): LiftingFromJs {
     const nameToIndex = new Map(enumModel.members.map((name, i) => [name, i]));
     return (_ctx: BindingContext, srcJsValue: JsValue): WasmValue[] => {
         const idx = nameToIndex.get(srcJsValue as string);
@@ -707,7 +707,7 @@ function createEnumLifting(_rctx: ResolverContext, enumModel: ComponentTypeDefin
 
 // --- Flags lifting ---
 
-function createFlagsLifting(_rctx: ResolverContext, flagsModel: ComponentTypeDefinedFlags): LiftingFromJs {
+function createFlagsLifting(_rctx: ResolvedContext, flagsModel: ComponentTypeDefinedFlags): LiftingFromJs {
     const wordCount = Math.max(1, Math.ceil(flagsModel.members.length / 32));
 
     return (_ctx: BindingContext, srcJsValue: JsValue): WasmValue[] => {
@@ -724,7 +724,7 @@ function createFlagsLifting(_rctx: ResolverContext, flagsModel: ComponentTypeDef
 
 // --- Tuple lifting ---
 
-function createTupleLifting(rctx: ResolverContext, tupleModel: ComponentTypeDefinedTuple): LiftingFromJs {
+function createTupleLifting(rctx: ResolvedContext, tupleModel: ComponentTypeDefinedTuple): LiftingFromJs {
     const elementLifters = tupleModel.members.map(m => createLifting(rctx, m));
 
     return (ctx: BindingContext, srcJsValue: JsValue): WasmValue[] => {
@@ -739,7 +739,7 @@ function createTupleLifting(rctx: ResolverContext, tupleModel: ComponentTypeDefi
 
 // --- Resource handle lifting ---
 
-function createOwnLifting(rctx: ResolverContext, ownModel: ComponentTypeDefinedOwn): LiftingFromJs {
+function createOwnLifting(rctx: ResolvedContext, ownModel: ComponentTypeDefinedOwn): LiftingFromJs {
     const resourceTypeIdx = getCanonicalResourceId(rctx, ownModel.value);
     return (ctx: BindingContext, srcJsValue: JsValue): WasmValue[] => {
         const handle = ctx.resources.add(resourceTypeIdx, srcJsValue);
@@ -747,7 +747,7 @@ function createOwnLifting(rctx: ResolverContext, ownModel: ComponentTypeDefinedO
     };
 }
 
-function createBorrowLifting(rctx: ResolverContext, borrowModel: ComponentTypeDefinedBorrow): LiftingFromJs {
+function createBorrowLifting(rctx: ResolvedContext, borrowModel: ComponentTypeDefinedBorrow): LiftingFromJs {
     const resourceTypeIdx = getCanonicalResourceId(rctx, borrowModel.value);
     return (ctx: BindingContext, srcJsValue: JsValue): WasmValue[] => {
         const handle = ctx.resources.add(resourceTypeIdx, srcJsValue);

--- a/src/resolver/binding/to-abi.ts
+++ b/src/resolver/binding/to-abi.ts
@@ -1,7 +1,7 @@
 import { ComponentTypeIndex } from '../../model/indices';
 import { ModelTag } from '../../model/tags';
 import { ComponentTypeDefinedRecord, ComponentTypeDefinedList, ComponentTypeDefinedOption, ComponentTypeDefinedResult, ComponentTypeDefinedVariant, ComponentTypeDefinedEnum, ComponentTypeDefinedFlags, ComponentTypeDefinedTuple, ComponentTypeFunc, ComponentValType, PrimitiveValType, ComponentTypeDefinedOwn, ComponentTypeDefinedBorrow } from '../../model/types';
-import { BindingContext, ResolverContext } from '../types';
+import { BindingContext, ResolverContext, StringEncoding } from '../types';
 import { jsco_assert } from '../../utils/assert';
 import type { ResolvedType } from '../type-resolution';
 import { getCanonicalResourceId } from '../context';
@@ -129,7 +129,7 @@ export function createLifting(rctx: ResolverContext, typeModel: ComponentValType
             case ModelTag.ComponentTypeDefinedPrimitive:
                 switch (typeModel.value) {
                     case PrimitiveValType.String:
-                        return createStringLifting();
+                        return createStringLifting(rctx.stringEncoding);
                     case PrimitiveValType.Bool:
                         return createBoolLifting();
                     case PrimitiveValType.S8:
@@ -317,7 +317,17 @@ function createCharLifting(): LiftingFromJs {
     };
 }
 
-function createStringLifting(): LiftingFromJs {
+function createStringLifting(encoding: StringEncoding): LiftingFromJs {
+    if (encoding === StringEncoding.Utf16) {
+        return createStringLiftingUtf16();
+    }
+    if (encoding === StringEncoding.CompactUtf16) {
+        throw new Error('CompactUTF-16 (latin1+utf16) string encoding not yet supported');
+    }
+    return createStringLiftingUtf8();
+}
+
+function createStringLiftingUtf8(): LiftingFromJs {
     return (ctx: BindingContext, srcJsValue: JsValue): any[] => {
         let str = srcJsValue as string;
         if (typeof str !== 'string') throw new TypeError('expected a string');
@@ -346,13 +356,36 @@ function createStringLifting(): LiftingFromJs {
     };
 }
 
+function createStringLiftingUtf16(): LiftingFromJs {
+    return (ctx: BindingContext, srcJsValue: JsValue): any[] => {
+        const str = srcJsValue as string;
+        if (typeof str !== 'string') throw new TypeError('expected a string');
+        if (str.length === 0) {
+            return [0, 0];
+        }
+        // UTF-16: each code unit is 2 bytes, alignment = 2
+        const codeUnits = str.length;
+        const byteLen = codeUnits * 2;
+        const ptr = ctx.allocator.realloc(0 as WasmPointer, 0 as WasmSize, 2 as any, byteLen as any);
+        validateAllocResult(ctx, ptr, 2, byteLen);
+        const view = ctx.memory.getViewU8(ptr, byteLen as WasmSize);
+        for (let i = 0; i < codeUnits; i++) {
+            const cu = str.charCodeAt(i);
+            view[i * 2] = cu & 0xFF;
+            view[i * 2 + 1] = (cu >> 8) & 0xFF;
+        }
+        // Return pointer and code unit count (not byte count)
+        return [ptr, codeUnits];
+    };
+}
+
 // --- Memory store helpers (for list element storage) ---
 
 function alignUp(offset: number, align: number): number {
     return (offset + align - 1) & ~(align - 1);
 }
 
-function storePrimitive(ctx: BindingContext, ptr: number, prim: PrimitiveValType, val: JsValue): void {
+function storePrimitive(ctx: BindingContext, ptr: number, prim: PrimitiveValType, val: JsValue, encoding: StringEncoding): void {
     switch (prim) {
         case PrimitiveValType.Bool: {
             const dv = ctx.memory.getView(ptr as WasmPointer, 1 as WasmSize);
@@ -416,7 +449,7 @@ function storePrimitive(ctx: BindingContext, ptr: number, prim: PrimitiveValType
         }
         case PrimitiveValType.String: {
             // Store string as pointer + length in memory
-            const lifter = createStringLifting();
+            const lifter = createStringLifting(encoding);
             const [strPtr, strLen] = lifter(ctx, val);
             const dv = ctx.memory.getView(ptr as WasmPointer, 8 as WasmSize);
             dv.setInt32(0, strPtr as number, true);
@@ -430,7 +463,7 @@ export function storeToMemory(ctx: BindingContext, rctx: ResolverContext, ptr: n
     switch (type.tag) {
         case ModelTag.ComponentValTypePrimitive:
         case ModelTag.ComponentTypeDefinedPrimitive:
-            storePrimitive(ctx, ptr, type.value, jsValue);
+            storePrimitive(ctx, ptr, type.value, jsValue, rctx.stringEncoding);
             break;
         case ModelTag.ComponentTypeDefinedRecord: {
             let offset = 0;

--- a/src/resolver/binding/to-abi.ts
+++ b/src/resolver/binding/to-abi.ts
@@ -5,7 +5,7 @@ import { BindingContext, ResolverContext, StringEncoding } from '../types';
 import { jsco_assert } from '../../utils/assert';
 import type { ResolvedType } from '../type-resolution';
 import { getCanonicalResourceId } from '../context';
-import { CallingConvention, determineFunctionCallingConvention, sizeOf, alignOf, flatCount, alignOfValType, flatCountForValType, resolveValType, discriminantSize } from '../calling-convention';
+import { CallingConvention, determineFunctionCallingConvention, sizeOf, alignOf, flatCount, alignOfValType, flatCountForValType, resolveValType, deepResolveType, discriminantSize } from '../calling-convention';
 import { memoize } from './cache';
 import { createLowering, loadFromMemory } from './to-js';
 import { LiftingFromJs, WasmPointer, FnLiftingCallFromJs, JsFunction, WasmSize, WasmValue, WasmFunction, JsValue } from './types';
@@ -43,12 +43,13 @@ export function createFunctionLifting(rctx: ResolverContext, importModel: Compon
             case ModelTag.ComponentFuncResultUnnamed: {
                 const lowerer = createLowering(rctx, importModel.results.type);
                 resultLowerers.push(lowerer);
-                resultType = resolveValType(rctx, importModel.results.type);
+                resultType = deepResolveType(rctx, resolveValType(rctx, importModel.results.type));
             }
         }
 
-        // Pre-resolve param types for spilled path
-        const paramResolvedTypes = importModel.params.map(p => resolveValType(rctx, p.type));
+        // Pre-resolve param types for spilled path — deep-resolve ensures
+        // storeToMemory/loadFromMemory can work without rctx.resolvedTypes lookups
+        const paramResolvedTypes = importModel.params.map(p => deepResolveType(rctx, resolveValType(rctx, p.type)));
 
         return (ctx: BindingContext, wasmFunction: WasmFunction): JsFunction => {
             function liftingTrampoline(...args: any[]): any {

--- a/src/resolver/binding/to-abi.ts
+++ b/src/resolver/binding/to-abi.ts
@@ -23,7 +23,7 @@ const canonicalNaN64: number = _f64[0];
 
 
 export function createFunctionLifting(rctx: ResolvedContext, importModel: ComponentTypeFunc): FnLiftingCallFromJs {
-    return memoize(rctx.memoizeCache, importModel, () => {
+    return memoize(rctx.liftingCache, importModel, () => {
         const callingConvention = determineFunctionCallingConvention(deepResolveType(rctx, importModel) as ComponentTypeFunc);
         const paramLifters: Function[] = [];
         for (const param of importModel.params) {
@@ -128,7 +128,7 @@ export function createFunctionLifting(rctx: ResolvedContext, importModel: Compon
 
 
 export function createLifting(rctx: ResolvedContext, typeModel: ComponentValType | ResolvedType): LiftingFromJs {
-    return memoize(rctx.memoizeCache, typeModel, () => {
+    return memoize(rctx.liftingCache, typeModel, () => {
         switch (typeModel.tag) {
             case ModelTag.ComponentValTypePrimitive:
             case ModelTag.ComponentTypeDefinedPrimitive:

--- a/src/resolver/binding/to-js.ts
+++ b/src/resolver/binding/to-js.ts
@@ -5,7 +5,7 @@ import { BindingContext, ResolverContext, StringEncoding } from '../types';
 import { jsco_assert } from '../../utils/assert';
 import type { ResolvedType } from '../type-resolution';
 import { getCanonicalResourceId } from '../context';
-import { CallingConvention, determineFunctionCallingConvention, sizeOf, alignOf, alignOfValType, resolveValType, deepResolveType, discriminantSize } from '../calling-convention';
+import { CallingConvention, determineFunctionCallingConvention, sizeOf, alignOf, alignOfValType, resolveValType, resolveValTypePure, deepResolveType, discriminantSize } from '../calling-convention';
 import { memoize } from './cache';
 import { createLifting, storeToMemory } from './to-abi';
 import { LoweringToJs, FnLoweringCallToJs, WasmFunction, WasmPointer, JsFunction, WasmSize, WasmValue } from './types';
@@ -24,7 +24,7 @@ const canonicalNaN64: number = _f64[0];
 
 export function createFunctionLowering(rctx: ResolverContext, exportModel: ComponentTypeFunc): FnLoweringCallToJs {
     return memoize(rctx.memoizeCache, exportModel, () => {
-        const callingConvention = determineFunctionCallingConvention(rctx, exportModel);
+        const callingConvention = determineFunctionCallingConvention(deepResolveType(rctx, exportModel) as ComponentTypeFunc);
         // Pre-resolve param/result types for spilled path — deep-resolve ensures
         // storeToMemory/loadFromMemory can work without rctx.resolvedTypes lookups
         const paramResolvedTypes = exportModel.params.map(p => deepResolveType(rctx, resolveValType(rctx, p.type)));
@@ -32,6 +32,10 @@ export function createFunctionLowering(rctx: ResolverContext, exportModel: Compo
         if (exportModel.results.tag === ModelTag.ComponentFuncResultUnnamed) {
             resultType = deepResolveType(rctx, resolveValType(rctx, exportModel.results.type));
         }
+
+        // Pre-capture rctx properties needed at call time — after this, rctx is not captured
+        const stringEncoding = rctx.stringEncoding;
+        const canonicalResourceIds = rctx.canonicalResourceIds;
 
         return (ctx: BindingContext, jsFunction: JsFunction): WasmFunction => {
 
@@ -63,10 +67,10 @@ export function createFunctionLowering(rctx: ResolverContext, exportModel: Compo
                     let memOffset = 0;
                     for (let i = 0; i < paramResolvedTypes.length; i++) {
                         const pt = paramResolvedTypes[i];
-                        const a = alignOf(rctx, pt);
+                        const a = alignOf(pt);
                         memOffset = alignUp(memOffset, a);
-                        covertedArgs.push(loadFromMemory(ctx, rctx, ptr + memOffset, pt));
-                        memOffset += sizeOf(rctx, pt);
+                        covertedArgs.push(loadFromMemory(ctx, ptr + memOffset, pt, stringEncoding, canonicalResourceIds));
+                        memOffset += sizeOf(pt);
                     }
                 } else {
                     // Flat/Scalar: read each param using lowerers
@@ -86,7 +90,7 @@ export function createFunctionLowering(rctx: ResolverContext, exportModel: Compo
                     const retptr = args[args.length - 1] as number;
                     const resJs = jsFunction(...covertedArgs);
                     if (resultType !== undefined) {
-                        storeToMemory(ctx, rctx, retptr, resultType, resJs);
+                        storeToMemory(ctx, retptr, resultType, resJs, stringEncoding, canonicalResourceIds);
                     }
                     // No return value - WASM reads from retptr
                 } else {
@@ -453,20 +457,20 @@ function loadPrimitive(ctx: BindingContext, ptr: number, prim: PrimitiveValType,
     }
 }
 
-export function loadFromMemory(ctx: BindingContext, rctx: ResolverContext, ptr: number, type: ResolvedType): any {
+export function loadFromMemory(ctx: BindingContext, ptr: number, type: ResolvedType, stringEncoding: StringEncoding, canonicalResourceIds: Map<number, number>): any {
     switch (type.tag) {
         case ModelTag.ComponentValTypePrimitive:
         case ModelTag.ComponentTypeDefinedPrimitive:
-            return loadPrimitive(ctx, ptr, type.value, rctx.stringEncoding);
+            return loadPrimitive(ctx, ptr, type.value, stringEncoding);
         case ModelTag.ComponentTypeDefinedRecord: {
             const result: Record<string, unknown> = {};
             let offset = 0;
             for (const member of type.members) {
-                const fieldType = resolveValType(rctx, member.type);
-                const fieldAlign = alignOf(rctx, fieldType);
+                const fieldType = resolveValTypePure(member.type);
+                const fieldAlign = alignOf(fieldType);
                 offset = alignUp(offset, fieldAlign);
-                result[member.name] = loadFromMemory(ctx, rctx, ptr + offset, fieldType);
-                offset += sizeOf(rctx, fieldType);
+                result[member.name] = loadFromMemory(ctx, ptr + offset, fieldType, stringEncoding, canonicalResourceIds);
+                offset += sizeOf(fieldType);
             }
             return result;
         }
@@ -474,38 +478,38 @@ export function loadFromMemory(ctx: BindingContext, rctx: ResolverContext, ptr: 
             const dv = ctx.memory.getView(ptr as WasmPointer, 8 as WasmSize);
             const listPtr = dv.getInt32(0, true);
             const len = dv.getInt32(4, true);
-            const elemType = resolveValType(rctx, type.value);
-            const elemSize = sizeOf(rctx, elemType);
+            const elemType = resolveValTypePure(type.value);
+            const elemSize = sizeOf(elemType);
             const result: any[] = [];
             for (let i = 0; i < len; i++) {
-                result.push(loadFromMemory(ctx, rctx, listPtr + i * elemSize, elemType));
+                result.push(loadFromMemory(ctx, listPtr + i * elemSize, elemType, stringEncoding, canonicalResourceIds));
             }
             return result;
         }
         case ModelTag.ComponentTypeDefinedOption: {
-            const payloadType = resolveValType(rctx, type.value);
-            const payloadAlign = alignOf(rctx, payloadType);
+            const payloadType = resolveValTypePure(type.value);
+            const payloadAlign = alignOf(payloadType);
             const payloadOffset = alignUp(1, payloadAlign);
             const dv = ctx.memory.getView(ptr as WasmPointer, 1 as WasmSize);
             const disc = dv.getUint8(0);
             if (disc === 0) return null;
-            return loadFromMemory(ctx, rctx, ptr + payloadOffset, payloadType);
+            return loadFromMemory(ctx, ptr + payloadOffset, payloadType, stringEncoding, canonicalResourceIds);
         }
         case ModelTag.ComponentTypeDefinedResult: {
             let payloadAlign = 1;
-            if (type.ok !== undefined) payloadAlign = Math.max(payloadAlign, alignOfValType(rctx, type.ok));
-            if (type.err !== undefined) payloadAlign = Math.max(payloadAlign, alignOfValType(rctx, type.err));
+            if (type.ok !== undefined) payloadAlign = Math.max(payloadAlign, alignOfValType(type.ok));
+            if (type.err !== undefined) payloadAlign = Math.max(payloadAlign, alignOfValType(type.err));
             const payloadOffset = alignUp(1, payloadAlign);
             const dv = ctx.memory.getView(ptr as WasmPointer, 1 as WasmSize);
             const disc = dv.getUint8(0);
             if (disc === 0) {
                 const val = type.ok !== undefined
-                    ? loadFromMemory(ctx, rctx, ptr + payloadOffset, resolveValType(rctx, type.ok))
+                    ? loadFromMemory(ctx, ptr + payloadOffset, resolveValTypePure(type.ok), stringEncoding, canonicalResourceIds)
                     : undefined;
                 return { tag: 'ok', val };
             } else {
                 const val = type.err !== undefined
-                    ? loadFromMemory(ctx, rctx, ptr + payloadOffset, resolveValType(rctx, type.err))
+                    ? loadFromMemory(ctx, ptr + payloadOffset, resolveValTypePure(type.err), stringEncoding, canonicalResourceIds)
                     : undefined;
                 return { tag: 'err', val };
             }
@@ -514,7 +518,7 @@ export function loadFromMemory(ctx: BindingContext, rctx: ResolverContext, ptr: 
             const discSize = discriminantSize(type.variants.length);
             let maxPayloadAlign = 1;
             for (const c of type.variants) {
-                if (c.ty !== undefined) maxPayloadAlign = Math.max(maxPayloadAlign, alignOfValType(rctx, c.ty));
+                if (c.ty !== undefined) maxPayloadAlign = Math.max(maxPayloadAlign, alignOfValType(c.ty));
             }
             const payloadOffset = alignUp(discSize, maxPayloadAlign);
             const dv = ctx.memory.getView(ptr as WasmPointer, discSize as WasmSize);
@@ -524,7 +528,7 @@ export function loadFromMemory(ctx: BindingContext, rctx: ResolverContext, ptr: 
             else disc = dv.getUint32(0, true);
             const c = type.variants[disc];
             if (c.ty !== undefined) {
-                return { tag: c.name, val: loadFromMemory(ctx, rctx, ptr + payloadOffset, resolveValType(rctx, c.ty)) };
+                return { tag: c.name, val: loadFromMemory(ctx, ptr + payloadOffset, resolveValTypePure(c.ty), stringEncoding, canonicalResourceIds) };
             }
             return { tag: c.name };
         }
@@ -553,23 +557,23 @@ export function loadFromMemory(ctx: BindingContext, rctx: ResolverContext, ptr: 
             const result: any[] = [];
             let offset = 0;
             for (const member of type.members) {
-                const memberType = resolveValType(rctx, member);
-                const memberAlign = alignOf(rctx, memberType);
+                const memberType = resolveValTypePure(member);
+                const memberAlign = alignOf(memberType);
                 offset = alignUp(offset, memberAlign);
-                result.push(loadFromMemory(ctx, rctx, ptr + offset, memberType));
-                offset += sizeOf(rctx, memberType);
+                result.push(loadFromMemory(ctx, ptr + offset, memberType, stringEncoding, canonicalResourceIds));
+                offset += sizeOf(memberType);
             }
             return result;
         }
         case ModelTag.ComponentTypeDefinedOwn: {
             const dv = ctx.memory.getView(ptr as WasmPointer, 4 as WasmSize);
             const handle = dv.getInt32(0, true);
-            return ctx.resources.remove(getCanonicalResourceId(rctx, type.value), handle);
+            return ctx.resources.remove(canonicalResourceIds?.get(type.value) ?? type.value, handle);
         }
         case ModelTag.ComponentTypeDefinedBorrow: {
             const dv = ctx.memory.getView(ptr as WasmPointer, 4 as WasmSize);
             const handle = dv.getInt32(0, true);
-            return ctx.resources.get(getCanonicalResourceId(rctx, type.value), handle);
+            return ctx.resources.get(canonicalResourceIds?.get(type.value) ?? type.value, handle);
         }
         default:
             throw new Error('loadFromMemory not implemented for tag ' + type.tag);
@@ -580,8 +584,10 @@ export function loadFromMemory(ctx: BindingContext, rctx: ResolverContext, ptr: 
 
 function createListLowering(rctx: ResolverContext, listModel: ComponentTypeDefinedList): LoweringToJs {
     const elementType = resolveValType(rctx, listModel.value);
-    const elemSize = sizeOf(rctx, elementType);
-    const elemAlign = alignOf(rctx, elementType);
+    const elemSize = sizeOf(elementType);
+    const elemAlign = alignOf(elementType);
+    const stringEncoding = rctx.stringEncoding;
+    const canonicalResourceIds = rctx.canonicalResourceIds;
 
     const fn = (ctx: BindingContext, ...args: WasmValue[]) => {
         const ptr = args[0] as number;
@@ -597,7 +603,7 @@ function createListLowering(rctx: ResolverContext, listModel: ComponentTypeDefin
         }
         const result: any[] = [];
         for (let i = 0; i < len; i++) {
-            result.push(loadFromMemory(ctx, rctx, ptr + i * elemSize, elementType));
+            result.push(loadFromMemory(ctx, ptr + i * elemSize, elementType, stringEncoding, canonicalResourceIds));
         }
         return result;
     };

--- a/src/resolver/binding/to-js.ts
+++ b/src/resolver/binding/to-js.ts
@@ -5,7 +5,7 @@ import { BindingContext, ResolverContext, StringEncoding } from '../types';
 import { jsco_assert } from '../../utils/assert';
 import type { ResolvedType } from '../type-resolution';
 import { getCanonicalResourceId } from '../context';
-import { CallingConvention, determineFunctionCallingConvention, sizeOf, alignOf, alignOfValType, resolveValType, discriminantSize } from '../calling-convention';
+import { CallingConvention, determineFunctionCallingConvention, sizeOf, alignOf, alignOfValType, resolveValType, deepResolveType, discriminantSize } from '../calling-convention';
 import { memoize } from './cache';
 import { createLifting, storeToMemory } from './to-abi';
 import { LoweringToJs, FnLoweringCallToJs, WasmFunction, WasmPointer, JsFunction, WasmSize, WasmValue } from './types';
@@ -25,11 +25,12 @@ const canonicalNaN64: number = _f64[0];
 export function createFunctionLowering(rctx: ResolverContext, exportModel: ComponentTypeFunc): FnLoweringCallToJs {
     return memoize(rctx.memoizeCache, exportModel, () => {
         const callingConvention = determineFunctionCallingConvention(rctx, exportModel);
-        // Pre-resolve param/result types for spilled path
-        const paramResolvedTypes = exportModel.params.map(p => resolveValType(rctx, p.type));
+        // Pre-resolve param/result types for spilled path — deep-resolve ensures
+        // storeToMemory/loadFromMemory can work without rctx.resolvedTypes lookups
+        const paramResolvedTypes = exportModel.params.map(p => deepResolveType(rctx, resolveValType(rctx, p.type)));
         let resultType: ResolvedType | undefined;
         if (exportModel.results.tag === ModelTag.ComponentFuncResultUnnamed) {
-            resultType = resolveValType(rctx, exportModel.results.type);
+            resultType = deepResolveType(rctx, resolveValType(rctx, exportModel.results.type));
         }
 
         return (ctx: BindingContext, jsFunction: JsFunction): WasmFunction => {

--- a/src/resolver/binding/to-js.ts
+++ b/src/resolver/binding/to-js.ts
@@ -23,7 +23,7 @@ const canonicalNaN64: number = _f64[0];
 
 
 export function createFunctionLowering(rctx: ResolvedContext, exportModel: ComponentTypeFunc): FnLoweringCallToJs {
-    return memoize(rctx.memoizeCache, exportModel, () => {
+    return memoize(rctx.loweringCache, exportModel, () => {
         const callingConvention = determineFunctionCallingConvention(deepResolveType(rctx, exportModel) as ComponentTypeFunc);
         // Pre-resolve param/result types for spilled path — deep-resolve ensures
         // storeToMemory/loadFromMemory can work without rctx.resolvedTypes lookups
@@ -107,7 +107,7 @@ export function createFunctionLowering(rctx: ResolvedContext, exportModel: Compo
 }
 
 export function createLowering(rctx: ResolvedContext, typeModel: ComponentValType | ResolvedType): LoweringToJs {
-    return memoize(rctx.memoizeCache, typeModel, () => {
+    return memoize(rctx.loweringCache, typeModel, () => {
         switch (typeModel.tag) {
             case ModelTag.ComponentValTypePrimitive:
             case ModelTag.ComponentTypeDefinedPrimitive:

--- a/src/resolver/binding/to-js.ts
+++ b/src/resolver/binding/to-js.ts
@@ -1,7 +1,7 @@
 import { ComponentTypeIndex } from '../../model/indices';
 import { ModelTag } from '../../model/tags';
 import { ComponentTypeDefinedRecord, ComponentTypeDefinedList, ComponentTypeDefinedOption, ComponentTypeDefinedResult, ComponentTypeDefinedVariant, ComponentTypeDefinedEnum, ComponentTypeDefinedFlags, ComponentTypeDefinedTuple, ComponentTypeFunc, ComponentValType, PrimitiveValType, ComponentTypeDefinedOwn, ComponentTypeDefinedBorrow } from '../../model/types';
-import { BindingContext, ResolverContext } from '../types';
+import { BindingContext, ResolverContext, StringEncoding } from '../types';
 import { jsco_assert } from '../../utils/assert';
 import type { ResolvedType } from '../type-resolution';
 import { getCanonicalResourceId } from '../context';
@@ -107,7 +107,7 @@ export function createLowering(rctx: ResolverContext, typeModel: ComponentValTyp
             case ModelTag.ComponentTypeDefinedPrimitive:
                 switch (typeModel.value) {
                     case PrimitiveValType.String:
-                        return createStringLowering(rctx);
+                        return createStringLowering(rctx.stringEncoding);
                     case PrimitiveValType.Bool:
                         return createBoolLowering();
                     case PrimitiveValType.S8:
@@ -322,7 +322,17 @@ function createRecordLowering(rctx: ResolverContext, recordModel: ComponentTypeD
     return fn;
 }
 
-function createStringLowering(_rctx: ResolverContext): LoweringToJs {
+function createStringLowering(encoding: StringEncoding): LoweringToJs {
+    if (encoding === StringEncoding.Utf16) {
+        return createStringLoweringUtf16();
+    }
+    if (encoding === StringEncoding.CompactUtf16) {
+        throw new Error('CompactUTF-16 (latin1+utf16) string encoding not yet supported');
+    }
+    return createStringLoweringUtf8();
+}
+
+function createStringLoweringUtf8(): LoweringToJs {
     const fn = (ctx: BindingContext, ...args: WasmValue[]) => {
         const pointer = args[0] as WasmPointer;
         const len = args[1] as WasmSize;
@@ -345,13 +355,38 @@ function createStringLowering(_rctx: ResolverContext): LoweringToJs {
     return fn;
 }
 
+function createStringLoweringUtf16(): LoweringToJs {
+    const fn = (ctx: BindingContext, ...args: WasmValue[]) => {
+        const pointer = args[0] as WasmPointer;
+        const codeUnits = args[1] as WasmSize;
+        if (codeUnits as number > 0) {
+            const byteLen = (codeUnits as number) * 2;
+            // Validate pointer alignment (UTF-16 = 2-byte alignment)
+            if ((pointer as number) & 1) {
+                throw new Error(`UTF-16 string pointer not aligned: ptr=${pointer}`);
+            }
+            // Validate bounds
+            const memorySize = ctx.memory.getMemory().buffer.byteLength;
+            if ((pointer as number) + byteLen > memorySize) {
+                throw new Error(`string pointer out of bounds: ptr=${pointer} byte_len=${byteLen} memory_size=${memorySize}`);
+            }
+        }
+        const byteLen = (codeUnits as number) * 2;
+        const view = ctx.memory.getView(pointer, byteLen as WasmSize);
+        const u16 = new Uint16Array(view.buffer, view.byteOffset, codeUnits as number);
+        return String.fromCharCode(...u16);
+    };
+    fn.spill = 2;
+    return fn;
+}
+
 // --- Memory load helpers (for list element loading) ---
 
 function alignUp(offset: number, align: number): number {
     return (offset + align - 1) & ~(align - 1);
 }
 
-function loadPrimitive(ctx: BindingContext, ptr: number, prim: PrimitiveValType): any {
+function loadPrimitive(ctx: BindingContext, ptr: number, prim: PrimitiveValType, encoding: StringEncoding): any {
     switch (prim) {
         case PrimitiveValType.Bool: {
             const dv = ctx.memory.getView(ptr as WasmPointer, 1 as WasmSize);
@@ -405,6 +440,12 @@ function loadPrimitive(ctx: BindingContext, ptr: number, prim: PrimitiveValType)
             const dv = ctx.memory.getView(ptr as WasmPointer, 8 as WasmSize);
             const strPtr = dv.getInt32(0, true);
             const strLen = dv.getInt32(4, true);
+            if (encoding === StringEncoding.Utf16) {
+                const byteLen = strLen * 2;
+                const strView = ctx.memory.getView(strPtr as WasmPointer, byteLen as WasmSize);
+                const u16 = new Uint16Array(strView.buffer, strView.byteOffset, strLen);
+                return String.fromCharCode(...u16);
+            }
             const strView = ctx.memory.getView(strPtr as WasmPointer, strLen as WasmSize);
             return ctx.utf8Decoder.decode(strView);
         }
@@ -415,7 +456,7 @@ export function loadFromMemory(ctx: BindingContext, rctx: ResolverContext, ptr: 
     switch (type.tag) {
         case ModelTag.ComponentValTypePrimitive:
         case ModelTag.ComponentTypeDefinedPrimitive:
-            return loadPrimitive(ctx, ptr, type.value);
+            return loadPrimitive(ctx, ptr, type.value, rctx.stringEncoding);
         case ModelTag.ComponentTypeDefinedRecord: {
             const result: Record<string, unknown> = {};
             let offset = 0;

--- a/src/resolver/binding/to-js.ts
+++ b/src/resolver/binding/to-js.ts
@@ -1,7 +1,7 @@
 import { ComponentTypeIndex } from '../../model/indices';
 import { ModelTag } from '../../model/tags';
 import { ComponentTypeDefinedRecord, ComponentTypeDefinedList, ComponentTypeDefinedOption, ComponentTypeDefinedResult, ComponentTypeDefinedVariant, ComponentTypeDefinedEnum, ComponentTypeDefinedFlags, ComponentTypeDefinedTuple, ComponentTypeFunc, ComponentValType, PrimitiveValType, ComponentTypeDefinedOwn, ComponentTypeDefinedBorrow } from '../../model/types';
-import { BindingContext, ResolverContext, StringEncoding } from '../types';
+import { BindingContext, ResolvedContext, StringEncoding } from '../types';
 import { jsco_assert } from '../../utils/assert';
 import type { ResolvedType } from '../type-resolution';
 import { getCanonicalResourceId } from '../context';
@@ -22,7 +22,7 @@ _i64[0] = 0x7ff8000000000000n;
 const canonicalNaN64: number = _f64[0];
 
 
-export function createFunctionLowering(rctx: ResolverContext, exportModel: ComponentTypeFunc): FnLoweringCallToJs {
+export function createFunctionLowering(rctx: ResolvedContext, exportModel: ComponentTypeFunc): FnLoweringCallToJs {
     return memoize(rctx.memoizeCache, exportModel, () => {
         const callingConvention = determineFunctionCallingConvention(deepResolveType(rctx, exportModel) as ComponentTypeFunc);
         // Pre-resolve param/result types for spilled path — deep-resolve ensures
@@ -33,31 +33,32 @@ export function createFunctionLowering(rctx: ResolverContext, exportModel: Compo
             resultType = deepResolveType(rctx, resolveValType(rctx, exportModel.results.type));
         }
 
+        // Pre-create lowerers/lifters at resolution time (matches createFunctionLifting pattern)
+        const paramLowerers: Function[] = [];
+        for (const param of exportModel.params) {
+            const lowerer = createLowering(rctx, param.type);
+            paramLowerers.push(lowerer);
+        }
+        const resultLifters: Function[] = [];
+        switch (exportModel.results.tag) {
+            case ModelTag.ComponentFuncResultNamed: {
+                for (const res of exportModel.results.values) {
+                    const lifter = createLifting(rctx, res.type);
+                    resultLifters.push(lifter);
+                }
+                break;
+            }
+            case ModelTag.ComponentFuncResultUnnamed: {
+                const lifter = createLifting(rctx, exportModel.results.type);
+                resultLifters.push(lifter);
+            }
+        }
+
         // Pre-capture rctx properties needed at call time — after this, rctx is not captured
         const stringEncoding = rctx.stringEncoding;
         const canonicalResourceIds = rctx.canonicalResourceIds;
 
         return (ctx: BindingContext, jsFunction: JsFunction): WasmFunction => {
-
-            const paramLowerers: Function[] = [];
-            for (const param of exportModel.params) {
-                const lowerer = createLowering(rctx, param.type);
-                paramLowerers.push(lowerer);
-            }
-            const resultLifters: Function[] = [];
-            switch (exportModel.results.tag) {
-                case ModelTag.ComponentFuncResultNamed: {
-                    for (const res of exportModel.results.values) {
-                        const lifter = createLifting(rctx, res.type);
-                        resultLifters.push(lifter);
-                    }
-                    break;
-                }
-                case ModelTag.ComponentFuncResultUnnamed: {
-                    const lifter = createLifting(rctx, exportModel.results.type);
-                    resultLifters.push(lifter);
-                }
-            }
 
             function loweringTrampoline(...args: any[]): any {
                 let covertedArgs: any[] = [];
@@ -105,7 +106,7 @@ export function createFunctionLowering(rctx: ResolverContext, exportModel: Compo
     });
 }
 
-export function createLowering(rctx: ResolverContext, typeModel: ComponentValType | ResolvedType): LoweringToJs {
+export function createLowering(rctx: ResolvedContext, typeModel: ComponentValType | ResolvedType): LoweringToJs {
     return memoize(rctx.memoizeCache, typeModel, () => {
         switch (typeModel.tag) {
             case ModelTag.ComponentValTypePrimitive:
@@ -302,7 +303,7 @@ function createCharLowering(): LoweringToJs {
     return fn;
 }
 
-function createRecordLowering(rctx: ResolverContext, recordModel: ComponentTypeDefinedRecord): LoweringToJs {
+function createRecordLowering(rctx: ResolvedContext, recordModel: ComponentTypeDefinedRecord): LoweringToJs {
     const fieldLowerers: { name: string, lowerer: LoweringToJs }[] = [];
     for (const member of recordModel.members) {
         const lowerer = createLowering(rctx, member.type);
@@ -582,7 +583,7 @@ export function loadFromMemory(ctx: BindingContext, ptr: number, type: ResolvedT
 
 // --- List lowering ---
 
-function createListLowering(rctx: ResolverContext, listModel: ComponentTypeDefinedList): LoweringToJs {
+function createListLowering(rctx: ResolvedContext, listModel: ComponentTypeDefinedList): LoweringToJs {
     const elementType = resolveValType(rctx, listModel.value);
     const elemSize = sizeOf(elementType);
     const elemAlign = alignOf(elementType);
@@ -613,7 +614,7 @@ function createListLowering(rctx: ResolverContext, listModel: ComponentTypeDefin
 
 // --- Option lowering ---
 
-function createOptionLowering(rctx: ResolverContext, optionModel: ComponentTypeDefinedOption): LoweringToJs {
+function createOptionLowering(rctx: ResolvedContext, optionModel: ComponentTypeDefinedOption): LoweringToJs {
     const innerLowerer = createLowering(rctx, optionModel.value);
     const innerSpill = (innerLowerer as any).spill as number;
 
@@ -630,7 +631,7 @@ function createOptionLowering(rctx: ResolverContext, optionModel: ComponentTypeD
 
 // --- Result lowering ---
 
-function createResultLowering(rctx: ResolverContext, resultModel: ComponentTypeDefinedResult): LoweringToJs {
+function createResultLowering(rctx: ResolvedContext, resultModel: ComponentTypeDefinedResult): LoweringToJs {
     const okLowerer = resultModel.ok ? createLowering(rctx, resultModel.ok) : undefined;
     const errLowerer = resultModel.err ? createLowering(rctx, resultModel.err) : undefined;
     const okSpill = okLowerer ? (okLowerer as any).spill as number : 0;
@@ -655,7 +656,7 @@ function createResultLowering(rctx: ResolverContext, resultModel: ComponentTypeD
 
 // --- Variant lowering ---
 
-function createVariantLowering(rctx: ResolverContext, variantModel: ComponentTypeDefinedVariant): LoweringToJs {
+function createVariantLowering(rctx: ResolvedContext, variantModel: ComponentTypeDefinedVariant): LoweringToJs {
     const cases = variantModel.variants.map((c) => ({
         name: c.name,
         lowerer: c.ty ? createLowering(rctx, c.ty) : undefined,
@@ -679,7 +680,7 @@ function createVariantLowering(rctx: ResolverContext, variantModel: ComponentTyp
 
 // --- Enum lowering ---
 
-function createEnumLowering(_rctx: ResolverContext, enumModel: ComponentTypeDefinedEnum): LoweringToJs {
+function createEnumLowering(_rctx: ResolvedContext, enumModel: ComponentTypeDefinedEnum): LoweringToJs {
     const fn = (_ctx: BindingContext, ...args: WasmValue[]) => {
         const disc = args[0] as number;
         if (disc >= enumModel.members.length) throw new Error(`Invalid enum discriminant: ${disc} >= ${enumModel.members.length}`);
@@ -691,7 +692,7 @@ function createEnumLowering(_rctx: ResolverContext, enumModel: ComponentTypeDefi
 
 // --- Flags lowering ---
 
-function createFlagsLowering(_rctx: ResolverContext, flagsModel: ComponentTypeDefinedFlags): LoweringToJs {
+function createFlagsLowering(_rctx: ResolvedContext, flagsModel: ComponentTypeDefinedFlags): LoweringToJs {
     const wordCount = Math.max(1, Math.ceil(flagsModel.members.length / 32));
 
     const fn = (_ctx: BindingContext, ...args: WasmValue[]) => {
@@ -708,7 +709,7 @@ function createFlagsLowering(_rctx: ResolverContext, flagsModel: ComponentTypeDe
 
 // --- Tuple lowering ---
 
-function createTupleLowering(rctx: ResolverContext, tupleModel: ComponentTypeDefinedTuple): LoweringToJs {
+function createTupleLowering(rctx: ResolvedContext, tupleModel: ComponentTypeDefinedTuple): LoweringToJs {
     const elementLowerers = tupleModel.members.map(m => createLowering(rctx, m));
 
     let totalSpill = 0;
@@ -730,7 +731,7 @@ function createTupleLowering(rctx: ResolverContext, tupleModel: ComponentTypeDef
 
 // --- Resource handle lowering ---
 
-function createOwnLowering(rctx: ResolverContext, ownModel: ComponentTypeDefinedOwn): LoweringToJs {
+function createOwnLowering(rctx: ResolvedContext, ownModel: ComponentTypeDefinedOwn): LoweringToJs {
     const resourceTypeIdx = getCanonicalResourceId(rctx, ownModel.value);
     const fn = (ctx: BindingContext, ...args: WasmValue[]) => {
         const handle = args[0] as number;
@@ -740,7 +741,7 @@ function createOwnLowering(rctx: ResolverContext, ownModel: ComponentTypeDefined
     return fn;
 }
 
-function createBorrowLowering(rctx: ResolverContext, borrowModel: ComponentTypeDefinedBorrow): LoweringToJs {
+function createBorrowLowering(rctx: ResolvedContext, borrowModel: ComponentTypeDefinedBorrow): LoweringToJs {
     const resourceTypeIdx = getCanonicalResourceId(rctx, borrowModel.value);
     const fn = (ctx: BindingContext, ...args: WasmValue[]) => {
         const handle = args[0] as number;

--- a/src/resolver/calling-convention.ts
+++ b/src/resolver/calling-convention.ts
@@ -87,7 +87,7 @@ function alignUp(offset: number, align: number): number {
     return (offset + align - 1) & ~(align - 1);
 }
 
-export function sizeOf(rctx: ResolverContext, type: ResolvedType): number {
+export function sizeOf(type: ResolvedType): number {
     switch (type.tag) {
         case ModelTag.ComponentValTypePrimitive:
         case ModelTag.ComponentTypeDefinedPrimitive:
@@ -96,22 +96,22 @@ export function sizeOf(rctx: ResolverContext, type: ResolvedType): number {
         case ModelTag.ComponentTypeDefinedRecord: {
             let size = 0;
             for (const member of type.members) {
-                const fieldAlign = alignOfValType(rctx, member.type);
+                const fieldAlign = alignOfValType(member.type);
                 size = alignUp(size, fieldAlign);
-                size += sizeOfValType(rctx, member.type);
+                size += sizeOfValType(member.type);
             }
-            const recordAlign = alignOf(rctx, type);
+            const recordAlign = alignOf(type);
             return alignUp(size, recordAlign);
         }
 
         case ModelTag.ComponentTypeDefinedTuple: {
             let size = 0;
             for (const member of type.members) {
-                const fieldAlign = alignOfValType(rctx, member);
+                const fieldAlign = alignOfValType(member);
                 size = alignUp(size, fieldAlign);
-                size += sizeOfValType(rctx, member);
+                size += sizeOfValType(member);
             }
-            const tupleAlign = alignOf(rctx, type);
+            const tupleAlign = alignOf(type);
             return alignUp(size, tupleAlign);
         }
 
@@ -119,8 +119,8 @@ export function sizeOf(rctx: ResolverContext, type: ResolvedType): number {
             return 8; // pointer + length
 
         case ModelTag.ComponentTypeDefinedOption: {
-            const payloadAlign = alignOfValType(rctx, type.value);
-            const payloadSize = sizeOfValType(rctx, type.value);
+            const payloadAlign = alignOfValType(type.value);
+            const payloadSize = sizeOfValType(type.value);
             // discriminant (1 byte) + padding to payload alignment + payload
             const totalAlign = Math.max(1, payloadAlign);
             return alignUp(alignUp(1, payloadAlign) + payloadSize, totalAlign);
@@ -130,12 +130,12 @@ export function sizeOf(rctx: ResolverContext, type: ResolvedType): number {
             let payloadSize = 0;
             let payloadAlign = 1;
             if (type.ok !== undefined) {
-                payloadSize = Math.max(payloadSize, sizeOfValType(rctx, type.ok));
-                payloadAlign = Math.max(payloadAlign, alignOfValType(rctx, type.ok));
+                payloadSize = Math.max(payloadSize, sizeOfValType(type.ok));
+                payloadAlign = Math.max(payloadAlign, alignOfValType(type.ok));
             }
             if (type.err !== undefined) {
-                payloadSize = Math.max(payloadSize, sizeOfValType(rctx, type.err));
-                payloadAlign = Math.max(payloadAlign, alignOfValType(rctx, type.err));
+                payloadSize = Math.max(payloadSize, sizeOfValType(type.err));
+                payloadAlign = Math.max(payloadAlign, alignOfValType(type.err));
             }
             const totalAlign = Math.max(1, payloadAlign);
             return alignUp(alignUp(1, payloadAlign) + payloadSize, totalAlign);
@@ -148,8 +148,8 @@ export function sizeOf(rctx: ResolverContext, type: ResolvedType): number {
             let maxPayloadAlign = 1;
             for (const c of type.variants) {
                 if (c.ty !== undefined) {
-                    maxPayloadSize = Math.max(maxPayloadSize, sizeOfValType(rctx, c.ty));
-                    maxPayloadAlign = Math.max(maxPayloadAlign, alignOfValType(rctx, c.ty));
+                    maxPayloadSize = Math.max(maxPayloadSize, sizeOfValType(c.ty));
+                    maxPayloadAlign = Math.max(maxPayloadAlign, alignOfValType(c.ty));
                 }
             }
             const totalAlign = Math.max(discAlign, maxPayloadAlign);
@@ -172,7 +172,7 @@ export function sizeOf(rctx: ResolverContext, type: ResolvedType): number {
     }
 }
 
-export function alignOf(rctx: ResolverContext, type: ResolvedType): number {
+export function alignOf(type: ResolvedType): number {
     switch (type.tag) {
         case ModelTag.ComponentValTypePrimitive:
         case ModelTag.ComponentTypeDefinedPrimitive:
@@ -181,7 +181,7 @@ export function alignOf(rctx: ResolverContext, type: ResolvedType): number {
         case ModelTag.ComponentTypeDefinedRecord: {
             let maxAlign = 1;
             for (const member of type.members) {
-                maxAlign = Math.max(maxAlign, alignOfValType(rctx, member.type));
+                maxAlign = Math.max(maxAlign, alignOfValType(member.type));
             }
             return maxAlign;
         }
@@ -189,7 +189,7 @@ export function alignOf(rctx: ResolverContext, type: ResolvedType): number {
         case ModelTag.ComponentTypeDefinedTuple: {
             let maxAlign = 1;
             for (const member of type.members) {
-                maxAlign = Math.max(maxAlign, alignOfValType(rctx, member));
+                maxAlign = Math.max(maxAlign, alignOfValType(member));
             }
             return maxAlign;
         }
@@ -198,12 +198,12 @@ export function alignOf(rctx: ResolverContext, type: ResolvedType): number {
             return 4; // pointer alignment
 
         case ModelTag.ComponentTypeDefinedOption:
-            return Math.max(1, alignOfValType(rctx, type.value));
+            return Math.max(1, alignOfValType(type.value));
 
         case ModelTag.ComponentTypeDefinedResult: {
             let maxAlign = 1;
-            if (type.ok !== undefined) maxAlign = Math.max(maxAlign, alignOfValType(rctx, type.ok));
-            if (type.err !== undefined) maxAlign = Math.max(maxAlign, alignOfValType(rctx, type.err));
+            if (type.ok !== undefined) maxAlign = Math.max(maxAlign, alignOfValType(type.ok));
+            if (type.err !== undefined) maxAlign = Math.max(maxAlign, alignOfValType(type.err));
             return maxAlign;
         }
 
@@ -212,7 +212,7 @@ export function alignOf(rctx: ResolverContext, type: ResolvedType): number {
             let maxAlign = disc;
             for (const c of type.variants) {
                 if (c.ty !== undefined) {
-                    maxAlign = Math.max(maxAlign, alignOfValType(rctx, c.ty));
+                    maxAlign = Math.max(maxAlign, alignOfValType(c.ty));
                 }
             }
             return maxAlign;
@@ -233,7 +233,7 @@ export function alignOf(rctx: ResolverContext, type: ResolvedType): number {
     }
 }
 
-export function flatCount(rctx: ResolverContext, type: ResolvedType): number {
+export function flatCount(type: ResolvedType): number {
     switch (type.tag) {
         case ModelTag.ComponentValTypePrimitive:
         case ModelTag.ComponentTypeDefinedPrimitive:
@@ -242,7 +242,7 @@ export function flatCount(rctx: ResolverContext, type: ResolvedType): number {
         case ModelTag.ComponentTypeDefinedRecord: {
             let count = 0;
             for (const member of type.members) {
-                count += flatCountForValType(rctx, member.type);
+                count += flatCountForValType(member.type);
             }
             return count;
         }
@@ -250,7 +250,7 @@ export function flatCount(rctx: ResolverContext, type: ResolvedType): number {
         case ModelTag.ComponentTypeDefinedTuple: {
             let count = 0;
             for (const member of type.members) {
-                count += flatCountForValType(rctx, member);
+                count += flatCountForValType(member);
             }
             return count;
         }
@@ -259,12 +259,12 @@ export function flatCount(rctx: ResolverContext, type: ResolvedType): number {
             return 2; // pointer + length
 
         case ModelTag.ComponentTypeDefinedOption:
-            return 1 + flatCountForValType(rctx, type.value); // discriminant + payload
+            return 1 + flatCountForValType(type.value); // discriminant + payload
 
         case ModelTag.ComponentTypeDefinedResult: {
             let maxPayloadFlat = 0;
-            if (type.ok !== undefined) maxPayloadFlat = Math.max(maxPayloadFlat, flatCountForValType(rctx, type.ok));
-            if (type.err !== undefined) maxPayloadFlat = Math.max(maxPayloadFlat, flatCountForValType(rctx, type.err));
+            if (type.ok !== undefined) maxPayloadFlat = Math.max(maxPayloadFlat, flatCountForValType(type.ok));
+            if (type.err !== undefined) maxPayloadFlat = Math.max(maxPayloadFlat, flatCountForValType(type.err));
             return 1 + maxPayloadFlat; // discriminant + max(ok, err)
         }
 
@@ -272,7 +272,7 @@ export function flatCount(rctx: ResolverContext, type: ResolvedType): number {
             let maxCaseFlat = 0;
             for (const c of type.variants) {
                 if (c.ty !== undefined) {
-                    maxCaseFlat = Math.max(maxCaseFlat, flatCountForValType(rctx, c.ty));
+                    maxCaseFlat = Math.max(maxCaseFlat, flatCountForValType(c.ty));
                 }
             }
             return 1 + maxCaseFlat; // discriminant + max case
@@ -308,6 +308,21 @@ export function resolveValType(rctx: ResolverContext, valType: ComponentValType)
         throw new Error(`Unresolved type at index ${valType.value}`);
     }
     return resolved;
+}
+
+/**
+ * Resolve a ComponentValType without rctx — only handles Primitive and Resolved.
+ * Throws on ComponentValTypeType, which indicates a missing deep-resolve step.
+ * Use this in call-time paths where rctx must not be captured.
+ */
+export function resolveValTypePure(valType: ComponentValType): ResolvedType {
+    if (valType.tag === ModelTag.ComponentValTypePrimitive) {
+        return valType;
+    }
+    if (valType.tag === ModelTag.ComponentValTypeResolved) {
+        return valType.resolved as ResolvedType;
+    }
+    throw new Error(`resolveValTypePure: unexpected ComponentValTypeType(${(valType as any).value}) — type was not deep-resolved`);
 }
 
 /**
@@ -417,16 +432,16 @@ function _deepResolve(rctx: ResolverContext, type: ResolvedType, visited: Set<un
     }
 }
 
-export function sizeOfValType(rctx: ResolverContext, valType: ComponentValType): number {
-    return sizeOf(rctx, resolveValType(rctx, valType));
+export function sizeOfValType(valType: ComponentValType): number {
+    return sizeOf(resolveValTypePure(valType));
 }
 
-export function alignOfValType(rctx: ResolverContext, valType: ComponentValType): number {
-    return alignOf(rctx, resolveValType(rctx, valType));
+export function alignOfValType(valType: ComponentValType): number {
+    return alignOf(resolveValTypePure(valType));
 }
 
-export function flatCountForValType(rctx: ResolverContext, valType: ComponentValType): number {
-    return flatCount(rctx, resolveValType(rctx, valType));
+export function flatCountForValType(valType: ComponentValType): number {
+    return flatCount(resolveValTypePure(valType));
 }
 
 // --- Discriminant sizing per canonical ABI ---
@@ -442,24 +457,23 @@ export function discriminantSize(caseCount: number): number {
 // --- Function-level calling convention decision ---
 
 export function determineFunctionCallingConvention(
-    rctx: ResolverContext,
     funcType: ComponentTypeFunc
 ): FunctionCallingConvention {
     let paramFlatCount = 0;
     for (const param of funcType.params) {
-        paramFlatCount += flatCountForValType(rctx, param.type);
+        paramFlatCount += flatCountForValType(param.type);
     }
 
     let resultFlatCount = 0;
     switch (funcType.results.tag) {
         case ModelTag.ComponentFuncResultNamed: {
             for (const res of funcType.results.values) {
-                resultFlatCount += flatCountForValType(rctx, res.type);
+                resultFlatCount += flatCountForValType(res.type);
             }
             break;
         }
         case ModelTag.ComponentFuncResultUnnamed: {
-            resultFlatCount = flatCountForValType(rctx, funcType.results.type);
+            resultFlatCount = flatCountForValType(funcType.results.type);
             break;
         }
     }

--- a/src/resolver/calling-convention.ts
+++ b/src/resolver/calling-convention.ts
@@ -299,12 +299,122 @@ export function resolveValType(rctx: ResolverContext, valType: ComponentValType)
     if (valType.tag === ModelTag.ComponentValTypePrimitive) {
         return valType;
     }
+    if (valType.tag === ModelTag.ComponentValTypeResolved) {
+        return valType.resolved as ResolvedType;
+    }
     // ComponentValTypeType — follow the reference
     const resolved = rctx.resolvedTypes.get(valType.value as ComponentTypeIndex);
     if (resolved === undefined) {
         throw new Error(`Unresolved type at index ${valType.value}`);
     }
     return resolved;
+}
+
+/**
+ * Deep-resolve a ResolvedType: recursively replace all nested ComponentValTypeType
+ * references with ComponentValTypeResolved carrying the resolved type inline.
+ * This allows storeToMemory/loadFromMemory/sizeOf/alignOf to work without
+ * looking up rctx.resolvedTypes at call time.
+ */
+export function deepResolveType(rctx: ResolverContext, type: ResolvedType): ResolvedType {
+    return _deepResolve(rctx, type, new Set());
+}
+
+function _deepResolveValType(rctx: ResolverContext, valType: ComponentValType, visited: Set<unknown>): ComponentValType {
+    if (valType.tag === ModelTag.ComponentValTypePrimitive) {
+        return valType; // primitives are self-contained
+    }
+    if (valType.tag === ModelTag.ComponentValTypeResolved) {
+        return valType; // already resolved
+    }
+    // ComponentValTypeType — resolve and wrap inline
+    const resolved = rctx.resolvedTypes.get(valType.value as ComponentTypeIndex);
+    if (resolved === undefined) {
+        throw new Error(`Unresolved type at index ${valType.value}`);
+    }
+    const deepResolved = _deepResolve(rctx, resolved, visited);
+    return { tag: ModelTag.ComponentValTypeResolved, resolved: deepResolved };
+}
+
+function _deepResolve(rctx: ResolverContext, type: ResolvedType, visited: Set<unknown>): ResolvedType {
+    // Guard against infinite recursion from circular type references
+    if (visited.has(type)) return type;
+    visited.add(type);
+
+    switch (type.tag) {
+        case ModelTag.ComponentValTypePrimitive:
+        case ModelTag.ComponentTypeDefinedPrimitive:
+        case ModelTag.ComponentTypeDefinedEnum:
+        case ModelTag.ComponentTypeDefinedFlags:
+        case ModelTag.ComponentTypeDefinedOwn:
+        case ModelTag.ComponentTypeDefinedBorrow:
+            // No nested ComponentValType references needing resolution
+            return type;
+
+        case ModelTag.ComponentTypeDefinedRecord:
+            return {
+                ...type,
+                members: type.members.map(m => ({
+                    name: m.name,
+                    type: _deepResolveValType(rctx, m.type, visited),
+                })),
+            };
+
+        case ModelTag.ComponentTypeDefinedTuple:
+            return {
+                ...type,
+                members: type.members.map(m => _deepResolveValType(rctx, m, visited)),
+            };
+
+        case ModelTag.ComponentTypeDefinedList:
+            return {
+                ...type,
+                value: _deepResolveValType(rctx, type.value, visited),
+            };
+
+        case ModelTag.ComponentTypeDefinedOption:
+            return {
+                ...type,
+                value: _deepResolveValType(rctx, type.value, visited),
+            };
+
+        case ModelTag.ComponentTypeDefinedResult:
+            return {
+                ...type,
+                ok: type.ok !== undefined ? _deepResolveValType(rctx, type.ok, visited) : undefined,
+                err: type.err !== undefined ? _deepResolveValType(rctx, type.err, visited) : undefined,
+            };
+
+        case ModelTag.ComponentTypeDefinedVariant:
+            return {
+                ...type,
+                variants: type.variants.map(c => ({
+                    ...c,
+                    ty: c.ty !== undefined ? _deepResolveValType(rctx, c.ty, visited) : undefined,
+                })),
+            };
+
+        case ModelTag.ComponentTypeFunc:
+            return {
+                ...type,
+                params: type.params.map(p => ({
+                    name: p.name,
+                    type: _deepResolveValType(rctx, p.type, visited),
+                })),
+                results: type.results.tag === ModelTag.ComponentFuncResultUnnamed
+                    ? { tag: ModelTag.ComponentFuncResultUnnamed, type: _deepResolveValType(rctx, type.results.type, visited) }
+                    : {
+                        tag: ModelTag.ComponentFuncResultNamed,
+                        values: type.results.values.map(v => ({
+                            name: v.name,
+                            type: _deepResolveValType(rctx, v.type, visited),
+                        })),
+                    },
+            };
+
+        default:
+            return type;
+    }
 }
 
 export function sizeOfValType(rctx: ResolverContext, valType: ComponentValType): number {

--- a/src/resolver/calling-convention.ts
+++ b/src/resolver/calling-convention.ts
@@ -2,7 +2,7 @@ import { ComponentTypeIndex } from '../model/indices';
 import { ModelTag } from '../model/tags';
 import { ComponentTypeFunc, ComponentValType, PrimitiveValType } from '../model/types';
 import type { ResolvedType } from './type-resolution';
-import type { ResolverContext } from './types';
+import type { ResolvedContext } from './types';
 
 // Canonical ABI limits
 export const MAX_FLAT_PARAMS = 16;
@@ -295,7 +295,7 @@ export function flatCount(type: ResolvedType): number {
 
 // --- Helpers for ComponentValType (which may be primitive or a type reference) ---
 
-export function resolveValType(rctx: ResolverContext, valType: ComponentValType): ResolvedType {
+export function resolveValType(rctx: ResolvedContext, valType: ComponentValType): ResolvedType {
     if (valType.tag === ModelTag.ComponentValTypePrimitive) {
         return valType;
     }
@@ -331,11 +331,11 @@ export function resolveValTypePure(valType: ComponentValType): ResolvedType {
  * This allows storeToMemory/loadFromMemory/sizeOf/alignOf to work without
  * looking up rctx.resolvedTypes at call time.
  */
-export function deepResolveType(rctx: ResolverContext, type: ResolvedType): ResolvedType {
+export function deepResolveType(rctx: ResolvedContext, type: ResolvedType): ResolvedType {
     return _deepResolve(rctx, type, new Set());
 }
 
-function _deepResolveValType(rctx: ResolverContext, valType: ComponentValType, visited: Set<unknown>): ComponentValType {
+function _deepResolveValType(rctx: ResolvedContext, valType: ComponentValType, visited: Set<unknown>): ComponentValType {
     if (valType.tag === ModelTag.ComponentValTypePrimitive) {
         return valType; // primitives are self-contained
     }
@@ -351,7 +351,7 @@ function _deepResolveValType(rctx: ResolverContext, valType: ComponentValType, v
     return { tag: ModelTag.ComponentValTypeResolved, resolved: deepResolved };
 }
 
-function _deepResolve(rctx: ResolverContext, type: ResolvedType, visited: Set<unknown>): ResolvedType {
+function _deepResolve(rctx: ResolvedContext, type: ResolvedType, visited: Set<unknown>): ResolvedType {
     // Guard against infinite recursion from circular type references
     if (visited.has(type)) return type;
     visited.add(type);

--- a/src/resolver/component-functions.ts
+++ b/src/resolver/component-functions.ts
@@ -36,8 +36,8 @@ export const resolveCanonicalFunctionLift: Resolver<CanonicalFunctionLift> = (rc
     const canonOpts = resolveCanonicalOptions(canonicalFunctionLift.options);
 
     // Set string encoding for this canonical function — read by createLifting/createLowering
-    const savedEncoding = rctx.stringEncoding;
-    rctx.stringEncoding = canonOpts.stringEncoding;
+    const savedEncoding = rctx.resolved.stringEncoding;
+    rctx.resolved.stringEncoding = canonOpts.stringEncoding;
 
     // Resolve the post-return core function if specified in canonical options
     let postReturnResolution: ResolverRes | undefined;
@@ -46,9 +46,9 @@ export const resolveCanonicalFunctionLift: Resolver<CanonicalFunctionLift> = (rc
         postReturnResolution = resolveCoreFunction(rctx, { element: postReturnFunc, callerElement: canonicalFunctionLift });
     }
 
-    const liftingBinder = createFunctionLifting(rctx, sectionFunType);
+    const liftingBinder = createFunctionLifting(rctx.resolved, sectionFunType);
 
-    rctx.stringEncoding = savedEncoding;
+    rctx.resolved.stringEncoding = savedEncoding;
 
     return {
         callerElement: rargs.callerElement,

--- a/src/resolver/component-functions.ts
+++ b/src/resolver/component-functions.ts
@@ -10,7 +10,7 @@ import { resolveComponentInstance } from './component-instances';
 import { resolveComponentImport } from './component-imports';
 import { resolveCoreFunction } from './core-functions';
 import { getCoreFunction, getComponentType, getComponentInstance } from './indices';
-import { Resolver, resolveCanonicalOptions } from './types';
+import { Resolver, ResolverRes, resolveCanonicalOptions } from './types';
 import camelCase from 'just-camel-case';
 
 export const resolveComponentFunction: Resolver<ComponentFunction> = (rctx, rargs) => {
@@ -40,7 +40,7 @@ export const resolveCanonicalFunctionLift: Resolver<CanonicalFunctionLift> = (rc
     rctx.stringEncoding = canonOpts.stringEncoding;
 
     // Resolve the post-return core function if specified in canonical options
-    let postReturnResolution: import('./types').ResolverRes | undefined;
+    let postReturnResolution: ResolverRes | undefined;
     if (canonOpts.postReturnIndex !== undefined) {
         const postReturnFunc = getCoreFunction(rctx, canonOpts.postReturnIndex as CoreFuncIndex);
         postReturnResolution = resolveCoreFunction(rctx, { element: postReturnFunc, callerElement: canonicalFunctionLift });

--- a/src/resolver/component-functions.ts
+++ b/src/resolver/component-functions.ts
@@ -10,7 +10,7 @@ import { resolveComponentInstance } from './component-instances';
 import { resolveComponentImport } from './component-imports';
 import { resolveCoreFunction } from './core-functions';
 import { getCoreFunction, getComponentType, getComponentInstance } from './indices';
-import { Resolver, resolveCanonicalOptions, StringEncoding } from './types';
+import { Resolver, resolveCanonicalOptions } from './types';
 import camelCase from 'just-camel-case';
 
 export const resolveComponentFunction: Resolver<ComponentFunction> = (rctx, rargs) => {
@@ -34,8 +34,10 @@ export const resolveCanonicalFunctionLift: Resolver<CanonicalFunctionLift> = (rc
     jsco_assert(sectionFunType.tag === ModelTag.ComponentTypeFunc, () => `expected ComponentTypeFunc, got ${sectionFunType.tag}`);
 
     const canonOpts = resolveCanonicalOptions(canonicalFunctionLift.options);
-    jsco_assert(canonOpts.stringEncoding === StringEncoding.Utf8,
-        () => `String encoding '${canonOpts.stringEncoding}' not yet supported, only UTF-8`);
+
+    // Set string encoding for this canonical function — read by createLifting/createLowering
+    const savedEncoding = rctx.stringEncoding;
+    rctx.stringEncoding = canonOpts.stringEncoding;
 
     // Resolve the post-return core function if specified in canonical options
     let postReturnResolution: import('./types').ResolverRes | undefined;
@@ -45,6 +47,8 @@ export const resolveCanonicalFunctionLift: Resolver<CanonicalFunctionLift> = (rc
     }
 
     const liftingBinder = createFunctionLifting(rctx, sectionFunType);
+
+    rctx.stringEncoding = savedEncoding;
 
     return {
         callerElement: rargs.callerElement,

--- a/src/resolver/component-imports.ts
+++ b/src/resolver/component-imports.ts
@@ -61,9 +61,8 @@ export const resolveComponentImport: Resolver<ComponentImport> = (rctx, rargs) =
         case ModelTag.ComponentTypeRefFunc: {
             // Function import: the component imports a function directly (not through an instance).
             // The JS imports object should have the function at the import name key.
-            // TODO: When the index space unification is implemented (imports contributing to
-            // componentFunctions), CanonicalFunctionLower will be able to reference this
-            // function by its component function index.
+            // Func imports contribute to componentFunctions[], so CanonicalFunctionLower
+            // can reference them by func_index.
             return {
                 callerElement: rargs.callerElement,
                 element: componentImport,

--- a/src/resolver/component-instances.ts
+++ b/src/resolver/component-instances.ts
@@ -1,5 +1,5 @@
 import camelCase from 'just-camel-case';
-import { ComponentExternalKind } from '../model/exports';
+import { ComponentExport, ComponentExternalKind } from '../model/exports';
 import { ComponentFuncIndex, ComponentInstanceIndex } from '../model/indices';
 import { ComponentInstance, ComponentInstanceFromExports, ComponentInstanceInstantiate, ComponentInstantiationArg } from '../model/instances';
 import { ModelTag, TaggedElement } from '../model/tags';
@@ -178,7 +178,7 @@ export const resolveComponentInstanceFromExports: Resolver<ComponentInstanceFrom
             const binderResult = lookupComponentInstance(bctx, componentInstanceFromExports.selfSortIndex!);
 
             for (const exportResolution of exportResolutions) {
-                const callerElement = exportResolution.callerElement as unknown as import('../model/exports').ComponentExport;
+                const callerElement = exportResolution.callerElement as unknown as ComponentExport;
                 const args: BinderArgs = {
                     arguments: bargs.arguments,
                     imports: bargs.imports,

--- a/src/resolver/context.ts
+++ b/src/resolver/context.ts
@@ -4,7 +4,7 @@ import { ComponentAliasInstanceExport, ComponentOuterAliasKind } from '../model/
 import { ExternalKind } from '../model/core';
 import { ComponentExternalKind } from '../model/exports';
 import { configuration } from '../utils/assert';
-import { BindingContext, ComponentFactoryOptions, MemoryView, Allocator, InstanceTable, ResolverContext, ResourceTable, StringEncoding } from './types';
+import { BindingContext, ComponentFactoryOptions, MemoryView, Allocator, InstanceTable, ResolvedContext, ResolverContext, ResourceTable, StringEncoding } from './types';
 import { TCabiRealloc, WasmPointer, WasmSize } from './binding/types';
 import { JsImports } from './api-types';
 import { buildResolvedTypeMap } from './type-resolution';
@@ -13,14 +13,16 @@ import type { ComponentTypeInstance } from '../model/types';
 
 export function createResolverContext(sections: WITModel, options: ComponentFactoryOptions): ResolverContext {
     const rctx: ResolverContext = {
-        usesNumberForInt64: (options.useNumberForInt64 === true) ? true : false,
+        resolved: {
+            usesNumberForInt64: (options.useNumberForInt64 === true) ? true : false,
+            stringEncoding: StringEncoding.Utf8,
+            memoizeCache: new Map(),
+            resolvedTypes: new Map(),
+            canonicalResourceIds: new Map(),
+        },
         validateTypes: (options.validateTypes === false) ? false : true,
-        stringEncoding: StringEncoding.Utf8,
         wasmInstantiate: options.wasmInstantiate ?? ((module, importObject) => WebAssembly.instantiate(module, importObject)),
-        memoizeCache: new Map(),
-        resolvedTypes: new Map(),
         importToInstanceIndex: new Map(),
-        canonicalResourceIds: new Map(),
         resourceAliasGroups: new Map(),
         indexes: {
             componentExports: [],
@@ -100,7 +102,7 @@ export function createResolverContext(sections: WITModel, options: ComponentFact
     // while type_index references componentTypes (TYPE sort).
     setSelfIndex(rctx);
     buildCanonicalResourceIds(rctx);
-    rctx.resolvedTypes = buildResolvedTypeMap(rctx);
+    rctx.resolved.resolvedTypes = buildResolvedTypeMap(rctx);
     return rctx;
 }
 
@@ -131,7 +133,7 @@ export function setSelfIndex(rctx: ResolverContext) {
 /// correctly across different aliases to the same underlying resource.
 function buildCanonicalResourceIds(rctx: ResolverContext): void {
     const types = rctx.indexes.componentTypes;
-    const map = rctx.canonicalResourceIds;
+    const map = rctx.resolved.canonicalResourceIds;
 
     // Phase 1: Assign canonical IDs to resource source types.
     // For ComponentTypeResource: the type index IS the canonical ID.
@@ -160,7 +162,7 @@ function buildCanonicalResourceIds(rctx: ResolverContext): void {
 
 /// Resolves a type index to its canonical resource ID.
 /// Handles own<T>/borrow<T> (follows .value) and direct resource/alias references.
-export function getCanonicalResourceId(rctx: ResolverContext, resourceTypeIdx: number): number {
+export function getCanonicalResourceId(rctx: ResolvedContext, resourceTypeIdx: number): number {
     return rctx.canonicalResourceIds?.get(resourceTypeIdx) ?? resourceTypeIdx;
 }
 

--- a/src/resolver/context.ts
+++ b/src/resolver/context.ts
@@ -246,7 +246,7 @@ export function createResourceTable(): ResourceTable {
     };
 }
 
-export function createBindingContext(rctx: ResolverContext, componentImports: JsImports): BindingContext {
+export function createBindingContext(componentImports: JsImports): BindingContext {
     const memory = createMemoryView();
     const allocator = createAllocator();
     const instances = createInstanceTable();

--- a/src/resolver/context.ts
+++ b/src/resolver/context.ts
@@ -4,7 +4,7 @@ import { ComponentAliasInstanceExport, ComponentOuterAliasKind } from '../model/
 import { ExternalKind } from '../model/core';
 import { ComponentExternalKind } from '../model/exports';
 import { configuration } from '../utils/assert';
-import { BindingContext, ComponentFactoryOptions, MemoryView, Allocator, InstanceTable, ResolverContext, ResourceTable } from './types';
+import { BindingContext, ComponentFactoryOptions, MemoryView, Allocator, InstanceTable, ResolverContext, ResourceTable, StringEncoding } from './types';
 import { TCabiRealloc, WasmPointer, WasmSize } from './binding/types';
 import { JsImports } from './api-types';
 import { buildResolvedTypeMap } from './type-resolution';
@@ -13,6 +13,7 @@ export function createResolverContext(sections: WITModel, options: ComponentFact
     const rctx: ResolverContext = {
         usesNumberForInt64: (options.useNumberForInt64 === true) ? true : false,
         validateTypes: (options.validateTypes === false) ? false : true,
+        stringEncoding: StringEncoding.Utf8,
         wasmInstantiate: options.wasmInstantiate ?? ((module, importObject) => WebAssembly.instantiate(module, importObject)),
         memoizeCache: new Map(),
         resolvedTypes: new Map(),

--- a/src/resolver/context.ts
+++ b/src/resolver/context.ts
@@ -8,6 +8,8 @@ import { BindingContext, ComponentFactoryOptions, MemoryView, Allocator, Instanc
 import { TCabiRealloc, WasmPointer, WasmSize } from './binding/types';
 import { JsImports } from './api-types';
 import { buildResolvedTypeMap } from './type-resolution';
+import type { ComponentImport } from '../model/imports';
+import type { ComponentTypeInstance } from '../model/types';
 
 export function createResolverContext(sections: WITModel, options: ComponentFactoryOptions): ResolverContext {
     const rctx: ResolverContext = {
@@ -47,31 +49,44 @@ export function createResolverContext(sections: WITModel, options: ComponentFact
             rctx.indexes.componentTypeResource.push({ ...section } as any);
         }
 
-        // ComponentImport with Instance kind creates an entry in the instance sort.
-        // The instance sort is built from imports (instance kind) + instance sections,
-        // in binary order. The imported instance's type definition (ComponentTypeInstance)
-        // is looked up from componentTypes and pushed to componentInstances.
+        // ComponentImport contributions to sort index spaces.
+        // Each import kind contributes to its respective sort, and we track the
+        // mapping from import index → sort index for kinds that need it at bind time.
         if (section.tag === ModelTag.ComponentImport) {
-            const imp = section as import('../model/imports').ComponentImport;
+            const imp = section as ComponentImport;
             if (imp.ty.tag === ModelTag.ComponentTypeRefInstance) {
-                // The ty.value is a type sort index pointing to a ComponentTypeInstance
+                // Instance import → instance sort.
+                // The ty.value is a type sort index pointing to a ComponentTypeInstance.
                 const instanceType = indexes.componentTypes[imp.ty.value];
                 if (instanceType) {
                     const instanceIndex = indexes.componentInstances.length;
                     // Shallow clone: the same object lives in componentTypes[] too.
                     // setSelfIndex runs on both arrays, so a shared reference would
                     // get its selfSortIndex clobbered by whichever array runs last.
-                    // Cloning lets each array track its own position.
-                    indexes.componentInstances.push({ ...instanceType } as import('../model/types').ComponentTypeInstance);
-                    // Track import→instance mapping: import's position in componentImports
-                    // may differ from its position in componentInstances when there are
-                    // non-instance imports or other entries in the instance sort.
+                    indexes.componentInstances.push({ ...instanceType } as ComponentTypeInstance);
                     const importIndex = indexes.componentImports.length - 1;
                     rctx.importToInstanceIndex.set(importIndex, instanceIndex);
                 }
             }
+            if (imp.ty.tag === ModelTag.ComponentTypeRefComponent) {
+                // Component import → instance sort (for JS binding, imported components
+                // are provided as objects with exports, equivalent to instances).
+                // Also pushed to componentSections (component sort) so
+                // ComponentInstanceInstantiate.component_index can reference it.
+                const instanceIndex = indexes.componentInstances.length;
+                const componentType = indexes.componentTypes[imp.ty.value];
+                if (componentType) {
+                    indexes.componentInstances.push({ ...componentType } as ComponentTypeInstance);
+                } else {
+                    // No type definition found — create a placeholder instance entry
+                    indexes.componentInstances.push({ tag: ModelTag.ComponentTypeInstance, declarations: [] } as any);
+                }
+                indexes.componentSections.push(imp as any);
+                const importIndex = indexes.componentImports.length - 1;
+                rctx.importToInstanceIndex.set(importIndex, instanceIndex);
+            }
             // Func imports contribute to the component function index space.
-            // CanonicalFunctionLower.func_index may reference imported functions.
+            // CanonicalFunctionLower.func_index references imported functions by index.
             if (imp.ty.tag === ModelTag.ComponentTypeRefFunc) {
                 indexes.componentFunctions.push(imp);
             }

--- a/src/resolver/context.ts
+++ b/src/resolver/context.ts
@@ -16,7 +16,8 @@ export function createResolverContext(sections: WITModel, options: ComponentFact
         resolved: {
             usesNumberForInt64: (options.useNumberForInt64 === true) ? true : false,
             stringEncoding: StringEncoding.Utf8,
-            memoizeCache: new Map(),
+            liftingCache: new Map(),
+            loweringCache: new Map(),
             resolvedTypes: new Map(),
             canonicalResourceIds: new Map(),
         },

--- a/src/resolver/core-functions.ts
+++ b/src/resolver/core-functions.ts
@@ -51,12 +51,12 @@ export const resolveCanonicalFunctionLower: Resolver<CanonicalFunctionLower> = (
     const canonOpts = resolveCanonicalOptions(canonicalFunctionLowerElem.options);
 
     // Set string encoding for this canonical function — read by createLifting/createLowering
-    const savedEncoding = rctx.stringEncoding;
-    rctx.stringEncoding = canonOpts.stringEncoding;
+    const savedEncoding = rctx.resolved.stringEncoding;
+    rctx.resolved.stringEncoding = canonOpts.stringEncoding;
 
-    const loweringBinder = createFunctionLowering(rctx, funcType);
+    const loweringBinder = createFunctionLowering(rctx.resolved, funcType);
 
-    rctx.stringEncoding = savedEncoding;
+    rctx.resolved.stringEncoding = savedEncoding;
 
     return {
         callerElement: rargs.callerElement,
@@ -171,7 +171,7 @@ function resolveAliasedFuncType(
     // Fallback: try resolvedTypes map
     const typeIndex = alias.selfSortIndex;
     if (typeIndex !== undefined) {
-        const resolved = rctx.resolvedTypes.get(typeIndex as ComponentTypeIndex);
+        const resolved = rctx.resolved.resolvedTypes.get(typeIndex as ComponentTypeIndex);
         if (resolved && resolved.tag === ModelTag.ComponentTypeFunc) {
             return resolved;
         }
@@ -223,7 +223,7 @@ function isTypeCreatingDeclaration(decl: InstanceTypeDeclaration): boolean {
 }
 
 /**
- * Register instance-local types in rctx.resolvedTypes so that resolveValType
+ * Register instance-local types in rctx.resolved.resolvedTypes so that resolveValType
  * can resolve Type(localIdx) references within function types from this instance.
  *
  * Instance type declarations create a local type index space. Function types
@@ -237,7 +237,7 @@ function registerInstanceLocalTypes(rctx: ResolverContext, instance: ComponentTy
     // in this same loop (which may share the same numeric index).
     // Note: canonicalResourceIds is NOT snapshotted — its entries are additive
     // (local→canonical mappings needed by resource.drop/new/rep resolvers).
-    const globalResolvedTypes = new Map(rctx.resolvedTypes);
+    const globalResolvedTypes = new Map(rctx.resolved.resolvedTypes);
 
     const localTypes: (ResolvedType | undefined)[] = [];
     // Track which local indices are resources, keyed by export name
@@ -287,9 +287,9 @@ function registerInstanceLocalTypes(rctx: ResolverContext, instance: ComponentTy
                     }
                     // Propagate canonical resource ID from the outer scope.
                     // If the outer type is a resource alias, this local index inherits its canonical ID.
-                    const outerCanonicalId = rctx.canonicalResourceIds?.get(alias.index);
+                    const outerCanonicalId = rctx.resolved.canonicalResourceIds?.get(alias.index);
                     if (outerCanonicalId !== undefined) {
-                        rctx.canonicalResourceIds.set(localTypeIdx, outerCanonicalId);
+                        rctx.resolved.canonicalResourceIds.set(localTypeIdx, outerCanonicalId);
                     }
                 }
                 break;
@@ -302,9 +302,9 @@ function registerInstanceLocalTypes(rctx: ResolverContext, instance: ComponentTy
                         const eqIdx = decl.ty.value.value;
                         resolved = localTypes[eqIdx];
                         // Inherit canonical resource ID from the equal type.
-                        const eqCanonicalId = rctx.canonicalResourceIds?.get(eqIdx);
+                        const eqCanonicalId = rctx.resolved.canonicalResourceIds?.get(eqIdx);
                         if (eqCanonicalId !== undefined) {
-                            rctx.canonicalResourceIds.set(localTypeIdx, eqCanonicalId);
+                            rctx.resolved.canonicalResourceIds.set(localTypeIdx, eqCanonicalId);
                         }
                     }
                     if (decl.ty.value.tag === ModelTag.TypeBoundsSubResource) {
@@ -319,7 +319,7 @@ function registerInstanceLocalTypes(rctx: ResolverContext, instance: ComponentTy
 
         localTypes.push(resolved);
         if (resolved) {
-            rctx.resolvedTypes.set(localTypeIdx as ComponentTypeIndex, resolved);
+            rctx.resolved.resolvedTypes.set(localTypeIdx as ComponentTypeIndex, resolved);
         }
         localTypeIdx++;
     }
@@ -333,7 +333,7 @@ function registerInstanceLocalTypes(rctx: ResolverContext, instance: ComponentTy
         const key = `${instanceIndex}:${resourceName}`;
         const canonicalId = rctx.resourceAliasGroups?.get(key);
         if (canonicalId !== undefined) {
-            rctx.canonicalResourceIds.set(localIdx, canonicalId);
+            rctx.resolved.canonicalResourceIds.set(localIdx, canonicalId);
         }
     }
 }
@@ -344,7 +344,7 @@ function registerInstanceLocalTypes(rctx: ResolverContext, instance: ComponentTy
  */
 export const resolveCanonicalFunctionResourceDrop: Resolver<CanonicalFunctionResourceDrop> = (rctx, rargs) => {
     const elem = rargs.element;
-    const resourceTypeIdx = getCanonicalResourceId(rctx, elem.resource);
+    const resourceTypeIdx = getCanonicalResourceId(rctx.resolved, elem.resource);
 
     return {
         callerElement: rargs.callerElement,
@@ -364,7 +364,7 @@ export const resolveCanonicalFunctionResourceDrop: Resolver<CanonicalFunctionRes
  */
 export const resolveCanonicalFunctionResourceNew: Resolver<CanonicalFunctionResourceNew> = (rctx, rargs) => {
     const elem = rargs.element;
-    const resourceTypeIdx = getCanonicalResourceId(rctx, elem.resource);
+    const resourceTypeIdx = getCanonicalResourceId(rctx.resolved, elem.resource);
 
     return {
         callerElement: rargs.callerElement,
@@ -383,7 +383,7 @@ export const resolveCanonicalFunctionResourceNew: Resolver<CanonicalFunctionReso
  */
 export const resolveCanonicalFunctionResourceRep: Resolver<CanonicalFunctionResourceRep> = (rctx, rargs) => {
     const elem = rargs.element;
-    const resourceTypeIdx = getCanonicalResourceId(rctx, elem.resource);
+    const resourceTypeIdx = getCanonicalResourceId(rctx.resolved, elem.resource);
 
     return {
         callerElement: rargs.callerElement,

--- a/src/resolver/core-functions.ts
+++ b/src/resolver/core-functions.ts
@@ -13,7 +13,7 @@ import { resolveComponentAliasCoreInstanceExport } from './core-exports';
 import type { ResolvedType } from './type-resolution';
 import { getCanonicalResourceId } from './context';
 import { getComponentFunction, getComponentType } from './indices';
-import { Resolver, BinderRes, ResolverRes, resolveCanonicalOptions, StringEncoding } from './types';
+import { Resolver, BinderRes, ResolverRes, resolveCanonicalOptions } from './types';
 
 
 export const resolveCoreFunction: Resolver<CoreFunction> = (rctx, rargs) => {
@@ -42,10 +42,14 @@ export const resolveCanonicalFunctionLower: Resolver<CanonicalFunctionLower> = (
     const funcType = resolveLoweredFuncType(rctx, componentFunction);
 
     const canonOpts = resolveCanonicalOptions(canonicalFunctionLowerElem.options);
-    jsco_assert(canonOpts.stringEncoding === StringEncoding.Utf8,
-        () => `String encoding '${canonOpts.stringEncoding}' not yet supported, only UTF-8`);
+
+    // Set string encoding for this canonical function — read by createLifting/createLowering
+    const savedEncoding = rctx.stringEncoding;
+    rctx.stringEncoding = canonOpts.stringEncoding;
 
     const loweringBinder = createFunctionLowering(rctx, funcType);
+
+    rctx.stringEncoding = savedEncoding;
 
     return {
         callerElement: rargs.callerElement,

--- a/src/resolver/core-functions.ts
+++ b/src/resolver/core-functions.ts
@@ -4,7 +4,7 @@ import { ComponentExternalKind } from '../model/exports';
 import { ComponentImport } from '../model/imports';
 import { ComponentTypeIndex } from '../model/indices';
 import { ModelTag } from '../model/tags';
-import { ComponentTypeFunc, ComponentTypeInstance, InstanceTypeDeclaration } from '../model/types';
+import { ComponentType, ComponentTypeFunc, ComponentTypeInstance, InstanceTypeDeclaration } from '../model/types';
 import { debugStack, withDebugTrace, jsco_assert } from '../utils/assert';
 import { createFunctionLowering } from './binding';
 import { JsFunction } from './binding/types';
@@ -13,7 +13,7 @@ import { resolveComponentAliasCoreInstanceExport } from './core-exports';
 import type { ResolvedType } from './type-resolution';
 import { getCanonicalResourceId } from './context';
 import { getComponentFunction, getComponentType } from './indices';
-import { Resolver, BinderRes, ResolverRes, resolveCanonicalOptions } from './types';
+import { Resolver, BinderRes, ResolverRes, ResolverContext, resolveCanonicalOptions } from './types';
 
 
 export const resolveCoreFunction: Resolver<CoreFunction> = (rctx, rargs) => {
@@ -39,6 +39,13 @@ export const resolveCanonicalFunctionLower: Resolver<CanonicalFunctionLower> = (
     // CanonicalFunctionLower.func_index → componentFunction →
     //   CanonicalFunctionLift.type_index → ComponentTypeFunc
     //   ComponentAliasInstanceExport → resolvedTypes lookup
+    //
+    // Instance-local type isolation: resolveLoweredFuncType may call
+    // registerInstanceLocalTypes, which overwrites global resolvedTypes entries
+    // with instance-local types. createFunctionLowering deep-resolves all nested
+    // ComponentValTypeType references at creation time, so the binder closures
+    // never look up resolvedTypes at call time.
+
     const funcType = resolveLoweredFuncType(rctx, componentFunction);
 
     const canonOpts = resolveCanonicalOptions(canonicalFunctionLowerElem.options);
@@ -74,7 +81,7 @@ export const resolveCanonicalFunctionLower: Resolver<CanonicalFunctionLower> = (
     };
 };
 
-function resolveLoweredFuncType(rctx: import('./types').ResolverContext, componentFunction: ComponentFunction): ComponentTypeFunc {
+function resolveLoweredFuncType(rctx: ResolverContext, componentFunction: ComponentFunction): ComponentTypeFunc {
     // If the component function is a CanonicalFunctionLift, it has type_index directly
     if (componentFunction.tag === ModelTag.CanonicalFunctionLift) {
         const sectionFunType = getComponentType(rctx, componentFunction.type_index);
@@ -117,7 +124,7 @@ function resolveLoweredFuncType(rctx: import('./types').ResolverContext, compone
  * maxDepth prevents infinite loops in pathological cases.
  */
 function resolveAliasedFuncType(
-    rctx: import('./types').ResolverContext,
+    rctx: ResolverContext,
     alias: ComponentAliasInstanceExportType,
     maxDepth: number
 ): ComponentTypeFunc | undefined {
@@ -178,7 +185,7 @@ function resolveAliasedFuncType(
  * Type-creating declarations are: InstanceTypeDeclarationType, InstanceTypeDeclarationAlias,
  * and InstanceTypeDeclarationExport with a Type bound (SubResource or Eq).
  */
-function findLocalType(declarations: InstanceTypeDeclaration[], localTypeIndex: number): import('../model/types').ComponentType | undefined {
+function findLocalType(declarations: InstanceTypeDeclaration[], localTypeIndex: number): ComponentType | undefined {
     let typeIdx = 0;
     for (const decl of declarations) {
         if (isTypeCreatingDeclaration(decl)) {
@@ -220,13 +227,18 @@ function isTypeCreatingDeclaration(decl: InstanceTypeDeclaration): boolean {
  * can resolve Type(localIdx) references within function types from this instance.
  *
  * Instance type declarations create a local type index space. Function types
- * inside the instance reference these local indices. Since the resolver processes
- * one CanonicalFunctionLower at a time, we register the current instance's types
- * at their local indices. This overwrites any previous instance's types at the
- * same indices, which is fine because the function type's lifters/lowerers
- * are fully created before the next function is processed.
+ * inside the instance reference these local indices. Local types are written
+ * to resolvedTypes at their local indices, which may overwrite global entries.
+ *
  */
-function registerInstanceLocalTypes(rctx: import('./types').ResolverContext, instance: ComponentTypeInstance, instanceIndex: number): void {
+function registerInstanceLocalTypes(rctx: ResolverContext, instance: ComponentTypeInstance, instanceIndex: number): void {
+    // Snapshot global resolved types before local overwrites. Outer alias lookups must
+    // read original global types, not local types that were written earlier
+    // in this same loop (which may share the same numeric index).
+    // Note: canonicalResourceIds is NOT snapshotted — its entries are additive
+    // (local→canonical mappings needed by resource.drop/new/rep resolvers).
+    const globalResolvedTypes = new Map(rctx.resolvedTypes);
+
     const localTypes: (ResolvedType | undefined)[] = [];
     // Track which local indices are resources, keyed by export name
     const localResourceNames = new Map<number, string>();
@@ -267,8 +279,9 @@ function registerInstanceLocalTypes(rctx: import('./types').ResolverContext, ins
             case ModelTag.InstanceTypeDeclarationAlias: {
                 const alias = decl.value;
                 if (alias.tag === ModelTag.ComponentAliasOuter) {
-                    // Outer alias: look up the referenced type in the outer scope's resolvedTypes
-                    const outerResolved = rctx.resolvedTypes.get(alias.index as ComponentTypeIndex);
+                    // Outer alias: look up the referenced type in the snapshot of global types,
+                    // not the live map which may have been overwritten by earlier local types.
+                    const outerResolved = globalResolvedTypes.get(alias.index as ComponentTypeIndex);
                     if (outerResolved) {
                         resolved = outerResolved;
                     }

--- a/src/resolver/import-index.test.ts
+++ b/src/resolver/import-index.test.ts
@@ -1,0 +1,213 @@
+import { setConfiguration } from '../utils/assert';
+setConfiguration('Debug');
+
+import { ModelTag, WITSection } from '../model/tags';
+import { PrimitiveValType, ComponentTypeInstance, ComponentTypeFunc } from '../model/types';
+import { ComponentImport } from '../model/imports';
+import { createResolverContext } from './context';
+
+/**
+ * Tests for import→sort index mapping.
+ *
+ * Each import kind contributes to its respective sort's index space:
+ *   - ComponentTypeRefInstance → componentInstances[]
+ *   - ComponentTypeRefFunc → componentFunctions[]
+ *   - ComponentTypeRefComponent → componentInstances[] + componentSections[]
+ *
+ * importToInstanceIndex maps componentImports[] positions to componentInstances[]
+ * positions for instance-kind and component-kind imports.
+ */
+
+function makeInstanceType(funcName: string): ComponentTypeInstance {
+    return {
+        tag: ModelTag.ComponentTypeInstance,
+        declarations: [
+            {
+                tag: ModelTag.InstanceTypeDeclarationType,
+                value: {
+                    tag: ModelTag.ComponentTypeFunc,
+                    params: [
+                        { name: 'x', type: { tag: ModelTag.ComponentValTypePrimitive, value: PrimitiveValType.U32 } },
+                    ],
+                    results: { tag: ModelTag.ComponentFuncResultNamed, values: [] },
+                },
+            },
+            {
+                tag: ModelTag.InstanceTypeDeclarationExport,
+                name: { tag: ModelTag.ComponentExternNameKebab, name: funcName },
+                ty: { tag: ModelTag.ComponentTypeRefFunc, value: 0 },
+            },
+        ],
+    } as ComponentTypeInstance;
+}
+
+function makeFuncType(): ComponentTypeFunc {
+    return {
+        tag: ModelTag.ComponentTypeFunc,
+        params: [
+            { name: 'v', type: { tag: ModelTag.ComponentValTypePrimitive, value: PrimitiveValType.U32 } },
+        ],
+        results: { tag: ModelTag.ComponentFuncResultNamed, values: [] },
+    } as ComponentTypeFunc;
+}
+
+describe('import index mapping', () => {
+    test('instance import populates importToInstanceIndex', () => {
+        const instanceType = makeInstanceType('do-thing');
+        const funcType = makeFuncType();
+
+        const sections: WITSection[] = [
+            instanceType,
+            funcType,
+            {
+                tag: ModelTag.ComponentImport,
+                name: { tag: ModelTag.ComponentExternNameKebab, name: 'my-instance' },
+                ty: { tag: ModelTag.ComponentTypeRefInstance, value: 0 as any },
+            } as ComponentImport as any,
+        ];
+
+        const rctx = createResolverContext(sections, {});
+
+        // Import 0 (instance kind) → instance 0
+        expect(rctx.importToInstanceIndex.get(0)).toBe(0);
+        expect(rctx.indexes.componentInstances.length).toBe(1);
+        expect(rctx.indexes.componentImports.length).toBe(1);
+    });
+
+    test('func import before instance import shifts instance index', () => {
+        const instanceType = makeInstanceType('do-thing');
+        const funcType = makeFuncType();
+
+        const sections: WITSection[] = [
+            instanceType,
+            funcType,
+            // Import 0: func import
+            {
+                tag: ModelTag.ComponentImport,
+                name: { tag: ModelTag.ComponentExternNameKebab, name: 'my-func' },
+                ty: { tag: ModelTag.ComponentTypeRefFunc, value: 1 as any },
+            } as ComponentImport as any,
+            // Import 1: instance import
+            {
+                tag: ModelTag.ComponentImport,
+                name: { tag: ModelTag.ComponentExternNameKebab, name: 'my-instance' },
+                ty: { tag: ModelTag.ComponentTypeRefInstance, value: 0 as any },
+            } as ComponentImport as any,
+        ];
+
+        const rctx = createResolverContext(sections, {});
+
+        // Func import is import 0 — no instance mapping
+        expect(rctx.importToInstanceIndex.has(0)).toBe(false);
+        // Instance import is import 1 → instance 0
+        expect(rctx.importToInstanceIndex.get(1)).toBe(0);
+        // Func import contributed to componentFunctions[]
+        expect(rctx.indexes.componentFunctions.length).toBe(1);
+        expect(rctx.indexes.componentInstances.length).toBe(1);
+    });
+
+    test('multiple instance imports get correct indices', () => {
+        const instanceType0 = makeInstanceType('func-a');
+        const instanceType1 = makeInstanceType('func-b');
+
+        const sections: WITSection[] = [
+            instanceType0,
+            instanceType1,
+            // Import 0: instance
+            {
+                tag: ModelTag.ComponentImport,
+                name: { tag: ModelTag.ComponentExternNameKebab, name: 'iface-a' },
+                ty: { tag: ModelTag.ComponentTypeRefInstance, value: 0 as any },
+            } as ComponentImport as any,
+            // Import 1: instance
+            {
+                tag: ModelTag.ComponentImport,
+                name: { tag: ModelTag.ComponentExternNameKebab, name: 'iface-b' },
+                ty: { tag: ModelTag.ComponentTypeRefInstance, value: 1 as any },
+            } as ComponentImport as any,
+        ];
+
+        const rctx = createResolverContext(sections, {});
+
+        expect(rctx.importToInstanceIndex.get(0)).toBe(0);
+        expect(rctx.importToInstanceIndex.get(1)).toBe(1);
+        expect(rctx.indexes.componentInstances.length).toBe(2);
+    });
+
+    test('component import populates importToInstanceIndex and componentSections', () => {
+        const instanceType = makeInstanceType('do-thing');
+
+        const sections: WITSection[] = [
+            instanceType,
+            // Import 0: component import
+            {
+                tag: ModelTag.ComponentImport,
+                name: { tag: ModelTag.ComponentExternNameKebab, name: 'my-component' },
+                ty: { tag: ModelTag.ComponentTypeRefComponent, value: 0 as any },
+            } as ComponentImport as any,
+        ];
+
+        const rctx = createResolverContext(sections, {});
+
+        // Component import → instance 0
+        expect(rctx.importToInstanceIndex.get(0)).toBe(0);
+        expect(rctx.indexes.componentInstances.length).toBe(1);
+        // Also in component sort
+        expect(rctx.indexes.componentSections.length).toBe(1);
+    });
+
+    test('mixed imports: type, func, component, instance all get correct indices', () => {
+        const instanceType0 = makeInstanceType('func-a');
+        const funcType = makeFuncType();
+        const instanceType1 = makeInstanceType('func-b');
+
+        const sections: WITSection[] = [
+            instanceType0,
+            funcType,
+            instanceType1,
+            // Import 0: type import (no instance entry)
+            {
+                tag: ModelTag.ComponentImport,
+                name: { tag: ModelTag.ComponentExternNameKebab, name: 'my-type' },
+                ty: {
+                    tag: ModelTag.ComponentTypeRefType,
+                    value: { tag: ModelTag.TypeBoundsEq, value: 0 },
+                },
+            } as ComponentImport as any,
+            // Import 1: func import (no instance entry, goes to componentFunctions)
+            {
+                tag: ModelTag.ComponentImport,
+                name: { tag: ModelTag.ComponentExternNameKebab, name: 'my-func' },
+                ty: { tag: ModelTag.ComponentTypeRefFunc, value: 1 as any },
+            } as ComponentImport as any,
+            // Import 2: component import (instance entry + componentSections entry)
+            {
+                tag: ModelTag.ComponentImport,
+                name: { tag: ModelTag.ComponentExternNameKebab, name: 'my-component' },
+                ty: { tag: ModelTag.ComponentTypeRefComponent, value: 0 as any },
+            } as ComponentImport as any,
+            // Import 3: instance import (instance entry)
+            {
+                tag: ModelTag.ComponentImport,
+                name: { tag: ModelTag.ComponentExternNameKebab, name: 'my-instance' },
+                ty: { tag: ModelTag.ComponentTypeRefInstance, value: 2 as any },
+            } as ComponentImport as any,
+        ];
+
+        const rctx = createResolverContext(sections, {});
+
+        // Type import (0) — no instance mapping
+        expect(rctx.importToInstanceIndex.has(0)).toBe(false);
+        // Func import (1) — no instance mapping
+        expect(rctx.importToInstanceIndex.has(1)).toBe(false);
+        // Component import (2) → instance 0
+        expect(rctx.importToInstanceIndex.get(2)).toBe(0);
+        // Instance import (3) → instance 1
+        expect(rctx.importToInstanceIndex.get(3)).toBe(1);
+
+        expect(rctx.indexes.componentImports.length).toBe(4);
+        expect(rctx.indexes.componentInstances.length).toBe(2);
+        expect(rctx.indexes.componentFunctions.length).toBe(1);
+        expect(rctx.indexes.componentSections.length).toBe(1);
+    });
+});

--- a/src/resolver/index.ts
+++ b/src/resolver/index.ts
@@ -73,8 +73,15 @@ export async function createComponent<TJSExports>(modelOrComponentOrUrl: Compone
     // are not exported but still needed)
     const sortedPlan = sortPlanForExecution(plan);
 
+    // Free the large indexes structure — no longer needed after resolution.
+    // rctx.resolvedTypes and rctx.memoizeCache are still captured by binder
+    // closures (createLifting/createLowering use them at bind time).
+    // The innermost trampoline closures no longer capture rctx — they pre-capture
+    // only stringEncoding (number) and canonicalResourceIds (Map).
+    rctx.indexes = null!;
+
     const component: WasmComponent<TJSExports> = {
-        instantiate: (imports) => executePlan(rctx, sortedPlan, imports),
+        instantiate: (imports) => executePlan(sortedPlan, imports),
         plan: sortedPlan,
     };
     return component;

--- a/src/resolver/index.ts
+++ b/src/resolver/index.ts
@@ -88,7 +88,7 @@ export async function createComponent<TJSExports>(modelOrComponentOrUrl: Compone
             if (firstInstantiation) {
                 firstInstantiation = false;
                 // After first instantiation all memoize factories have run.
-                // Null heavy maps — memoize cache still serves cached lifters/lowerers.
+                // Null heavy maps — lift/lower caches still serve cached lifters/lowerers.
                 resolved.resolvedTypes = null!;
                 resolved.canonicalResourceIds = null!;
             }

--- a/src/resolver/index.ts
+++ b/src/resolver/index.ts
@@ -74,14 +74,26 @@ export async function createComponent<TJSExports>(modelOrComponentOrUrl: Compone
     const sortedPlan = sortPlanForExecution(plan);
 
     // Free the large indexes structure — no longer needed after resolution.
-    // rctx.resolvedTypes and rctx.memoizeCache are still captured by binder
-    // closures (createLifting/createLowering use them at bind time).
-    // The innermost trampoline closures no longer capture rctx — they pre-capture
-    // only stringEncoding (number) and canonicalResourceIds (Map).
+    // Binder closures capture rctx.resolved (ResolvedContext) — a separate object
+    // from rctx, so rctx itself (with indexes, importToInstanceIndex, etc.) is GC-eligible.
+    // The innermost trampoline closures don't capture resolved at all — they pre-capture
+    // only stringEncoding (number) and canonicalResourceIds (Map) values.
     rctx.indexes = null!;
 
+    const resolved = rctx.resolved;
+    let firstInstantiation = true;
     const component: WasmComponent<TJSExports> = {
-        instantiate: (imports) => executePlan(sortedPlan, imports),
+        instantiate: async (imports) => {
+            const result = await executePlan<TJSExports>(sortedPlan, imports);
+            if (firstInstantiation) {
+                firstInstantiation = false;
+                // After first instantiation all memoize factories have run.
+                // Null heavy maps — memoize cache still serves cached lifters/lowerers.
+                resolved.resolvedTypes = null!;
+                resolved.canonicalResourceIds = null!;
+            }
+            return result;
+        },
         plan: sortedPlan,
     };
     return component;

--- a/src/resolver/type-isolation.test.ts
+++ b/src/resolver/type-isolation.test.ts
@@ -12,7 +12,7 @@ import type { ResolvedType } from './type-resolution';
 /**
  * Tests for instance-local type isolation.
  *
- * registerInstanceLocalTypes writes instance-local types to rctx.resolvedTypes
+ * registerInstanceLocalTypes writes instance-local types to rctx.resolved.resolvedTypes
  * using local indices (0, 1, 2, ...). These can collide with global type indices.
  *
  * Fixed (intra-function): Outer alias lookups inside registerInstanceLocalTypes
@@ -22,17 +22,19 @@ import type { ResolvedType } from './type-resolution';
  * Fixed (inter-function): createFunctionLowering/createFunctionLifting deep-resolve
  * all nested ComponentValTypeType references at binder creation time using
  * deepResolveType. Binder closures (storeToMemory/loadFromMemory) never look up
- * rctx.resolvedTypes at call time, so local type overwrites are harmless.
+ * rctx.resolved.resolvedTypes at call time, so local type overwrites are harmless.
  */
 
 function createRctxWithGlobalTypes(globalTypes: [number, ResolvedType][]): ResolverContext {
     return {
-        memoizeCache: new Map(),
-        resolvedTypes: new Map(globalTypes.map(([idx, t]) => [idx as ComponentTypeIndex, t])),
-        canonicalResourceIds: new Map(),
+        resolved: {
+            memoizeCache: new Map(),
+            resolvedTypes: new Map(globalTypes.map(([idx, t]) => [idx as ComponentTypeIndex, t])),
+            canonicalResourceIds: new Map(),
+            usesNumberForInt64: false,
+            stringEncoding: StringEncoding.Utf8,
+        },
         resourceAliasGroups: new Map(),
-        usesNumberForInt64: false,
-        stringEncoding: StringEncoding.Utf8,
         validateTypes: true,
         indexes: {
             coreModules: [],
@@ -68,23 +70,23 @@ describe('instance-local type isolation', () => {
         ]);
 
         // Snapshot before local registration (as registerInstanceLocalTypes does)
-        const snapshot = new Map(rctx.resolvedTypes);
+        const snapshot = new Map(rctx.resolved.resolvedTypes);
 
         // Local type 0: new Enum (overwrites global index 0)
         const localEnum = {
             tag: ModelTag.ComponentTypeDefinedEnum as const,
             members: ['x', 'y'],
         };
-        rctx.resolvedTypes.set(0 as ComponentTypeIndex, localEnum as any);
+        rctx.resolved.resolvedTypes.set(0 as ComponentTypeIndex, localEnum as any);
 
         // Local type 1: outer alias to global index 0
-        // WITHOUT fix: would read rctx.resolvedTypes[0] = localEnum (WRONG)
+        // WITHOUT fix: would read rctx.resolved.resolvedTypes[0] = localEnum (WRONG)
         // WITH fix: reads from snapshot, gets globalRecord (CORRECT)
         const outerAliasResult = snapshot.get(0 as ComponentTypeIndex);
         expect(outerAliasResult).toBe(globalRecord);
 
         // The live map has the LOCAL type
-        expect(rctx.resolvedTypes.get(0 as ComponentTypeIndex)).toBe(localEnum);
+        expect(rctx.resolved.resolvedTypes.get(0 as ComponentTypeIndex)).toBe(localEnum);
     });
 
     test('memoizeCache keyed by type object identity, not by index', () => {
@@ -100,20 +102,20 @@ describe('instance-local type isolation', () => {
         ]);
 
         // Create a binder for the global record — populates memoizeCache
-        const lifter1 = createLifting(rctx, globalRecord as any);
+        const lifter1 = createLifting(rctx.resolved, globalRecord as any);
 
         // Overwrite index 0 with a local type (different object)
         const localType = {
             tag: ModelTag.ComponentTypeDefinedEnum as const,
             members: ['x', 'y'],
         };
-        rctx.resolvedTypes.set(0 as ComponentTypeIndex, localType as any);
+        rctx.resolved.resolvedTypes.set(0 as ComponentTypeIndex, localType as any);
 
         // Create binder for the local type — different cache key (different object)
-        const lifter2 = createLifting(rctx, localType as any);
+        const lifter2 = createLifting(rctx.resolved, localType as any);
 
         // Cache hit for the original global record (same object reference)
-        const lifter3 = createLifting(rctx, globalRecord as any);
+        const lifter3 = createLifting(rctx.resolved, globalRecord as any);
         expect(lifter3).toBe(lifter1); // same from cache
         expect(lifter2).not.toBe(lifter1); // different type → different binder
     });
@@ -123,18 +125,18 @@ describe('instance-local type isolation', () => {
         // because resource.drop/new/rep resolvers read them after
         // resolveCanonicalFunctionLower completes.
         const rctx = createRctxWithGlobalTypes([]);
-        rctx.canonicalResourceIds.set(0, 100);
-        rctx.canonicalResourceIds.set(1, 200);
+        rctx.resolved.canonicalResourceIds.set(0, 100);
+        rctx.resolved.canonicalResourceIds.set(1, 200);
 
         // Simulate local registration adding new entries
-        rctx.canonicalResourceIds.set(2, 300);
-        rctx.canonicalResourceIds.set(3, 400);
+        rctx.resolved.canonicalResourceIds.set(2, 300);
+        rctx.resolved.canonicalResourceIds.set(3, 400);
 
         // All entries present (additive, not restored)
-        expect(rctx.canonicalResourceIds.get(0)).toBe(100);
-        expect(rctx.canonicalResourceIds.get(1)).toBe(200);
-        expect(rctx.canonicalResourceIds.get(2)).toBe(300);
-        expect(rctx.canonicalResourceIds.get(3)).toBe(400);
+        expect(rctx.resolved.canonicalResourceIds.get(0)).toBe(100);
+        expect(rctx.resolved.canonicalResourceIds.get(1)).toBe(200);
+        expect(rctx.resolved.canonicalResourceIds.get(2)).toBe(300);
+        expect(rctx.resolved.canonicalResourceIds.get(3)).toBe(400);
     });
 
     test('local types overwrite global entries in resolvedTypes (harmless with deep-resolve)', () => {
@@ -153,17 +155,17 @@ describe('instance-local type isolation', () => {
             [0, globalRecord as any],
         ]);
 
-        expect(rctx.resolvedTypes.get(0 as ComponentTypeIndex)).toBe(globalRecord);
+        expect(rctx.resolved.resolvedTypes.get(0 as ComponentTypeIndex)).toBe(globalRecord);
 
         // Simulate registerInstanceLocalTypes overwriting
         const localType = {
             tag: ModelTag.ComponentTypeDefinedList as const,
             value: { tag: ModelTag.ComponentValTypePrimitive, value: PrimitiveValType.U8 },
         };
-        rctx.resolvedTypes.set(0 as ComponentTypeIndex, localType as any);
+        rctx.resolved.resolvedTypes.set(0 as ComponentTypeIndex, localType as any);
 
         // Global entry is overwritten in the map
-        expect(rctx.resolvedTypes.get(0 as ComponentTypeIndex)).toBe(localType);
+        expect(rctx.resolved.resolvedTypes.get(0 as ComponentTypeIndex)).toBe(localType);
     });
 
     test('deepResolveType replaces ComponentValTypeType with ComponentValTypeResolved', () => {
@@ -187,7 +189,7 @@ describe('instance-local type isolation', () => {
             ],
         };
 
-        const deepResolved = deepResolveType(rctx, record as any);
+        const deepResolved = deepResolveType(rctx.resolved, record as any);
 
         // Original is untouched
         expect(record.members[1].type.tag).toBe(ModelTag.ComponentValTypeType);
@@ -210,7 +212,7 @@ describe('instance-local type isolation', () => {
             members: ['x'],
         };
 
-        const resolved = resolveValType(rctx, {
+        const resolved = resolveValType(rctx.resolved, {
             tag: ModelTag.ComponentValTypeResolved,
             resolved: someType,
         });

--- a/src/resolver/type-isolation.test.ts
+++ b/src/resolver/type-isolation.test.ts
@@ -1,0 +1,220 @@
+import { setConfiguration } from '../utils/assert';
+setConfiguration('Debug');
+
+import { ModelTag } from '../model/tags';
+import { ComponentTypeIndex } from '../model/indices';
+import { PrimitiveValType } from '../model/types';
+import { ResolverContext, StringEncoding } from './types';
+import { createLifting } from './binding/to-abi';
+import { deepResolveType, resolveValType } from './calling-convention';
+import type { ResolvedType } from './type-resolution';
+
+/**
+ * Tests for instance-local type isolation.
+ *
+ * registerInstanceLocalTypes writes instance-local types to rctx.resolvedTypes
+ * using local indices (0, 1, 2, ...). These can collide with global type indices.
+ *
+ * Fixed (intra-function): Outer alias lookups inside registerInstanceLocalTypes
+ * use a snapshot of the original global state, so they read the correct global
+ * type instead of a previously-written local type that shares the same index.
+ *
+ * Fixed (inter-function): createFunctionLowering/createFunctionLifting deep-resolve
+ * all nested ComponentValTypeType references at binder creation time using
+ * deepResolveType. Binder closures (storeToMemory/loadFromMemory) never look up
+ * rctx.resolvedTypes at call time, so local type overwrites are harmless.
+ */
+
+function createRctxWithGlobalTypes(globalTypes: [number, ResolvedType][]): ResolverContext {
+    return {
+        memoizeCache: new Map(),
+        resolvedTypes: new Map(globalTypes.map(([idx, t]) => [idx as ComponentTypeIndex, t])),
+        canonicalResourceIds: new Map(),
+        resourceAliasGroups: new Map(),
+        usesNumberForInt64: false,
+        stringEncoding: StringEncoding.Utf8,
+        validateTypes: true,
+        indexes: {
+            coreModules: [],
+            coreInstances: [],
+            coreFunctions: [],
+            coreMemories: [],
+            coreGlobals: [],
+            coreTables: [],
+            componentImports: [],
+            componentExports: [],
+            componentInstances: [],
+            componentTypeResource: [],
+            componentFunctions: [],
+            componentTypes: [],
+            componentSections: [],
+        },
+    } as any as ResolverContext;
+}
+
+describe('instance-local type isolation', () => {
+    test('outer alias lookup uses snapshot, not live map', () => {
+        // Scenario: instance has local type 0 = new Enum, local type 1 = outer alias to global 0
+        // Without fix: local type 1 would get the Enum (from local 0) instead of the global Record
+        const globalRecord = {
+            tag: ModelTag.ComponentTypeDefinedRecord as const,
+            members: [
+                { name: 'x', type: { tag: ModelTag.ComponentValTypePrimitive, value: PrimitiveValType.U32 } },
+            ],
+        };
+
+        const rctx = createRctxWithGlobalTypes([
+            [0, globalRecord as any],
+        ]);
+
+        // Snapshot before local registration (as registerInstanceLocalTypes does)
+        const snapshot = new Map(rctx.resolvedTypes);
+
+        // Local type 0: new Enum (overwrites global index 0)
+        const localEnum = {
+            tag: ModelTag.ComponentTypeDefinedEnum as const,
+            members: ['x', 'y'],
+        };
+        rctx.resolvedTypes.set(0 as ComponentTypeIndex, localEnum as any);
+
+        // Local type 1: outer alias to global index 0
+        // WITHOUT fix: would read rctx.resolvedTypes[0] = localEnum (WRONG)
+        // WITH fix: reads from snapshot, gets globalRecord (CORRECT)
+        const outerAliasResult = snapshot.get(0 as ComponentTypeIndex);
+        expect(outerAliasResult).toBe(globalRecord);
+
+        // The live map has the LOCAL type
+        expect(rctx.resolvedTypes.get(0 as ComponentTypeIndex)).toBe(localEnum);
+    });
+
+    test('memoizeCache keyed by type object identity, not by index', () => {
+        const globalRecord = {
+            tag: ModelTag.ComponentTypeDefinedRecord as const,
+            members: [
+                { name: 'a', type: { tag: ModelTag.ComponentValTypePrimitive, value: PrimitiveValType.U32 } },
+            ],
+        };
+
+        const rctx = createRctxWithGlobalTypes([
+            [0, globalRecord as any],
+        ]);
+
+        // Create a binder for the global record — populates memoizeCache
+        const lifter1 = createLifting(rctx, globalRecord as any);
+
+        // Overwrite index 0 with a local type (different object)
+        const localType = {
+            tag: ModelTag.ComponentTypeDefinedEnum as const,
+            members: ['x', 'y'],
+        };
+        rctx.resolvedTypes.set(0 as ComponentTypeIndex, localType as any);
+
+        // Create binder for the local type — different cache key (different object)
+        const lifter2 = createLifting(rctx, localType as any);
+
+        // Cache hit for the original global record (same object reference)
+        const lifter3 = createLifting(rctx, globalRecord as any);
+        expect(lifter3).toBe(lifter1); // same from cache
+        expect(lifter2).not.toBe(lifter1); // different type → different binder
+    });
+
+    test('canonicalResourceIds entries are additive across instances', () => {
+        // canonicalResourceIds set by registerInstanceLocalTypes persist
+        // because resource.drop/new/rep resolvers read them after
+        // resolveCanonicalFunctionLower completes.
+        const rctx = createRctxWithGlobalTypes([]);
+        rctx.canonicalResourceIds.set(0, 100);
+        rctx.canonicalResourceIds.set(1, 200);
+
+        // Simulate local registration adding new entries
+        rctx.canonicalResourceIds.set(2, 300);
+        rctx.canonicalResourceIds.set(3, 400);
+
+        // All entries present (additive, not restored)
+        expect(rctx.canonicalResourceIds.get(0)).toBe(100);
+        expect(rctx.canonicalResourceIds.get(1)).toBe(200);
+        expect(rctx.canonicalResourceIds.get(2)).toBe(300);
+        expect(rctx.canonicalResourceIds.get(3)).toBe(400);
+    });
+
+    test('local types overwrite global entries in resolvedTypes (harmless with deep-resolve)', () => {
+        // Local types still overwrite globals in the resolvedTypes map,
+        // but this is now safe because binder closures use deep-resolved types
+        // that carry resolved values inline (ComponentValTypeResolved), so they
+        // never look up resolvedTypes at call time.
+        const globalRecord = {
+            tag: ModelTag.ComponentTypeDefinedRecord as const,
+            members: [
+                { name: 'x', type: { tag: ModelTag.ComponentValTypePrimitive, value: PrimitiveValType.U32 } },
+            ],
+        };
+
+        const rctx = createRctxWithGlobalTypes([
+            [0, globalRecord as any],
+        ]);
+
+        expect(rctx.resolvedTypes.get(0 as ComponentTypeIndex)).toBe(globalRecord);
+
+        // Simulate registerInstanceLocalTypes overwriting
+        const localType = {
+            tag: ModelTag.ComponentTypeDefinedList as const,
+            value: { tag: ModelTag.ComponentValTypePrimitive, value: PrimitiveValType.U8 },
+        };
+        rctx.resolvedTypes.set(0 as ComponentTypeIndex, localType as any);
+
+        // Global entry is overwritten in the map
+        expect(rctx.resolvedTypes.get(0 as ComponentTypeIndex)).toBe(localType);
+    });
+
+    test('deepResolveType replaces ComponentValTypeType with ComponentValTypeResolved', () => {
+        // A record with a member whose type is ComponentValTypeType (index reference)
+        // After deep-resolve, the member type is ComponentValTypeResolved carrying
+        // the resolved type inline, making it independent of resolvedTypes.
+        const innerEnum = {
+            tag: ModelTag.ComponentTypeDefinedEnum as const,
+            members: ['a', 'b', 'c'],
+        };
+
+        const rctx = createRctxWithGlobalTypes([
+            [5, innerEnum as any],
+        ]);
+
+        const record = {
+            tag: ModelTag.ComponentTypeDefinedRecord as const,
+            members: [
+                { name: 'primitiveField', type: { tag: ModelTag.ComponentValTypePrimitive, value: PrimitiveValType.U32 } },
+                { name: 'typeRefField', type: { tag: ModelTag.ComponentValTypeType, value: 5 } },
+            ],
+        };
+
+        const deepResolved = deepResolveType(rctx, record as any);
+
+        // Original is untouched
+        expect(record.members[1].type.tag).toBe(ModelTag.ComponentValTypeType);
+
+        // Deep-resolved clone has ComponentValTypeResolved for the type reference
+        const deepRecord = deepResolved as any;
+        expect(deepRecord.tag).toBe(ModelTag.ComponentTypeDefinedRecord);
+        expect(deepRecord.members[0].type.tag).toBe(ModelTag.ComponentValTypePrimitive);
+        expect(deepRecord.members[1].type.tag).toBe(ModelTag.ComponentValTypeResolved);
+        expect(deepRecord.members[1].type.resolved).toBe(innerEnum);
+    });
+
+    test('resolveValType handles ComponentValTypeResolved without map lookup', () => {
+        // After deep-resolve, resolveValType should return the inline resolved type
+        // even if resolvedTypes map is empty (no lookup needed).
+        const rctx = createRctxWithGlobalTypes([]);
+
+        const someType = {
+            tag: ModelTag.ComponentTypeDefinedEnum as const,
+            members: ['x'],
+        };
+
+        const resolved = resolveValType(rctx, {
+            tag: ModelTag.ComponentValTypeResolved,
+            resolved: someType,
+        });
+
+        expect(resolved).toBe(someType);
+    });
+});

--- a/src/resolver/type-isolation.test.ts
+++ b/src/resolver/type-isolation.test.ts
@@ -28,7 +28,7 @@ import type { ResolvedType } from './type-resolution';
 function createRctxWithGlobalTypes(globalTypes: [number, ResolvedType][]): ResolverContext {
     return {
         resolved: {
-            memoizeCache: new Map(),
+            liftingCache: new Map(), loweringCache: new Map(),
             resolvedTypes: new Map(globalTypes.map(([idx, t]) => [idx as ComponentTypeIndex, t])),
             canonicalResourceIds: new Map(),
             usesNumberForInt64: false,

--- a/src/resolver/type-validation.test.ts
+++ b/src/resolver/type-validation.test.ts
@@ -9,7 +9,7 @@ function makeMinimalRctx(overrides?: Partial<ResolverContext['indexes']>): Resol
         usesNumberForInt64: false,
         validateTypes: true,
         wasmInstantiate: async (m, i) => WebAssembly.instantiate(m, i),
-        memoizeCache: new Map(),
+        liftingCache: new Map(), loweringCache: new Map(),
         resolvedTypes: new Map(),
         importToInstanceIndex: new Map(),
         canonicalResourceIds: new Map(),

--- a/src/resolver/type-validation.ts
+++ b/src/resolver/type-validation.ts
@@ -121,7 +121,16 @@ function compareFuncTypes(name: string, declared: ComponentFuncType, actual: Com
 
 function valTypesEqual(a: ComponentValType, b: ComponentValType): boolean {
     if (a.tag !== b.tag) return false;
-    return a.value === b.value;
+    if (a.tag === ModelTag.ComponentValTypePrimitive && b.tag === ModelTag.ComponentValTypePrimitive) {
+        return a.value === b.value;
+    }
+    if (a.tag === ModelTag.ComponentValTypeType && b.tag === ModelTag.ComponentValTypeType) {
+        return a.value === b.value;
+    }
+    if (a.tag === ModelTag.ComponentValTypeResolved && b.tag === ModelTag.ComponentValTypeResolved) {
+        return a.resolved === b.resolved;
+    }
+    return false;
 }
 
 export function validateImportType(rctx: ResolverContext, componentImport: ComponentImport): void {

--- a/src/resolver/types.ts
+++ b/src/resolver/types.ts
@@ -92,7 +92,8 @@ export type IndexedModel = {
 /** Subset of ResolverContext retained for binding/call time. Separate object so
  *  binder closures don't keep the heavy IndexedModel alive. */
 export type ResolvedContext = {
-    memoizeCache: Map<unknown, unknown>
+    liftingCache: Map<unknown, unknown>
+    loweringCache: Map<unknown, unknown>
     resolvedTypes: Map<ComponentTypeIndex, ResolvedType>
     /** Maps type index → canonical resource ID. Multiple type aliases to the same resource share one ID. */
     canonicalResourceIds: Map<number, number>

--- a/src/resolver/types.ts
+++ b/src/resolver/types.ts
@@ -89,21 +89,27 @@ export type IndexedModel = {
     componentSections: ComponentSection[]// append to componentTypes
 }
 
+/** Subset of ResolverContext retained for binding/call time. Separate object so
+ *  binder closures don't keep the heavy IndexedModel alive. */
+export type ResolvedContext = {
+    memoizeCache: Map<unknown, unknown>
+    resolvedTypes: Map<ComponentTypeIndex, ResolvedType>
+    /** Maps type index → canonical resource ID. Multiple type aliases to the same resource share one ID. */
+    canonicalResourceIds: Map<number, number>
+    /** Current string encoding for the canonical function being resolved. Set per lift/lower. */
+    stringEncoding: StringEncoding
+    usesNumberForInt64: boolean
+}
+
 export type ResolverContext = {
+    resolved: ResolvedContext;
     indexes: IndexedModel;
     /** Maps componentImports[] index → componentInstances[] index for instance imports */
     importToInstanceIndex: Map<number, number>;
-    /** Maps type index → canonical resource ID. Multiple type aliases to the same resource share one ID. */
-    canonicalResourceIds: Map<number, number>;
     /** Maps "instanceIndex:exportName" → canonical resource ID for resource type alias deduplication */
     resourceAliasGroups: Map<string, number>;
-    usesNumberForInt64: boolean
     validateTypes: boolean
-    /** Current string encoding for the canonical function being resolved. Set per lift/lower. */
-    stringEncoding: StringEncoding
     wasmInstantiate: (moduleObject: WebAssembly.Module, importObject?: WebAssembly.Imports) => Promise<WebAssembly.Instance>
-    memoizeCache: Map<unknown, unknown>
-    resolvedTypes: Map<ComponentTypeIndex, ResolvedType>
 }
 
 export type InstanceTable = {

--- a/src/resolver/types.ts
+++ b/src/resolver/types.ts
@@ -99,6 +99,8 @@ export type ResolverContext = {
     resourceAliasGroups: Map<string, number>;
     usesNumberForInt64: boolean
     validateTypes: boolean
+    /** Current string encoding for the canonical function being resolved. Set per lift/lower. */
+    stringEncoding: StringEncoding
     wasmInstantiate: (moduleObject: WebAssembly.Module, importObject?: WebAssembly.Imports) => Promise<WebAssembly.Instance>
     memoizeCache: Map<unknown, unknown>
     resolvedTypes: Map<ComponentTypeIndex, ResolvedType>

--- a/tests/resolve-hello.ts
+++ b/tests/resolve-hello.ts
@@ -50,22 +50,22 @@ export async function resolveJCO(sections: WITModel, imports: any) {
     };
 
     const { sendMessage } = componentImports['hello:city/city@0.1.0'];
-    const stringToJs = createLowering(rctx, {
+    const stringToJs = createLowering(rctx.resolved, {
         tag: ModelTag.ComponentValTypePrimitive,
         value: PrimitiveValType.String,
     });
 
-    const stringFromJs = createLifting(rctx, {
+    const stringFromJs = createLifting(rctx.resolved, {
         tag: ModelTag.ComponentValTypePrimitive,
         value: PrimitiveValType.String,
     });
 
-    const numberToUint32 = createLifting(rctx, {
+    const numberToUint32 = createLifting(rctx.resolved, {
         tag: ModelTag.ComponentValTypePrimitive,
         value: PrimitiveValType.U32,
     });
 
-    const bigIntToInt64 = createLifting(rctx, {
+    const bigIntToInt64 = createLifting(rctx.resolved, {
         tag: ModelTag.ComponentValTypePrimitive,
         value: PrimitiveValType.S64,
     });

--- a/tests/resolve-hello.ts
+++ b/tests/resolve-hello.ts
@@ -42,7 +42,7 @@ export const expectedContext: Partial<ResolverContext> = {
 
 export async function resolveJCO(sections: WITModel, imports: any) {
     const rctx: ResolverContext = createResolverContext(sections, {});
-    const ctx: BindingContext = createBindingContext(rctx, imports);
+    const ctx: BindingContext = createBindingContext(imports);
     const wasmInstantiate = WebAssembly.instantiate;
 
     const componentImports = (imports ? imports : {}) as {


### PR DESCRIPTION
## Summary

Restructures the resolver to separate resolution-time state from bind-time state, eliminating unnecessary closure captures and fixing a memoization cache collision bug. Adds comprehensive test coverage for the new structure.

## Changes

### ResolvedContext extraction

Extracted `ResolvedContext` as a separate type from `ResolverContext`, containing only the 6 fields needed by binding closures at call time:

- `liftingCache`, `loweringCache` — memoize caches (split from single `memoizeCache`, see below)
- `resolvedTypes` — type index → resolved type map
- `canonicalResourceIds` — type index → canonical resource ID map
- `stringEncoding` — current encoding for canonical function being resolved
- `usesNumberForInt64` — whether to use Number instead of BigInt for i64

`ResolverContext` now has a `resolved: ResolvedContext` field. Binder closures capture only `resolved`, so the heavy `indexes` / `IndexedModel` structure becomes GC-eligible after `createComponent` returns.

### Closure elimination for sizeOf / alignOf / flatCount

`sizeOf`, `alignOf`, `sizeOfValType`, `alignOfValType`, and `flatCount` are now pure functions — they no longer take `rctx` and operate only on their `ResolvedType` argument. This removes `rctx` captures from the innermost trampoline closures in `to-abi.ts` and `to-js.ts`.

### Type isolation via `ComponentValTypeResolved`

Added `ModelTag.ComponentValTypeResolved` and `ComponentValTypeResolved` type to the model. During resolution, `deepResolveType` replaces `ComponentValTypeType` references (which are index-based, shared across parent types) with `ComponentValTypeResolved` nodes that carry a direct reference to the resolved type. This prevents type resolution cross-talk when the same `ComponentValType` object appears in multiple parent types.

### Import index mapping for ComponentTypeRefComponent

`ComponentTypeRefComponent` imports now correctly contribute to the instance sort and component sort index spaces in `createResolverContext`. Previously, component-kind imports were not tracked, causing `ComponentInstanceInstantiate.component_index` to reference the wrong entry.

### Memoization cache collision fix

`createLifting` and `createLowering` previously shared a single `memoizeCache` keyed by model object identity. When a `ComponentValTypeType` resolved to the same `ResolvedType` object for both directions, whichever direction ran first would poison the cache — the other direction would get a lifter instead of a lowerer (or vice versa). Fixed by splitting into `liftingCache` (used by `createLifting` / `createFunctionLifting`) and `loweringCache` (used by `createLowering` / `createFunctionLowering`).

### GC lifecycle

After `createComponent` returns, `rctx.indexes` is nulled. After first `instantiate()` call, `resolved.resolvedTypes` and `resolved.canonicalResourceIds` are nulled — the lifting/lowering caches still serve cached closures that have already captured what they need.

### Inline `import()` cleanup

Replaced inline `import('...').SomeType` type annotations with top-level `import type` statements per project conventions.

## New tests

| File | Tests | Coverage |
|------|-------|----------|
| `type-isolation.test.ts` | 5 | `ComponentValTypeResolved` tag, `deepResolveType` isolation, nested types |
| `import-index.test.ts` | 5 | Component-kind import index mapping, mixed import kinds |
| `memoization.test.ts` | 14 | Cache hit/miss by identity, lifting/lowering isolation, `stringEncoding` and `usesNumberForInt64` baked at creation, per-rctx cache isolation |

Updated all existing binding test files to use the new `ResolvedContext` shape (`liftingCache` + `loweringCache` instead of `memoizeCache`).

## Verification

- 0 lint errors/warnings
- Build clean (`dist/index.js` + `dist/index.d.ts`)
- 823 tests passing across 28 suites
