### PR TITLE
Minification, hardening, and public API cleanup

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -74,6 +74,11 @@ jobs:
     - name: Run integration tests
       run: node --experimental-vm-modules --experimental-wasm-jspi node_modules/.bin/jest --no-coverage --testPathPattern='integration\.test|echo-reactor\.test|hello-world\.test'
 
+    - name: Run integration tests (Release)
+      env:
+        Configuration: Release
+      run: node --experimental-vm-modules --experimental-wasm-jspi node_modules/.bin/jest --no-coverage --testPathPattern='integration\.test|echo-reactor\.test|hello-world\.test'
+
     - name: Upload wasm artifacts
       uses: actions/upload-artifact@v6
       if: always()

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -27,6 +27,34 @@ jobs:
     - name: Run Jest unit tests (${{ matrix.configuration }})
       run: node --experimental-vm-modules --experimental-wasm-jspi node_modules/.bin/jest --no-coverage --testPathIgnorePatterns integration.test echo-reactor.test hello-world.test
 
+  release-bundle-size:
+    runs-on: ubuntu-latest
+    env:
+      Configuration: Release
+      ContinuousIntegrationBuild: 'true'
+
+    steps:
+    - uses: actions/checkout@v6
+    - uses: actions/setup-node@v5
+      with:
+        node-version: 24
+
+    - name: Install npm dependencies
+      run: npm ci
+
+    - name: Build release bundle
+      run: npm run build
+
+    - name: Assert bundle size under 90 KB
+      run: |
+        size=$(stat --format=%s dist/index.js)
+        echo "Release bundle size: ${size} bytes"
+        if [ "$size" -gt 92160 ]; then
+          echo "::error::Release bundle size ${size} bytes exceeds 90 KB limit (92160 bytes)"
+          exit 1
+        fi
+        echo "✓ Bundle size OK (under 90 KB)"
+
   browser-tests:
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -8,8 +8,12 @@ on:
 jobs:
   unit-tests:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        configuration: [Debug, Release]
     env:
       NODE_OPTIONS: --experimental-vm-modules
+      Configuration: ${{ matrix.configuration }}
 
     steps:
     - uses: actions/checkout@v6
@@ -20,7 +24,7 @@ jobs:
     - name: Install npm dependencies
       run: npm ci
 
-    - name: Run Jest unit tests
+    - name: Run Jest unit tests (${{ matrix.configuration }})
       run: node --experimental-vm-modules --experimental-wasm-jspi node_modules/.bin/jest --no-coverage --testPathIgnorePatterns integration.test echo-reactor.test hello-world.test
 
   browser-tests:

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Prints `Welcome to Kladno!` to the console.
 |--------|---------|-------------|
 | `validateTypes` | `false` | Validate export/import type annotations against the component's type index. Catches kind mismatches and structural function type differences. |
 | `useNumberForInt64` | `false` | Use `number` instead of `bigint` for 64-bit integers |
+| `noJspi` | `false` | Disable JSPI wrapping of exports. `false` (default) — all exports are wrapped with `WebAssembly.promising()` and return `Promise`s. `true` — no exports are wrapped (synchronous, blocking WASI will not work). `string[]` — only the listed export names are synchronous; all others remain async. |
 | `wasmInstantiate` | `WebAssembly.instantiate` | Custom WASM instantiation function (used by JSPI wrapping) |
 
 See [./usage.mjs](./usage.mjs) for full commented sample.
@@ -84,7 +85,20 @@ WASI preview 2 APIs that perform blocking operations require [JSPI (JavaScript P
 - **Node.js:** `--experimental-wasm-jspi`
 - **Chrome:** Enable via `chrome://flags/#enable-experimental-webassembly-jspi`
 
-Non-blocking WASI APIs (random, wall-clock, environment, exit) and pure component model bindings (no WASI) work without JSPI. Pass `{ noJspi: true }` to `instantiateWasiComponent` to disable JSPI wrapping.
+**Exports are async by default:** When JSPI is available (the default), all component exports are wrapped with `WebAssembly.promising()` and return `Promise`s. Callers must `await` every export call:
+```js
+const result = await ns.myFunction(arg); // ← await required
+```
+You can selectively opt out specific exports with an array of export names:
+```js
+// Only 'my:pkg/fast-path' is synchronous; everything else returns Promises
+const component = await createComponent(wasm, {
+    noJspi: ['my:pkg/fast-path']
+});
+```
+Pass `{ noJspi: true }` to `createComponent` or `instantiateWasiComponent` to make all exports synchronous — but blocking WASI operations will not work in that mode.
+
+Non-blocking WASI APIs (random, wall-clock, environment, exit) and pure component model bindings (no WASI) work with `{ noJspi: true }`.
 
 **WASIp3 outlook:** WASI preview 3 replaces the current blocking-call pattern with native async support via the Component Model [async proposal](https://github.com/WebAssembly/component-model/blob/main/design/mvp/Async.md) (`stream`, `future`, `error-context` built-ins). On the **host side**, this eliminates JSPI — async imports/exports become first-class, and the host can use native `Promise`/`async` directly. However, **guest components** compiled from languages with synchronous calling conventions (C, C#, Rust with blocking I/O) still need the async canonical ABI to suspend the WASM stack while awaiting the host's async result. In a browser JS host, that suspension mechanism **is JSPI** (`WebAssembly.Suspending` + `WebAssembly.promising`). JSPI is only fully eliminated when the guest uses async/callback patterns natively (e.g., async Rust reactor). jsco plans to support WASIp3 when the spec stabilizes.
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Prints `Welcome to Kladno!` to the console.
 | Option | Default | Description |
 |--------|---------|-------------|
 | `validateTypes` | `false` | Validate export/import type annotations against the component's type index. Catches kind mismatches and structural function type differences. |
-| `useNumberForInt64` | `false` | Use `number` instead of `bigint` for 64-bit integers |
+| `useNumberForInt64` | `false` | Convert 64-bit integers to `number` instead of `bigint`. `false` (default) — all exports use `bigint`. `true` — all exports use `number`. `string[]` — only the listed export names use `number`; all others use `bigint`. |
 | `noJspi` | `false` | Disable JSPI wrapping of exports. `false` (default) — all exports are wrapped with `WebAssembly.promising()` and return `Promise`s. `true` — no exports are wrapped (synchronous, blocking WASI will not work). `string[]` — only the listed export names are synchronous; all others remain async. |
 | `wasmInstantiate` | `WebAssembly.instantiate` | Custom WASM instantiation function (used by JSPI wrapping) |
 

--- a/TODO.md
+++ b/TODO.md
@@ -8,10 +8,6 @@
 - fused adapters https://github.com/bytecodealliance/wasmtime/blob/main/crates/environ/src/component/translate/adapt.rs
 - validate string, list and buffer sizes to not cause OOM or out of range
 - validate HTTP API to not receive evil payload, like unlimited body or headers
-- limit runtime allocations: `for (const { name, lowerer } of fieldLowerers)`
-- use decoder/encoder `String.fromCharCode(...u16)`
-- unroll `loadFromMemory` during binding
-- free memory and resource handles
 - make i64 -> number vs bingint configurable again, add tests for it. usesNumberForInt64
 - multiple memories
 

--- a/TODO.md
+++ b/TODO.md
@@ -51,13 +51,6 @@
 - re-entry on async - queue
 - zero copy bring-your-own-buffer
 
-# Minification
-- `jsco_assert` should be eliminated in Release builds via Rollup plugin (inline macro)
-- Jest can't resolve Rollup virtual modules for build-time constant injection
-- `isDebug` doesn't trim, use proper virtual/const import
-- internal fields
-- refactor string constants
-
 # Demo
 - create demo web site
 - command line in the browser for WASI cli programs

--- a/jest.config.js
+++ b/jest.config.js
@@ -10,6 +10,11 @@ export default {
         '^.+\\.(ts|tsx|js|jsx)$': ['@swc/jest'],
         //"^.+\\.(ts|tsx)$": "ts-jest"
     },
+    moduleNameMapper: {
+        '^env:isDebug$': '<rootDir>/src/__mocks__/env-isDebug.ts',
+        '^env:configuration$': '<rootDir>/src/__mocks__/env-configuration.ts',
+        '^env:gitHash$': '<rootDir>/src/__mocks__/env-gitHash.ts',
+    },
     transformIgnorePatterns: [
         '/node_modules/@bytecodealliance/'
     ],

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -21,6 +21,7 @@ let gitHash = (() => {
 
 const constants = {
     'env:configuration': `export default "${configuration}"`,
+    'env:isDebug': `export default ${isDebug}`,
     'env:gitHash': `export default "${gitHash}"`,
 };
 const plugins = isDebug ? [] : [terser({

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -31,12 +31,15 @@ const plugins = isDebug ? [] : [terser({
         module: true,
         ecma: 2022,
         toplevel: true,
-        passes: 4
+        passes: 4,
+        computed_props: false,
     },
     mangle: {
         module: true,
         toplevel: true,
-        // TODO properties:{ reserved:['leb128DecodeU64', 'leb128DecodeI64', 'leb128EncodeU64', 'leb128EncodeI64', 'buf', 'memory'] }
+        properties: {
+            keep_quoted: 'strict',
+        },
     },
 })];
 const banner = '//! Pavel Savara licenses this file to you under the MIT license.\n';

--- a/src/__mocks__/env-configuration.ts
+++ b/src/__mocks__/env-configuration.ts
@@ -1,0 +1,2 @@
+const configuration = process.env.Configuration ?? 'Debug';
+export default configuration;

--- a/src/__mocks__/env-gitHash.ts
+++ b/src/__mocks__/env-gitHash.ts
@@ -1,0 +1,1 @@
+export default 'test';

--- a/src/__mocks__/env-isDebug.ts
+++ b/src/__mocks__/env-isDebug.ts
@@ -1,0 +1,2 @@
+const isDebug = process.env.Configuration !== 'Release';
+export default isDebug;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,44 @@
+/**
+ * String constants for property names that cross the public API boundary.
+ *
+ * Used with computed bracket notation (e.g. `obj[EXPORTS]`, `{ [TAG]: OK }`)
+ * to prevent terser property mangling from renaming them. Terser cannot
+ * resolve computed property accesses, so these are inherently safe.
+ *
+ * Internal-only property names do NOT need constants — terser mangles them
+ * consistently within the bundle.
+ */
+
+// WasmComponent
+export const INSTANTIATE = 'instantiate';
+
+// WasmComponentInstance
+export const EXPORTS = 'exports';
+export const ABORT = 'abort';
+
+// Variant / Result convention — consumers create { tag: 'ok', val: 42 }
+export const TAG = 'tag';
+export const VAL = 'val';
+export const OK = 'ok';
+export const ERR = 'err';
+
+// getBuildInfo() return value
+export const GIT_HASH = 'gitHash';
+export const CONFIGURATION = 'configuration';
+
+// ComponentFactoryOptions
+export const USE_NUMBER_FOR_INT64 = 'useNumberForInt64';
+export const VALIDATE_TYPES = 'validateTypes';
+export const NO_JSPI = 'noJspi';
+export const WASM_INSTANTIATE = 'wasmInstantiate';
+export const VERBOSE = 'verbose';
+export const LOGGER = 'logger';
+
+// ParserOptions
+export const OTHER_SECTION_DATA = 'otherSectionData';
+export const COMPILE_STREAMING = 'compileStreaming';
+export const PROCESS_CUSTOM_SECTION = 'processCustomSection';
+
+// WebAssembly JSPI experimental APIs (not in terser's domprops)
+export const PROMISING = 'promising';
+export const SUSPENDING = 'Suspending';

--- a/src/host/wasip2/echo-reactor.test.ts
+++ b/src/host/wasip2/echo-reactor.test.ts
@@ -14,6 +14,7 @@ import { createWasiHost } from './index';
 initializeAsserts();
 
 const echoWasm = './integration-tests/target/wasm32-wasip1/release/echo_reactor.wasm';
+const echoOptions = (verbose: ReturnType<typeof useVerboseOnFailure>) => ({ noJspi: true as const, ...verboseOptions(verbose) });
 
 interface SinkReport {
     label: string;
@@ -54,7 +55,7 @@ describe('echo-reactor', () => {
     describe('primitives', () => {
         test('echo-bool round-trips true and false', () => runWithVerbose(verbose, async () => {
             const { imports, primitiveReports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const ns = (instance.exports['jsco:test/echo-primitives@0.1.0']) as any;
 
@@ -66,7 +67,7 @@ describe('echo-reactor', () => {
 
         test('echo-u8 round-trips boundary values', async () => {
             const { imports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const ns = (instance.exports['jsco:test/echo-primitives@0.1.0']) as any;
 
@@ -77,7 +78,7 @@ describe('echo-reactor', () => {
 
         test('echo-u16 round-trips', async () => {
             const { imports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const ns = (instance.exports['jsco:test/echo-primitives@0.1.0']) as any;
 
@@ -87,7 +88,7 @@ describe('echo-reactor', () => {
 
         test('echo-u32 round-trips', async () => {
             const { imports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const ns = (instance.exports['jsco:test/echo-primitives@0.1.0']) as any;
 
@@ -97,7 +98,7 @@ describe('echo-reactor', () => {
 
         test('echo-u64 round-trips as bigint', async () => {
             const { imports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const ns = (instance.exports['jsco:test/echo-primitives@0.1.0']) as any;
 
@@ -107,7 +108,7 @@ describe('echo-reactor', () => {
 
         test('echo-s8 round-trips negative values', async () => {
             const { imports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const ns = (instance.exports['jsco:test/echo-primitives@0.1.0']) as any;
 
@@ -118,7 +119,7 @@ describe('echo-reactor', () => {
 
         test('echo-s16 round-trips', async () => {
             const { imports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const ns = (instance.exports['jsco:test/echo-primitives@0.1.0']) as any;
 
@@ -128,7 +129,7 @@ describe('echo-reactor', () => {
 
         test('echo-s32 round-trips', async () => {
             const { imports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const ns = (instance.exports['jsco:test/echo-primitives@0.1.0']) as any;
 
@@ -138,7 +139,7 @@ describe('echo-reactor', () => {
 
         test('echo-s64 round-trips as bigint', async () => {
             const { imports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const ns = (instance.exports['jsco:test/echo-primitives@0.1.0']) as any;
 
@@ -148,7 +149,7 @@ describe('echo-reactor', () => {
 
         test('echo-f32 round-trips', async () => {
             const { imports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const ns = (instance.exports['jsco:test/echo-primitives@0.1.0']) as any;
 
@@ -159,7 +160,7 @@ describe('echo-reactor', () => {
 
         test('echo-f64 round-trips', async () => {
             const { imports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const ns = (instance.exports['jsco:test/echo-primitives@0.1.0']) as any;
 
@@ -170,7 +171,7 @@ describe('echo-reactor', () => {
 
         test('echo-char round-trips', async () => {
             const { imports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const ns = (instance.exports['jsco:test/echo-primitives@0.1.0']) as any;
 
@@ -180,7 +181,7 @@ describe('echo-reactor', () => {
 
         test('echo-string round-trips', async () => {
             const { imports, primitiveReports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const ns = (instance.exports['jsco:test/echo-primitives@0.1.0']) as any;
 
@@ -195,7 +196,7 @@ describe('echo-reactor', () => {
     describe('compound types', () => {
         test('echo-tuple2 round-trips', async () => {
             const { imports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const ns = (instance.exports['jsco:test/echo-compound@0.1.0']) as any;
 
@@ -205,7 +206,7 @@ describe('echo-reactor', () => {
 
         test('echo-tuple3 round-trips', async () => {
             const { imports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const ns = (instance.exports['jsco:test/echo-compound@0.1.0']) as any;
 
@@ -217,7 +218,7 @@ describe('echo-reactor', () => {
 
         test('echo-record round-trips point', async () => {
             const { imports, recordReports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const ns = (instance.exports['jsco:test/echo-compound@0.1.0']) as any;
 
@@ -228,7 +229,7 @@ describe('echo-reactor', () => {
 
         test('echo-nested-record round-trips labeled point', async () => {
             const { imports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const ns = (instance.exports['jsco:test/echo-compound@0.1.0']) as any;
 
@@ -245,7 +246,7 @@ describe('echo-reactor', () => {
 
         test('echo-nested-record with none elevation', async () => {
             const { imports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const ns = (instance.exports['jsco:test/echo-compound@0.1.0']) as any;
 
@@ -261,7 +262,7 @@ describe('echo-reactor', () => {
 
         test('echo-list-u8 round-trips bytes', async () => {
             const { imports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const ns = (instance.exports['jsco:test/echo-compound@0.1.0']) as any;
 
@@ -272,7 +273,7 @@ describe('echo-reactor', () => {
 
         test('echo-list-string round-trips', async () => {
             const { imports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const ns = (instance.exports['jsco:test/echo-compound@0.1.0']) as any;
 
@@ -282,7 +283,7 @@ describe('echo-reactor', () => {
 
         test('echo-list-record round-trips list of points', async () => {
             const { imports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const ns = (instance.exports['jsco:test/echo-compound@0.1.0']) as any;
 
@@ -297,7 +298,7 @@ describe('echo-reactor', () => {
 
         test('echo-option-u32 with some and none', async () => {
             const { imports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const ns = (instance.exports['jsco:test/echo-compound@0.1.0']) as any;
 
@@ -307,7 +308,7 @@ describe('echo-reactor', () => {
 
         test('echo-option-string with some and none', async () => {
             const { imports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const ns = (instance.exports['jsco:test/echo-compound@0.1.0']) as any;
 
@@ -317,7 +318,7 @@ describe('echo-reactor', () => {
 
         test('echo-result ok and err variants', async () => {
             const { imports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const ns = (instance.exports['jsco:test/echo-compound@0.1.0']) as any;
 
@@ -331,7 +332,7 @@ describe('echo-reactor', () => {
     describe('algebraic types', () => {
         test('echo-enum round-trips all variants', async () => {
             const { imports, primitiveReports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const ns = (instance.exports['jsco:test/echo-algebraic@0.1.0']) as any;
 
@@ -346,7 +347,7 @@ describe('echo-reactor', () => {
 
         test('echo-flags round-trips individual and combined', async () => {
             const { imports, primitiveReports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const ns = (instance.exports['jsco:test/echo-algebraic@0.1.0']) as any;
 
@@ -365,7 +366,7 @@ describe('echo-reactor', () => {
 
         test('echo-variant round-trips all cases', async () => {
             const { imports, primitiveReports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const ns = (instance.exports['jsco:test/echo-algebraic@0.1.0']) as any;
 
@@ -393,7 +394,7 @@ describe('echo-reactor', () => {
     describe('sink round-trip', () => {
         test('wasm calls JS sink imports during echo', async () => {
             const { imports, primitiveReports, recordReports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
 
             const prim = (instance.exports['jsco:test/echo-primitives@0.1.0']) as any;
@@ -412,7 +413,7 @@ describe('echo-reactor', () => {
     describe('edge cases', () => {
         test('result with ok-only payload', async () => {
             const { imports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const ns = (instance.exports['jsco:test/echo-edge-cases@0.1.0']) as any;
 
@@ -424,7 +425,7 @@ describe('echo-reactor', () => {
 
         test('result with err-only payload', async () => {
             const { imports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const ns = (instance.exports['jsco:test/echo-edge-cases@0.1.0']) as any;
 
@@ -436,7 +437,7 @@ describe('echo-reactor', () => {
 
         test('result with no payloads', async () => {
             const { imports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const ns = (instance.exports['jsco:test/echo-edge-cases@0.1.0']) as any;
 
@@ -448,7 +449,7 @@ describe('echo-reactor', () => {
 
         test('nested option round-trips all cases', async () => {
             const { imports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const ns = (instance.exports['jsco:test/echo-edge-cases@0.1.0']) as any;
 
@@ -462,7 +463,7 @@ describe('echo-reactor', () => {
 
         test('tuple5 round-trips', async () => {
             const { imports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const ns = (instance.exports['jsco:test/echo-edge-cases@0.1.0']) as any;
 
@@ -472,7 +473,7 @@ describe('echo-reactor', () => {
 
         test('list of options round-trips', async () => {
             const { imports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const ns = (instance.exports['jsco:test/echo-edge-cases@0.1.0']) as any;
 
@@ -482,7 +483,7 @@ describe('echo-reactor', () => {
 
         test('list of results round-trips', async () => {
             const { imports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const ns = (instance.exports['jsco:test/echo-edge-cases@0.1.0']) as any;
 
@@ -497,7 +498,7 @@ describe('echo-reactor', () => {
 
         test('option containing list', async () => {
             const { imports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const ns = (instance.exports['jsco:test/echo-edge-cases@0.1.0']) as any;
 
@@ -509,7 +510,7 @@ describe('echo-reactor', () => {
 
         test('list of tuples round-trips', async () => {
             const { imports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const ns = (instance.exports['jsco:test/echo-edge-cases@0.1.0']) as any;
 
@@ -520,7 +521,7 @@ describe('echo-reactor', () => {
 
         test('big-flags (32 members) round-trips', async () => {
             const { imports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const ns = (instance.exports['jsco:test/echo-edge-cases@0.1.0']) as any;
 
@@ -552,7 +553,7 @@ describe('echo-reactor', () => {
 
         test('zero-length list round-trips', async () => {
             const { imports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const ns = (instance.exports['jsco:test/echo-edge-cases@0.1.0']) as any;
 
@@ -562,7 +563,7 @@ describe('echo-reactor', () => {
 
         test('empty string round-trips', async () => {
             const { imports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const ns = (instance.exports['jsco:test/echo-edge-cases@0.1.0']) as any;
 
@@ -571,7 +572,7 @@ describe('echo-reactor', () => {
 
         test('result with resource in error tuple (ok case)', async () => {
             const { imports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const ns = (instance.exports['jsco:test/echo-edge-cases@0.1.0']) as any;
 
@@ -583,7 +584,7 @@ describe('echo-reactor', () => {
 
         test('result with resource in error tuple (err case)', () => runWithVerbose(verbose, async () => {
             const { imports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const ns = (instance.exports['jsco:test/echo-edge-cases@0.1.0']) as any;
 
@@ -607,7 +608,7 @@ describe('echo-reactor', () => {
 
         test('f32/f64 special values', () => runWithVerbose(verbose, async () => {
             const { imports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const prim = (instance.exports['jsco:test/echo-primitives@0.1.0']) as any;
 
@@ -627,7 +628,7 @@ describe('echo-reactor', () => {
 
         test('string edge cases: CJK, emoji, surrogate-safe', () => runWithVerbose(verbose, async () => {
             const { imports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const prim = (instance.exports['jsco:test/echo-primitives@0.1.0']) as any;
 
@@ -645,7 +646,7 @@ describe('echo-reactor', () => {
     describe('resources', () => {
         test('accumulator: constructor and get-total', () => runWithVerbose(verbose, async () => {
             const { imports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const ns = (instance.exports['jsco:test/echo-resources@0.1.0']) as any;
 
@@ -656,7 +657,7 @@ describe('echo-reactor', () => {
 
         test('accumulator: snapshot creates independent copy', () => runWithVerbose(verbose, async () => {
             const { imports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const ns = (instance.exports['jsco:test/echo-resources@0.1.0']) as any;
 
@@ -669,7 +670,7 @@ describe('echo-reactor', () => {
 
         test('transform-owned: doubles value via own transfer', () => runWithVerbose(verbose, async () => {
             const { imports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const ns = (instance.exports['jsco:test/echo-resources@0.1.0']) as any;
 
@@ -680,7 +681,7 @@ describe('echo-reactor', () => {
 
         test('inspect-borrowed: reads without consuming', () => runWithVerbose(verbose, async () => {
             const { imports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const ns = (instance.exports['jsco:test/echo-resources@0.1.0']) as any;
 
@@ -695,7 +696,7 @@ describe('echo-reactor', () => {
 
         test('merge-accumulators: combines two owned resources', () => runWithVerbose(verbose, async () => {
             const { imports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const ns = (instance.exports['jsco:test/echo-resources@0.1.0']) as any;
 
@@ -707,7 +708,7 @@ describe('echo-reactor', () => {
 
         test('byte-buffer: constructor, read, remaining, is-empty lifecycle', () => runWithVerbose(verbose, async () => {
             const { imports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const ns = (instance.exports['jsco:test/echo-resources@0.1.0']) as any;
 
@@ -732,7 +733,7 @@ describe('echo-reactor', () => {
 
         test('echo-buffer: round-trips a buffer resource', () => runWithVerbose(verbose, async () => {
             const { imports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const ns = (instance.exports['jsco:test/echo-resources@0.1.0']) as any;
 
@@ -747,7 +748,7 @@ describe('echo-reactor', () => {
 
         test('multiple resource types: accumulator and byte-buffer coexist', () => runWithVerbose(verbose, async () => {
             const { imports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const ns = (instance.exports['jsco:test/echo-resources@0.1.0']) as any;
 
@@ -767,7 +768,7 @@ describe('echo-reactor', () => {
 
         test('transform-owned chained: transform twice', () => runWithVerbose(verbose, async () => {
             const { imports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const ns = (instance.exports['jsco:test/echo-resources@0.1.0']) as any;
 
@@ -781,7 +782,7 @@ describe('echo-reactor', () => {
 
         test('snapshot creates independent handle', () => runWithVerbose(verbose, async () => {
             const { imports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const ns = (instance.exports['jsco:test/echo-resources@0.1.0']) as any;
 
@@ -796,7 +797,7 @@ describe('echo-reactor', () => {
 
         test('many resources: sequential create and use', () => runWithVerbose(verbose, async () => {
             const { imports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const ns = (instance.exports['jsco:test/echo-resources@0.1.0']) as any;
 
@@ -813,7 +814,7 @@ describe('echo-reactor', () => {
 
         test('inspect-borrowed after merge', () => runWithVerbose(verbose, async () => {
             const { imports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const ns = (instance.exports['jsco:test/echo-resources@0.1.0']) as any;
 
@@ -828,7 +829,7 @@ describe('echo-reactor', () => {
     describe('complex types', () => {
         test('echo-deeply-nested: team with nested person/address', () => runWithVerbose(verbose, async () => {
             const { imports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const ns = (instance.exports['jsco:test/echo-complex@0.1.0']) as any;
 
@@ -866,7 +867,7 @@ describe('echo-reactor', () => {
 
         test('echo-list-of-records: list<person>', () => runWithVerbose(verbose, async () => {
             const { imports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const ns = (instance.exports['jsco:test/echo-complex@0.1.0']) as any;
 
@@ -882,7 +883,7 @@ describe('echo-reactor', () => {
 
         test('echo-tuple-of-records: tuple<person, address>', () => runWithVerbose(verbose, async () => {
             const { imports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const ns = (instance.exports['jsco:test/echo-complex@0.1.0']) as any;
 
@@ -895,7 +896,7 @@ describe('echo-reactor', () => {
 
         test('echo-complex-variant: all geometry arms', () => runWithVerbose(verbose, async () => {
             const { imports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const ns = (instance.exports['jsco:test/echo-complex@0.1.0']) as any;
 
@@ -937,7 +938,7 @@ describe('echo-reactor', () => {
 
         test('echo-message: all message arms', () => runWithVerbose(verbose, async () => {
             const { imports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const ns = (instance.exports['jsco:test/echo-complex@0.1.0']) as any;
 
@@ -996,7 +997,7 @@ describe('echo-reactor', () => {
 
         test('echo-kitchen-sink: record with all compound fields', () => runWithVerbose(verbose, async () => {
             const { imports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const ns = (instance.exports['jsco:test/echo-complex@0.1.0']) as any;
 
@@ -1019,7 +1020,7 @@ describe('echo-reactor', () => {
 
         test('echo-kitchen-sink: none and err variants', () => runWithVerbose(verbose, async () => {
             const { imports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const ns = (instance.exports['jsco:test/echo-complex@0.1.0']) as any;
 
@@ -1041,7 +1042,7 @@ describe('echo-reactor', () => {
 
         test('echo-nested-lists: list<list<u32>>', () => runWithVerbose(verbose, async () => {
             const { imports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const ns = (instance.exports['jsco:test/echo-complex@0.1.0']) as any;
 
@@ -1052,7 +1053,7 @@ describe('echo-reactor', () => {
 
         test('echo-option-record: some and none', () => runWithVerbose(verbose, async () => {
             const { imports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const ns = (instance.exports['jsco:test/echo-complex@0.1.0']) as any;
 
@@ -1065,7 +1066,7 @@ describe('echo-reactor', () => {
 
         test('echo-result-record: ok and err', () => runWithVerbose(verbose, async () => {
             const { imports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const ns = (instance.exports['jsco:test/echo-complex@0.1.0']) as any;
 
@@ -1081,7 +1082,7 @@ describe('echo-reactor', () => {
 
         test('echo-list-of-variants: list<geometry>', () => runWithVerbose(verbose, async () => {
             const { imports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const ns = (instance.exports['jsco:test/echo-complex@0.1.0']) as any;
 
@@ -1102,7 +1103,7 @@ describe('echo-reactor', () => {
     describe('post-return and memory lifecycle', () => {
         test('repeated string-returning exports deallocate correctly', () => runWithVerbose(verbose, async () => {
             const { imports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const prim = (instance.exports['jsco:test/echo-primitives@0.1.0']) as any;
             const comp = (instance.exports['jsco:test/echo-compound@0.1.0']) as any;
@@ -1117,7 +1118,7 @@ describe('echo-reactor', () => {
 
         test('mixed type exports in sequence', () => runWithVerbose(verbose, async () => {
             const { imports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const prim = (instance.exports['jsco:test/echo-primitives@0.1.0']) as any;
             const comp = (instance.exports['jsco:test/echo-compound@0.1.0']) as any;
@@ -1145,7 +1146,7 @@ describe('echo-reactor', () => {
 
         test('deeply-nested post-return deallocation stress loop', () => runWithVerbose(verbose, async () => {
             const { imports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const ns = (instance.exports['jsco:test/echo-complex@0.1.0']) as any;
 
@@ -1190,7 +1191,7 @@ describe('echo-reactor', () => {
 
         test('list-of-records post-return deallocation stress loop', () => runWithVerbose(verbose, async () => {
             const { imports } = createEchoImports();
-            const component = await createComponent(echoWasm, verboseOptions(verbose));
+            const component = await createComponent(echoWasm, echoOptions(verbose));
             const instance = await component.instantiate(imports);
             const ns = (instance.exports['jsco:test/echo-complex@0.1.0']) as any;
 

--- a/src/host/wasip2/echo-reactor.test.ts
+++ b/src/host/wasip2/echo-reactor.test.ts
@@ -9,7 +9,7 @@
 import { createComponent } from '../../resolver';
 import { initializeAsserts } from '../../utils/assert';
 import { useVerboseOnFailure, verboseOptions, runWithVerbose } from '../../test-utils/verbose-logger';
-import { createWasiHost } from './index';
+import { createWasiP2Host } from './index';
 
 initializeAsserts();
 
@@ -30,11 +30,11 @@ interface RecordReport {
 function createEchoImports() {
     const primitiveReports: SinkReport[] = [];
     const recordReports: RecordReport[] = [];
-    const wasiImports = createWasiHost();
+    const wasiExports = createWasiP2Host();
 
     return {
         imports: {
-            ...wasiImports,
+            ...wasiExports,
             'jsco:test/echo-sink@0.1.0': {
                 'report-primitive': (label: string, value: string) => {
                     primitiveReports.push({ label, value });

--- a/src/host/wasip2/echo-reactor.test.ts
+++ b/src/host/wasip2/echo-reactor.test.ts
@@ -7,11 +7,11 @@
  */
 
 import { createComponent } from '../../resolver';
-import { setConfiguration } from '../../utils/assert';
+import { initializeAsserts } from '../../utils/assert';
 import { useVerboseOnFailure, verboseOptions, runWithVerbose } from '../../test-utils/verbose-logger';
 import { createWasiHost } from './index';
 
-setConfiguration('Debug');
+initializeAsserts();
 
 const echoWasm = './integration-tests/target/wasm32-wasip1/release/echo_reactor.wasm';
 

--- a/src/host/wasip2/hello-world.test.ts
+++ b/src/host/wasip2/hello-world.test.ts
@@ -60,7 +60,7 @@ describe('hello-world component', () => {
                 const runNs = (instance.exports['wasi:cli/run@0.2.11']
                     ?? instance.exports['wasi:cli/run']) as any;
                 expect(runNs).toBeDefined();
-                const result = runNs.run();
+                const result = await runNs.run();
                 exitCode = (result?.tag === 'ok') ? 0 : 1;
             } catch (e) {
                 if (e instanceof WasiExit) {

--- a/src/host/wasip2/hello-world.test.ts
+++ b/src/host/wasip2/hello-world.test.ts
@@ -11,7 +11,7 @@
 
 import { parse } from '../../parser';
 import { createComponent } from '../../resolver';
-import { createWasiHost } from './index';
+import { createWasiP2Host } from './index';
 import { WasiExit } from './types';
 import { instantiateWasiComponent } from './instantiate';
 import { initializeAsserts } from '../../utils/assert';
@@ -48,7 +48,7 @@ describe('hello-world component', () => {
     describe('instantiation', () => {
         test('stdout captures println output', () => runWithVerbose(verbose, async () => {
             const chunks: Uint8Array[] = [];
-            const wasiImports = createWasiHost({
+            const wasiExports = createWasiP2Host({
                 stdout: (bytes) => { chunks.push(new Uint8Array(bytes)); },
             });
 
@@ -56,7 +56,7 @@ describe('hello-world component', () => {
 
             let exitCode: number | undefined;
             try {
-                const instance = await component.instantiate(wasiImports);
+                const instance = await component.instantiate(wasiExports);
                 const runNs = (instance.exports['wasi:cli/run@0.2.11']
                     ?? instance.exports['wasi:cli/run']) as any;
                 expect(runNs).toBeDefined();
@@ -64,7 +64,7 @@ describe('hello-world component', () => {
                 exitCode = (result?.tag === 'ok') ? 0 : 1;
             } catch (e) {
                 if (e instanceof WasiExit) {
-                    exitCode = e.code;
+                    exitCode = e.status;
                 } else {
                     throw e;
                 }

--- a/src/host/wasip2/hello-world.test.ts
+++ b/src/host/wasip2/hello-world.test.ts
@@ -14,10 +14,10 @@ import { createComponent } from '../../resolver';
 import { createWasiHost } from './index';
 import { WasiExit } from './types';
 import { instantiateWasiComponent } from './instantiate';
-import { setConfiguration } from '../../utils/assert';
+import { initializeAsserts } from '../../utils/assert';
 import { useVerboseOnFailure, verboseOptions, runWithVerbose } from '../../test-utils/verbose-logger';
 
-setConfiguration('Debug');
+initializeAsserts();
 
 const helloWasm = './integration-tests/target/wasm32-wasip1/release/hello_world.wasm';
 

--- a/src/host/wasip2/index.ts
+++ b/src/host/wasip2/index.ts
@@ -1,7 +1,7 @@
 /**
  * WASI Preview 2 Host — Browser-native implementation
  *
- * Entry point for the WASI host. Provides createWasiHost(config) factory
+ * Entry point for the WASI host. Provides createWasiP2Host(config) factory
  * that returns a flat JsImports object ready to pass to instantiate().
  *
  * Implemented interfaces:
@@ -54,7 +54,7 @@ export type { SocketErrorCode, IpAddressFamily, IpAddress, IpSocketAddress, Sock
 export { createNetwork, createTcpSocket, createUdpSocket, resolveAddresses, instanceNetwork } from './sockets';
 
 /** JsImports-compatible flat map: { 'wasi:cli/stdin': { 'get-stdin': fn }, ... } */
-export type WasiHostImports = Record<string, Record<string, Function>>;
+export type WasiP2HostExports = Record<string, Record<string, Function>>;
 
 /**
  * Create a flat JsImports object containing all WASI host implementations.
@@ -68,7 +68,7 @@ export type WasiHostImports = Record<string, Record<string, Function>>;
  * @param config Optional configuration for CLI, filesystem, HTTP, etc.
  * @returns A flat JsImports object ready to pass to instantiate() or merge with other imports.
  */
-export function createWasiHost(config?: WasiConfig): WasiHostImports {
+export function createWasiP2Host(config?: WasiConfig): WasiP2HostExports {
     const random = createWasiRandom();
     const insecure = createWasiRandomInsecure();
     const insecureSeed = createWasiRandomInsecureSeed();
@@ -78,7 +78,7 @@ export function createWasiHost(config?: WasiConfig): WasiHostImports {
     const filesystem = createWasiFilesystem(config?.fs);
     const outgoingHandler = createOutgoingHandler();
 
-    const result: WasiHostImports = {};
+    const result: WasiP2HostExports = {};
     const versions = ['0.2.0', '0.2.1', '0.2.2', '0.2.3', '0.2.4', '0.2.5', '0.2.6', '0.2.7', '0.2.8', '0.2.9', '0.2.10', '0.2.11'];
     const wasiPrefix = 'wasi:';
     const methodPrefix = '[method]';

--- a/src/host/wasip2/index.ts
+++ b/src/host/wasip2/index.ts
@@ -78,161 +78,164 @@ export function createWasiHost(config?: WasiConfig): WasiHostImports {
     const filesystem = createWasiFilesystem(config?.fs);
     const outgoingHandler = createOutgoingHandler();
 
-    const interfaces: Record<string, Record<string, Function>> = {
-        // wasi:random/*
-        'wasi:random/random': {
-            'get-random-bytes': random.getRandomBytes,
-            'get-random-u64': random.getRandomU64,
-        },
-        'wasi:random/insecure': {
-            'get-insecure-random-bytes': insecure.getInsecureRandomBytes,
-            'get-insecure-random-u64': insecure.getInsecureRandomU64,
-        },
-        'wasi:random/insecure-seed': {
-            'insecure-seed': insecureSeed.insecureSeed,
-        },
-
-        // wasi:clocks/*
-        'wasi:clocks/wall-clock': {
-            'now': wallClock.now,
-            'resolution': wallClock.resolution,
-        },
-        'wasi:clocks/monotonic-clock': {
-            'now': monotonicClock.now,
-            'resolution': monotonicClock.resolution,
-            'subscribe-duration': monotonicClock.subscribeDuration,
-            'subscribe-instant': monotonicClock.subscribeInstant,
-        },
-
-        // wasi:io/*
-        'wasi:io/poll': {
-            'poll': poll,
-        },
-        // wasi:io/error — resource methods dispatched on WasiError objects
-        'wasi:io/error': {
-            '[method]error.to-debug-string': (self: WasiError) => self.toDebugString(),
-            '[resource-drop]error': (_self: WasiError) => { /* GC handles cleanup */ },
-        },
-        // wasi:io/streams — resource methods dispatched on stream objects
-        'wasi:io/streams': {
-            // InputStream methods
-            '[method]input-stream.read': (self: WasiInputStream, len: bigint) => self.read(len),
-            '[method]input-stream.blocking-read': (self: WasiInputStream, len: bigint) => self.blockingRead(len),
-            '[method]input-stream.skip': (self: WasiInputStream, len: bigint) => self.skip(len),
-            '[method]input-stream.blocking-skip': (self: WasiInputStream, len: bigint) => self.blockingSkip(len),
-            '[method]input-stream.subscribe': (self: WasiInputStream) => self.subscribe(),
-            '[resource-drop]input-stream': (_self: WasiInputStream) => { /* GC handles cleanup */ },
-            // OutputStream methods
-            '[method]output-stream.check-write': (self: WasiOutputStream) => self.checkWrite(),
-            '[method]output-stream.write': (self: WasiOutputStream, contents: Uint8Array) => self.write(contents),
-            '[method]output-stream.blocking-write-and-flush': (self: WasiOutputStream, contents: Uint8Array) => self.blockingWriteAndFlush(contents),
-            '[method]output-stream.flush': (self: WasiOutputStream) => self.flush(),
-            '[method]output-stream.blocking-flush': (self: WasiOutputStream) => self.blockingFlush(),
-            '[method]output-stream.write-zeroes': (self: WasiOutputStream, len: bigint) => self.writeZeroes(len),
-            '[method]output-stream.blocking-write-zeroes-and-flush': (self: WasiOutputStream, len: bigint) => self.blockingWriteZeroesAndFlush(len),
-            '[method]output-stream.subscribe': (self: WasiOutputStream) => self.subscribe(),
-            '[resource-drop]output-stream': (_self: WasiOutputStream) => { /* GC handles cleanup */ },
-        },
-
-        // wasi:cli/*
-        'wasi:cli/environment': {
-            'get-environment': cli.environment.getEnvironment,
-            'get-arguments': cli.environment.getArguments,
-            'initial-cwd': cli.environment.initialCwd,
-        },
-        'wasi:cli/exit': {
-            'exit': cli.exit.exit,
-        },
-        'wasi:cli/stdin': {
-            'get-stdin': cli.stdin.getStdin,
-        },
-        'wasi:cli/stdout': {
-            'get-stdout': cli.stdout.getStdout,
-        },
-        'wasi:cli/stderr': {
-            'get-stderr': cli.stderr.getStderr,
-        },
-        'wasi:cli/terminal-input': {
-            'get-terminal-stdin': cli.terminalInput.getTerminalStdin,
-        },
-        'wasi:cli/terminal-stdout': {
-            'get-terminal-stdout': cli.terminalOutput.getTerminalStdout,
-        },
-        'wasi:cli/terminal-stderr': {
-            'get-terminal-stderr': cli.terminalOutput.getTerminalStderr,
-        },
-
-        // wasi:filesystem/*
-        'wasi:filesystem/types': {
-            'filesystem-error-code': (_err: WasiError) => {
-                // In our VFS, stream errors don't carry filesystem error codes.
-                // Return none (undefined) per the WIT spec.
-                return undefined;
-            },
-            '[resource-drop]descriptor': (_self: WasiDescriptor) => { /* GC handles cleanup */ },
-            '[method]descriptor.read-via-stream': (self: WasiDescriptor, offset: bigint) => self.readViaStream(offset),
-            '[method]descriptor.write-via-stream': (self: WasiDescriptor, offset: bigint) => self.writeViaStream(offset),
-            '[method]descriptor.append-via-stream': (self: WasiDescriptor) => self.appendViaStream(),
-            '[method]descriptor.get-type': (self: WasiDescriptor) => self.getType(),
-            '[method]descriptor.stat': (self: WasiDescriptor) => self.stat(),
-            '[method]descriptor.stat-at': (self: WasiDescriptor, pathFlags: any, path: string) => self.statAt(pathFlags, path),
-            '[method]descriptor.open-at': (self: WasiDescriptor, pathFlags: any, path: string, openFlags: any, descFlags: any) => self.openAt(pathFlags, path, openFlags, descFlags),
-            '[method]descriptor.read-directory': (self: WasiDescriptor) => self.readDirectory(),
-            '[method]descriptor.create-directory-at': (self: WasiDescriptor, path: string) => self.createDirectoryAt(path),
-            '[method]descriptor.remove-directory-at': (self: WasiDescriptor, path: string) => self.removeDirectoryAt(path),
-            '[method]descriptor.unlink-file-at': (self: WasiDescriptor, path: string) => self.unlinkFileAt(path),
-            '[method]descriptor.read': (self: WasiDescriptor, length: bigint, offset: bigint) => self.read(length, offset),
-            '[method]descriptor.write': (self: WasiDescriptor, buffer: Uint8Array, offset: bigint) => self.write(buffer, offset),
-            '[method]descriptor.get-flags': (self: WasiDescriptor) => self.getFlags(),
-            '[method]descriptor.set-size': (self: WasiDescriptor, size: bigint) => self.setSize(size),
-            '[method]descriptor.sync': (self: WasiDescriptor) => self.sync(),
-            '[method]descriptor.sync-data': (self: WasiDescriptor) => self.syncData(),
-            '[method]descriptor.metadata-hash': (self: WasiDescriptor) => self.metadataHash(),
-            '[method]descriptor.metadata-hash-at': (self: WasiDescriptor, pathFlags: any, path: string) => self.metadataHashAt(pathFlags, path),
-            '[method]descriptor.rename-at': (self: WasiDescriptor, oldPath: string, newDesc: WasiDescriptor, newPath: string) => self.renameAt(oldPath, newDesc, newPath),
-            '[method]descriptor.set-times': (self: WasiDescriptor, atime: any, mtime: any) => self.setTimes(atime, mtime),
-            '[method]descriptor.set-times-at': (self: WasiDescriptor, pathFlags: any, path: string, atime: any, mtime: any) => self.setTimesAt(pathFlags, path, atime, mtime),
-            '[method]descriptor.is-same-object': (self: WasiDescriptor, other: WasiDescriptor) => self.isSameObject(other),
-            '[method]descriptor.advise': (self: WasiDescriptor, offset: bigint, length: bigint, advice: string) => self.advise(offset, length, advice),
-            '[resource-drop]directory-entry-stream': (_self: WasiDirectoryEntryStream) => { /* GC handles cleanup */ },
-            '[method]directory-entry-stream.read-directory-entry': (self: WasiDirectoryEntryStream) => self.readDirectoryEntry(),
-        },
-        'wasi:filesystem/preopens': {
-            'get-directories': filesystem.preopens.getDirectories,
-        },
-
-        // wasi:http/*
-        'wasi:http/outgoing-handler': {
-            'handle': outgoingHandler.handle,
-        },
-
-        // wasi:sockets/* (all stubs)
-        'wasi:sockets/instance-network': {
-            'instance-network': instanceNetwork,
-        },
-        'wasi:sockets/tcp-create-socket': {
-            'create-tcp-socket': (family: any) => createTcpSocket(family),
-        },
-        'wasi:sockets/udp-create-socket': {
-            'create-udp-socket': (family: any) => createUdpSocket(family),
-        },
-        'wasi:sockets/ip-name-lookup': {
-            'resolve-addresses': (network: any, name: string) => resolveAddresses(network, name),
-        },
-    };
-
-    // Register versioned aliases — WASI components use versioned import names
-    // like 'wasi:cli/stdin@0.2.0'. Register all known WASI preview 2 versions.
     const result: WasiHostImports = {};
     const versions = ['0.2.0', '0.2.1', '0.2.2', '0.2.3', '0.2.4', '0.2.5', '0.2.6', '0.2.7', '0.2.8', '0.2.9', '0.2.10', '0.2.11'];
-    for (const [iface, methods] of Object.entries(interfaces)) {
-        // Unversioned
-        result[iface] = methods;
-        // Versioned
-        for (const version of versions) {
-            result[`${iface}@${version}`] = methods;
-        }
+    const wasiPrefix = 'wasi:';
+    const methodPrefix = '[method]';
+    const resourceDropPrefix = '[resource-drop]';
+    const method = (cls: string, name: string) => methodPrefix + cls + '.' + name;
+    const drop = (cls: string) => resourceDropPrefix + cls;
+    function register(ns: string, methods: Record<string, Function>) {
+        const key = wasiPrefix + ns;
+        result[key] = methods;
+        for (const v of versions) result[key + '@' + v] = methods;
     }
+
+    // wasi:random/*
+    register('random/random', {
+        'get-random-bytes': random.getRandomBytes,
+        'get-random-u64': random.getRandomU64,
+    });
+    register('random/insecure', {
+        'get-insecure-random-bytes': insecure.getInsecureRandomBytes,
+        'get-insecure-random-u64': insecure.getInsecureRandomU64,
+    });
+    register('random/insecure-seed', {
+        'insecure-seed': insecureSeed.insecureSeed,
+    });
+
+    // wasi:clocks/*
+    register('clocks/wall-clock', {
+        'now': wallClock.now,
+        'resolution': wallClock.resolution,
+    });
+    register('clocks/monotonic-clock', {
+        'now': monotonicClock.now,
+        'resolution': monotonicClock.resolution,
+        'subscribe-duration': monotonicClock.subscribeDuration,
+        'subscribe-instant': monotonicClock.subscribeInstant,
+    });
+
+    // wasi:io/*
+    register('io/poll', {
+        'poll': poll,
+    });
+    // wasi:io/error — resource methods dispatched on WasiError objects
+    const _error = 'error';
+    register('io/error', {
+        [method(_error, 'to-debug-string')]: (self: WasiError) => self.toDebugString(),
+        [drop(_error)]: (_self: WasiError) => { /* GC handles cleanup */ },
+    });
+    // wasi:io/streams — resource methods dispatched on stream objects
+    const inputStreamPrefix = 'input-stream';
+    const outputStreamPrefix = 'output-stream';
+    register('io/streams', {
+        // InputStream methods
+        [method(inputStreamPrefix, 'read')]: (self: WasiInputStream, len: bigint) => self.read(len),
+        [method(inputStreamPrefix, 'blocking-read')]: (self: WasiInputStream, len: bigint) => self.blockingRead(len),
+        [method(inputStreamPrefix, 'skip')]: (self: WasiInputStream, len: bigint) => self.skip(len),
+        [method(inputStreamPrefix, 'blocking-skip')]: (self: WasiInputStream, len: bigint) => self.blockingSkip(len),
+        [method(inputStreamPrefix, 'subscribe')]: (self: WasiInputStream) => self.subscribe(),
+        [drop(inputStreamPrefix)]: (_self: WasiInputStream) => { /* GC handles cleanup */ },
+        // OutputStream methods
+        [method(outputStreamPrefix, 'check-write')]: (self: WasiOutputStream) => self.checkWrite(),
+        [method(outputStreamPrefix, 'write')]: (self: WasiOutputStream, contents: Uint8Array) => self.write(contents),
+        [method(outputStreamPrefix, 'blocking-write-and-flush')]: (self: WasiOutputStream, contents: Uint8Array) => self.blockingWriteAndFlush(contents),
+        [method(outputStreamPrefix, 'flush')]: (self: WasiOutputStream) => self.flush(),
+        [method(outputStreamPrefix, 'blocking-flush')]: (self: WasiOutputStream) => self.blockingFlush(),
+        [method(outputStreamPrefix, 'write-zeroes')]: (self: WasiOutputStream, len: bigint) => self.writeZeroes(len),
+        [method(outputStreamPrefix, 'blocking-write-zeroes-and-flush')]: (self: WasiOutputStream, len: bigint) => self.blockingWriteZeroesAndFlush(len),
+        [method(outputStreamPrefix, 'subscribe')]: (self: WasiOutputStream) => self.subscribe(),
+        [drop(outputStreamPrefix)]: (_self: WasiOutputStream) => { /* GC handles cleanup */ },
+    });
+
+    // wasi:cli/*
+    register('cli/environment', {
+        'get-environment': cli.environment.getEnvironment,
+        'get-arguments': cli.environment.getArguments,
+        'initial-cwd': cli.environment.initialCwd,
+    });
+    register('cli/exit', {
+        'exit': cli.exit.exit,
+    });
+    register('cli/stdin', {
+        'get-stdin': cli.stdin.getStdin,
+    });
+    register('cli/stdout', {
+        'get-stdout': cli.stdout.getStdout,
+    });
+    register('cli/stderr', {
+        'get-stderr': cli.stderr.getStderr,
+    });
+    register('cli/terminal-input', {
+        'get-terminal-stdin': cli.terminalInput.getTerminalStdin,
+    });
+    register('cli/terminal-stdout', {
+        'get-terminal-stdout': cli.terminalOutput.getTerminalStdout,
+    });
+    register('cli/terminal-stderr', {
+        'get-terminal-stderr': cli.terminalOutput.getTerminalStderr,
+    });
+
+    // wasi:filesystem/*
+    const descriptorPrefix = 'descriptor';
+    const directoryPrefix = 'directory-entry-stream';
+    register('filesystem/types', {
+        'filesystem-error-code': (_err: WasiError) => {
+            // In our VFS, stream errors don't carry filesystem error codes.
+            // Return none (undefined) per the WIT spec.
+            return undefined;
+        },
+        [drop(descriptorPrefix)]: (_self: WasiDescriptor) => { /* GC handles cleanup */ },
+        [method(descriptorPrefix, 'read-via-stream')]: (self: WasiDescriptor, offset: bigint) => self.readViaStream(offset),
+        [method(descriptorPrefix, 'write-via-stream')]: (self: WasiDescriptor, offset: bigint) => self.writeViaStream(offset),
+        [method(descriptorPrefix, 'append-via-stream')]: (self: WasiDescriptor) => self.appendViaStream(),
+        [method(descriptorPrefix, 'get-type')]: (self: WasiDescriptor) => self.getType(),
+        [method(descriptorPrefix, 'stat')]: (self: WasiDescriptor) => self.stat(),
+        [method(descriptorPrefix, 'stat-at')]: (self: WasiDescriptor, pathFlags: any, path: string) => self.statAt(pathFlags, path),
+        [method(descriptorPrefix, 'open-at')]: (self: WasiDescriptor, pathFlags: any, path: string, openFlags: any, descFlags: any) => self.openAt(pathFlags, path, openFlags, descFlags),
+        [method(descriptorPrefix, 'read-directory')]: (self: WasiDescriptor) => self.readDirectory(),
+        [method(descriptorPrefix, 'create-directory-at')]: (self: WasiDescriptor, path: string) => self.createDirectoryAt(path),
+        [method(descriptorPrefix, 'remove-directory-at')]: (self: WasiDescriptor, path: string) => self.removeDirectoryAt(path),
+        [method(descriptorPrefix, 'unlink-file-at')]: (self: WasiDescriptor, path: string) => self.unlinkFileAt(path),
+        [method(descriptorPrefix, 'read')]: (self: WasiDescriptor, length: bigint, offset: bigint) => self.read(length, offset),
+        [method(descriptorPrefix, 'write')]: (self: WasiDescriptor, buffer: Uint8Array, offset: bigint) => self.write(buffer, offset),
+        [method(descriptorPrefix, 'get-flags')]: (self: WasiDescriptor) => self.getFlags(),
+        [method(descriptorPrefix, 'set-size')]: (self: WasiDescriptor, size: bigint) => self.setSize(size),
+        [method(descriptorPrefix, 'sync')]: (self: WasiDescriptor) => self.sync(),
+        [method(descriptorPrefix, 'sync-data')]: (self: WasiDescriptor) => self.syncData(),
+        [method(descriptorPrefix, 'metadata-hash')]: (self: WasiDescriptor) => self.metadataHash(),
+        [method(descriptorPrefix, 'metadata-hash-at')]: (self: WasiDescriptor, pathFlags: any, path: string) => self.metadataHashAt(pathFlags, path),
+        [method(descriptorPrefix, 'rename-at')]: (self: WasiDescriptor, oldPath: string, newDesc: WasiDescriptor, newPath: string) => self.renameAt(oldPath, newDesc, newPath),
+        [method(descriptorPrefix, 'set-times')]: (self: WasiDescriptor, atime: any, mtime: any) => self.setTimes(atime, mtime),
+        [method(descriptorPrefix, 'set-times-at')]: (self: WasiDescriptor, pathFlags: any, path: string, atime: any, mtime: any) => self.setTimesAt(pathFlags, path, atime, mtime),
+        [method(descriptorPrefix, 'is-same-object')]: (self: WasiDescriptor, other: WasiDescriptor) => self.isSameObject(other),
+        [method(descriptorPrefix, 'advise')]: (self: WasiDescriptor, offset: bigint, length: bigint, advice: string) => self.advise(offset, length, advice),
+        [drop(directoryPrefix)]: (_self: WasiDirectoryEntryStream) => { /* GC handles cleanup */ },
+        [method(directoryPrefix, 'read-directory-entry')]: (self: WasiDirectoryEntryStream) => self.readDirectoryEntry(),
+    });
+    register('filesystem/preopens', {
+        'get-directories': filesystem.preopens.getDirectories,
+    });
+
+    // wasi:http/*
+    register('http/outgoing-handler', {
+        'handle': outgoingHandler.handle,
+    });
+
+    // wasi:sockets/* (all stubs)
+    register('sockets/instance-network', {
+        'instance-network': instanceNetwork,
+    });
+    register('sockets/tcp-create-socket', {
+        'create-tcp-socket': (family: any) => createTcpSocket(family),
+    });
+    register('sockets/udp-create-socket', {
+        'create-udp-socket': (family: any) => createUdpSocket(family),
+    });
+    register('sockets/ip-name-lookup', {
+        'resolve-addresses': (network: any, name: string) => resolveAddresses(network, name),
+    });
 
     return result;
 }

--- a/src/host/wasip2/instantiate.ts
+++ b/src/host/wasip2/instantiate.ts
@@ -41,9 +41,10 @@ export async function instantiateWasiComponent<TJSExports>(
     extraImports?: JsImports,
     options?: WasiInstantiateOptions,
 ): Promise<WasmComponentInstance<TJSExports>> {
-    const useJspi = options?.[NO_JSPI] !== true;
+    const noJspi = options?.[NO_JSPI];
+    const needsJspi = noJspi !== true; // false or array both need JSPI available
 
-    if (useJspi && !hasJspi()) {
+    if (needsJspi && !hasJspi()) {
         throw new Error(
             'JSPI required for WASI components. ' +
             'Enable with --experimental-wasm-jspi (Node.js) or ' +

--- a/src/host/wasip2/instantiate.ts
+++ b/src/host/wasip2/instantiate.ts
@@ -1,7 +1,7 @@
 /**
  * instantiateWasiComponent — Dedicated WASI component instantiator
  *
- * Wraps createComponent + createWasiHost with JSPI integration.
+ * Wraps createComponent + createWasiP2Host with JSPI integration.
  * JSPI wraps blocking WASI imports with WebAssembly.Suspending
  * and component exports with WebAssembly.promising, so WASM can
  * call async host functions synchronously.
@@ -14,7 +14,7 @@ import { ComponentFactoryInput, ComponentFactoryOptions } from '../../resolver/t
 import { ParserOptions } from '../../parser/types';
 import { JsImports, WasmComponentInstance } from '../../resolver/api-types';
 import { WasiConfig } from './types';
-import { createWasiHost } from './index';
+import { createWasiP2Host } from './index';
 import { hasJspi } from './poll';
 import { NO_JSPI, INSTANTIATE } from '../../constants';
 
@@ -54,10 +54,10 @@ export async function instantiateWasiComponent<TJSExports>(
     }
 
     // Build WASI host
-    const wasiImports = createWasiHost(wasiConfig);
+    const wasiExports = createWasiP2Host(wasiConfig);
 
     // Merge: WASI first, then user extras override
-    const mergedImports: JsImports = { ...wasiImports };
+    const mergedImports: JsImports = { ...wasiExports };
     if (extraImports) {
         Object.assign(mergedImports, extraImports);
     }

--- a/src/host/wasip2/instantiate.ts
+++ b/src/host/wasip2/instantiate.ts
@@ -16,11 +16,10 @@ import { JsImports, WasmComponentInstance } from '../../resolver/api-types';
 import { WasiConfig } from './types';
 import { createWasiHost } from './index';
 import { hasJspi } from './poll';
+import { NO_JSPI, INSTANTIATE } from '../../constants';
 
 /** Options for WASI component instantiation */
 export interface WasiInstantiateOptions extends ComponentFactoryOptions, ParserOptions {
-    /** Disable JSPI wrapping. Default: false (JSPI enabled). */
-    noJspi?: boolean;
 }
 
 /**
@@ -42,7 +41,7 @@ export async function instantiateWasiComponent<TJSExports>(
     extraImports?: JsImports,
     options?: WasiInstantiateOptions,
 ): Promise<WasmComponentInstance<TJSExports>> {
-    const useJspi = !options?.noJspi;
+    const useJspi = options?.[NO_JSPI] !== true;
 
     if (useJspi && !hasJspi()) {
         throw new Error(
@@ -62,20 +61,11 @@ export async function instantiateWasiComponent<TJSExports>(
         Object.assign(mergedImports, extraImports);
     }
 
-    // Create component with optional JSPI-aware WASM instantiation
+    // Create component — noJspi flows through from options
     const componentOptions: ComponentFactoryOptions & ParserOptions = {
         ...(options ?? {}),
     };
 
-    if (useJspi) {
-        // Tell the resolver to wrap component export entry points with
-        // WebAssembly.promising(). This is applied only to the specific core
-        // function referenced by canon.lift — NOT to all core module exports.
-        // Wrapping all exports breaks core-to-core module linking because
-        // promising()-wrapped functions return Promises, which WASM coerces to 0.
-        componentOptions.jspi = true;
-    }
-
     const component = await createComponent<TJSExports>(source, componentOptions);
-    return component.instantiate(mergedImports);
+    return component[INSTANTIATE](mergedImports);
 }

--- a/src/host/wasip2/integration-helpers.ts
+++ b/src/host/wasip2/integration-helpers.ts
@@ -7,7 +7,7 @@
  */
 
 import { createComponent } from '../../resolver';
-import { createWasiHost } from './index';
+import { createWasiP2Host } from './index';
 import { WasiExit } from './types';
 import type { VerboseCapture } from '../../test-utils/verbose-logger';
 import { verboseOptions } from '../../test-utils/verbose-logger';
@@ -173,7 +173,7 @@ export function wireExportsToImports(
 export async function runConsumerScenario(
     verbose: VerboseCapture,
     buildChain: (ctx: {
-        wasiImports: ImportsMap;
+        wasiExports: ImportsMap;
         extraImports: ImportsMap;
     }) => Promise<ImportsMap>,
     expectForwarderLogs: boolean | number = false,
@@ -183,7 +183,7 @@ export async function runConsumerScenario(
     const stderrChunks: string[] = [];
     const logMessages: string[] = [];
 
-    const wasiImports = createWasiHost({
+    const wasiExports = createWasiP2Host({
         args: wasiConfig?.args,
         env: wasiConfig?.env,
         stdout: (bytes) => { stdoutChunks.push(new Uint8Array(bytes)); },
@@ -191,7 +191,7 @@ export async function runConsumerScenario(
     });
     const extraImports = createTestImports(logMessages, stderrChunks);
 
-    const consumerImports = await buildChain({ wasiImports, extraImports });
+    const consumerImports = await buildChain({ wasiExports: wasiExports, extraImports });
 
     await yieldToGC();
     const consumerComponent = await createComponent(consumerWasm, verboseOptions(verbose));

--- a/src/host/wasip2/integration-helpers.ts
+++ b/src/host/wasip2/integration-helpers.ts
@@ -199,7 +199,7 @@ export async function runConsumerScenario(
     try {
         const instance = await consumerComponent.instantiate(consumerImports);
         const runNs = (instance.exports['wasi:cli/run@0.2.11'] ?? instance.exports['wasi:cli/run']) as any;
-        const result = runNs.run();
+        const result = await runNs.run();
         exitCode = (result && typeof result === 'object' && result.tag === 'err') ? 1 : 0;
     } catch (e) {
         if (e instanceof WasiExit) exitCode = e.status; else throw e;
@@ -209,7 +209,7 @@ export async function runConsumerScenario(
         new Uint8Array(stdoutChunks.reduce((acc, c) => [...acc, ...c], [] as number[]))
     );
     assertTestResults(stdout, logMessages, exitCode, expectForwarderLogs);
-    return consumerComponent.stats;
+    return (consumerComponent as any).stats;
 }
 
 /** Instantiate a component with yield points for GC. */
@@ -219,7 +219,7 @@ export async function instantiateComponent(
     verbose: VerboseCapture,
 ): Promise<ComponentResult> {
     await yieldToGC();
-    const component = await createComponent(wasmPath, verboseOptions(verbose));
+    const component = await createComponent(wasmPath, { noJspi: true, ...verboseOptions(verbose) });
     const instance = await component.instantiate(imports);
-    return { exports: instance.exports as ImportsMap, stats: component.stats };
+    return { exports: instance.exports as ImportsMap, stats: (component as any).stats };
 }

--- a/src/host/wasip2/integration.test.ts
+++ b/src/host/wasip2/integration.test.ts
@@ -15,7 +15,7 @@
  * Scenario L: consumer ← echo-reactor-wat + JS host (hand-written WAT with shifted indices)
  */
 
-import { createWasiHost } from './index';
+import { createWasiP2Host } from './index';
 import { initializeAsserts } from '../../utils/assert';
 import { useVerboseOnFailure, runWithVerbose } from '../../test-utils/verbose-logger';
 import {
@@ -39,7 +39,7 @@ describe('Integration tests (flat)', () => {
     test('Scenario A: consumer-direct', async () => runWithVerbose(verbose, async () => {
         await runConsumerScenario(
             verbose,
-            async ({ wasiImports, extraImports }) => ({ ...wasiImports, ...extraImports }),
+            async ({ wasiExports, extraImports }) => ({ ...wasiExports, ...extraImports }),
             false,
             fullWasiConfig,
         );
@@ -48,9 +48,9 @@ describe('Integration tests (flat)', () => {
     test('Scenario B: consumer ← forwarder ← JS host', async () => runWithVerbose(verbose, async () => {
         await runConsumerScenario(
             verbose,
-            async ({ wasiImports, extraImports }) => {
-                const fwd = await instantiateComponent(forwarderWasm, { ...wasiImports, ...extraImports }, verbose);
-                const consumerImports: ImportsMap = { ...wasiImports, ...extraImports };
+            async ({ wasiExports, extraImports }) => {
+                const fwd = await instantiateComponent(forwarderWasm, { ...wasiExports, ...extraImports }, verbose);
+                const consumerImports: ImportsMap = { ...wasiExports, ...extraImports };
                 wireExportsToImports(fwd.exports, consumerImports, forwardedInterfaces);
                 return consumerImports;
             },
@@ -62,14 +62,14 @@ describe('Integration tests (flat)', () => {
     test('Scenario C: consumer ← forwarder ← implementer', async () => runWithVerbose(verbose, async () => {
         await runConsumerScenario(
             verbose,
-            async ({ wasiImports, extraImports }) => {
-                const impl = await instantiateComponent(implementerWasm, createWasiHost({}), verbose);
+            async ({ wasiExports, extraImports }) => {
+                const impl = await instantiateComponent(implementerWasm, createWasiP2Host({}), verbose);
 
-                const fwdImports: ImportsMap = { ...wasiImports, ...extraImports };
+                const fwdImports: ImportsMap = { ...wasiExports, ...extraImports };
                 wireExportsToImports(impl.exports, fwdImports, implementerInterfaces);
                 const fwd = await instantiateComponent(forwarderWasm, fwdImports, verbose);
 
-                const consumerImports: ImportsMap = { ...wasiImports, ...extraImports };
+                const consumerImports: ImportsMap = { ...wasiExports, ...extraImports };
                 wireExportsToImports(fwd.exports, consumerImports, forwardedInterfaces);
                 return consumerImports;
             },
@@ -80,18 +80,18 @@ describe('Integration tests (flat)', () => {
     test('Scenario D: consumer ← fwd ← fwd ← implementer (flat)', async () => runWithVerbose(verbose, async () => {
         await runConsumerScenario(
             verbose,
-            async ({ wasiImports, extraImports }) => {
-                const impl = await instantiateComponent(implementerWasm, createWasiHost({}), verbose);
+            async ({ wasiExports, extraImports }) => {
+                const impl = await instantiateComponent(implementerWasm, createWasiP2Host({}), verbose);
 
-                const fwd2Imports: ImportsMap = { ...wasiImports, ...extraImports };
+                const fwd2Imports: ImportsMap = { ...wasiExports, ...extraImports };
                 wireExportsToImports(impl.exports, fwd2Imports, implementerInterfaces);
                 const fwd2 = await instantiateComponent(forwarderWasm, fwd2Imports, verbose);
 
-                const fwd1Imports: ImportsMap = { ...wasiImports, ...extraImports };
+                const fwd1Imports: ImportsMap = { ...wasiExports, ...extraImports };
                 wireExportsToImports(fwd2.exports, fwd1Imports, forwardedInterfaces);
                 const fwd1 = await instantiateComponent(forwarderWasm, fwd1Imports, verbose);
 
-                const consumerImports: ImportsMap = { ...wasiImports, ...extraImports };
+                const consumerImports: ImportsMap = { ...wasiExports, ...extraImports };
                 wireExportsToImports(fwd1.exports, consumerImports, forwardedInterfaces);
                 return consumerImports;
             },
@@ -102,14 +102,14 @@ describe('Integration tests (flat)', () => {
     test('Scenario E: consumer ← fwd ← fwd ← host (flat)', async () => runWithVerbose(verbose, async () => {
         await runConsumerScenario(
             verbose,
-            async ({ wasiImports, extraImports }) => {
-                const fwd2 = await instantiateComponent(forwarderWasm, { ...wasiImports, ...extraImports }, verbose);
+            async ({ wasiExports, extraImports }) => {
+                const fwd2 = await instantiateComponent(forwarderWasm, { ...wasiExports, ...extraImports }, verbose);
 
-                const fwd1Imports: ImportsMap = { ...wasiImports, ...extraImports };
+                const fwd1Imports: ImportsMap = { ...wasiExports, ...extraImports };
                 wireExportsToImports(fwd2.exports, fwd1Imports, forwardedInterfaces);
                 const fwd1 = await instantiateComponent(forwarderWasm, fwd1Imports, verbose);
 
-                const consumerImports: ImportsMap = { ...wasiImports, ...extraImports };
+                const consumerImports: ImportsMap = { ...wasiExports, ...extraImports };
                 wireExportsToImports(fwd1.exports, consumerImports, forwardedInterfaces);
                 return consumerImports;
             },
@@ -127,16 +127,16 @@ describe('Integration tests (WAC compositions)', () => {
         let fwdStats;
         await runConsumerScenario(
             verbose,
-            async ({ wasiImports, extraImports }) => {
-                const wrapped = await instantiateComponent(wrappedForwarderWasm, { ...wasiImports, ...extraImports }, verbose);
+            async ({ wasiExports, extraImports }) => {
+                const wrapped = await instantiateComponent(wrappedForwarderWasm, { ...wasiExports, ...extraImports }, verbose);
                 wrappedStats = wrapped.stats;
 
-                const fwdImports: ImportsMap = { ...wasiImports, ...extraImports };
+                const fwdImports: ImportsMap = { ...wasiExports, ...extraImports };
                 wireExportsToImports(wrapped.exports, fwdImports, forwardedInterfaces);
                 const fwd = await instantiateComponent(forwarderWasm, fwdImports, verbose);
                 fwdStats = fwd.stats;
 
-                const consumerImports: ImportsMap = { ...wasiImports, ...extraImports };
+                const consumerImports: ImportsMap = { ...wasiExports, ...extraImports };
                 wireExportsToImports(fwd.exports, consumerImports, forwardedInterfaces);
                 return consumerImports;
             },
@@ -159,10 +159,10 @@ describe('Integration tests (WAC compositions)', () => {
         let dblStats;
         await runConsumerScenario(
             verbose,
-            async ({ wasiImports, extraImports }) => {
-                const dbl = await instantiateComponent(doubleForwarderWasm, { ...wasiImports, ...extraImports }, verbose);
+            async ({ wasiExports, extraImports }) => {
+                const dbl = await instantiateComponent(doubleForwarderWasm, { ...wasiExports, ...extraImports }, verbose);
                 dblStats = dbl.stats;
-                const consumerImports: ImportsMap = { ...wasiImports, ...extraImports };
+                const consumerImports: ImportsMap = { ...wasiExports, ...extraImports };
                 wireExportsToImports(dbl.exports, consumerImports, forwardedInterfaces);
                 return consumerImports;
             },
@@ -182,10 +182,10 @@ describe('Integration tests (WAC compositions)', () => {
         let nestedStats;
         await runConsumerScenario(
             verbose,
-            async ({ wasiImports, extraImports }) => {
-                const nested = await instantiateComponent(nestedDoubleForwarderWasm, { ...wasiImports, ...extraImports }, verbose);
+            async ({ wasiExports, extraImports }) => {
+                const nested = await instantiateComponent(nestedDoubleForwarderWasm, { ...wasiExports, ...extraImports }, verbose);
                 nestedStats = nested.stats;
-                const consumerImports: ImportsMap = { ...wasiImports, ...extraImports };
+                const consumerImports: ImportsMap = { ...wasiExports, ...extraImports };
                 wireExportsToImports(nested.exports, consumerImports, forwardedInterfaces);
                 return consumerImports;
             },
@@ -205,10 +205,10 @@ describe('Integration tests (WAC compositions)', () => {
         let composedStats;
         await runConsumerScenario(
             verbose,
-            async ({ wasiImports, extraImports }) => {
-                const composed = await instantiateComponent(forwarderImplementerWasm, { ...wasiImports, ...extraImports }, verbose);
+            async ({ wasiExports, extraImports }) => {
+                const composed = await instantiateComponent(forwarderImplementerWasm, { ...wasiExports, ...extraImports }, verbose);
                 composedStats = composed.stats;
-                const consumerImports: ImportsMap = { ...wasiImports, ...extraImports };
+                const consumerImports: ImportsMap = { ...wasiExports, ...extraImports };
                 wireExportsToImports(composed.exports, consumerImports, forwardedInterfaces);
                 return consumerImports;
             },
@@ -227,10 +227,10 @@ describe('Integration tests (WAC compositions)', () => {
         let composedStats;
         await runConsumerScenario(
             verbose,
-            async ({ wasiImports, extraImports }) => {
-                const composed = await instantiateComponent(doubleForwarderImplementerWasm, { ...wasiImports, ...extraImports }, verbose);
+            async ({ wasiExports, extraImports }) => {
+                const composed = await instantiateComponent(doubleForwarderImplementerWasm, { ...wasiExports, ...extraImports }, verbose);
                 composedStats = composed.stats;
-                const consumerImports: ImportsMap = { ...wasiImports, ...extraImports };
+                const consumerImports: ImportsMap = { ...wasiExports, ...extraImports };
                 wireExportsToImports(composed.exports, consumerImports, forwardedInterfaces);
                 return consumerImports;
             },
@@ -249,10 +249,10 @@ describe('Integration tests (WAC compositions)', () => {
         let nestedStats;
         await runConsumerScenario(
             verbose,
-            async ({ wasiImports, extraImports }) => {
-                const nested = await instantiateComponent(nestedForwarderImplementerWasm, { ...wasiImports, ...extraImports }, verbose);
+            async ({ wasiExports, extraImports }) => {
+                const nested = await instantiateComponent(nestedForwarderImplementerWasm, { ...wasiExports, ...extraImports }, verbose);
                 nestedStats = nested.stats;
-                const consumerImports: ImportsMap = { ...wasiImports, ...extraImports };
+                const consumerImports: ImportsMap = { ...wasiExports, ...extraImports };
                 wireExportsToImports(nested.exports, consumerImports, forwardedInterfaces);
                 return consumerImports;
             },
@@ -273,9 +273,9 @@ describe('Integration tests (WAC compositions)', () => {
         ];
         await runConsumerScenario(
             verbose,
-            async ({ wasiImports, extraImports }) => {
+            async ({ wasiExports, extraImports }) => {
                 const echoWat = await instantiateComponent(echoReactorWatWasm, {}, verbose);
-                const consumerImports: ImportsMap = { ...wasiImports, ...extraImports };
+                const consumerImports: ImportsMap = { ...wasiExports, ...extraImports };
                 wireExportsToImports(echoWat.exports, consumerImports, echoInterfaces);
                 return consumerImports;
             },

--- a/src/host/wasip2/integration.test.ts
+++ b/src/host/wasip2/integration.test.ts
@@ -27,6 +27,7 @@ import {
     runConsumerScenario, instantiateComponent, wireExportsToImports,
 } from './integration-helpers';
 import type { ImportsMap } from './integration-helpers';
+import isDebug from 'env:isDebug';
 
 initializeAsserts();
 
@@ -143,13 +144,15 @@ describe('Integration tests (WAC compositions)', () => {
             fullWasiConfig,
         );
         // wrapped-forwarder: 14 scoped contexts, 63 instance cache hits, 123 core instance cache hits
-        expect(wrappedStats!.createScopedResolverContext).toBe(14);
-        expect(wrappedStats!.componentSectionCacheHits).toBe(0);
-        expect(wrappedStats!.componentInstanceCacheHits).toBe(63);
-        expect(wrappedStats!.coreInstanceCacheHits).toBe(154);
-        // plain forwarder: 13 unique sub-components, 42 instance cache hits
-        expect(fwdStats!.createScopedResolverContext).toBe(13);
-        expect(fwdStats!.componentInstanceCacheHits).toBe(51);
+        if (isDebug) {
+            expect(wrappedStats!.createScopedResolverContext).toBe(14);
+            expect(wrappedStats!.componentSectionCacheHits).toBe(0);
+            expect(wrappedStats!.componentInstanceCacheHits).toBe(63);
+            expect(wrappedStats!.coreInstanceCacheHits).toBe(154);
+            // plain forwarder: 13 unique sub-components, 42 instance cache hits
+            expect(fwdStats!.createScopedResolverContext).toBe(13);
+            expect(fwdStats!.componentInstanceCacheHits).toBe(51);
+        }
     }));
 
     test('Scenario G: consumer ← (fwd ← fwd ← host) wac-composed', async () => runWithVerbose(verbose, async () => {
@@ -167,10 +170,12 @@ describe('Integration tests (WAC compositions)', () => {
             fullWasiConfig,
         );
         // double-forwarder: 14 scoped contexts, 1 section cache hit, 80 instance cache hits
-        expect(dblStats!.createScopedResolverContext).toBe(14);
-        expect(dblStats!.componentSectionCacheHits).toBe(1);
-        expect(dblStats!.componentInstanceCacheHits).toBe(80);
-        expect(dblStats!.coreInstanceCacheHits).toBe(154);
+        if (isDebug) {
+            expect(dblStats!.createScopedResolverContext).toBe(14);
+            expect(dblStats!.componentSectionCacheHits).toBe(1);
+            expect(dblStats!.componentInstanceCacheHits).toBe(80);
+            expect(dblStats!.coreInstanceCacheHits).toBe(154);
+        }
     }));
 
     test('Scenario H: consumer ← (fwd ← (fwd ← host)) nested wac', async () => runWithVerbose(verbose, async () => {
@@ -188,10 +193,12 @@ describe('Integration tests (WAC compositions)', () => {
             fullWasiConfig,
         );
         // nested-double-forwarder: 29 scoped contexts, 143 instance cache hits
-        expect(nestedStats!.createScopedResolverContext).toBe(29);
-        expect(nestedStats!.componentSectionCacheHits).toBe(0);
-        expect(nestedStats!.componentInstanceCacheHits).toBe(143);
-        expect(nestedStats!.coreInstanceCacheHits).toBe(308);
+        if (isDebug) {
+            expect(nestedStats!.createScopedResolverContext).toBe(29);
+            expect(nestedStats!.componentSectionCacheHits).toBe(0);
+            expect(nestedStats!.componentInstanceCacheHits).toBe(143);
+            expect(nestedStats!.coreInstanceCacheHits).toBe(308);
+        }
     }));
 
     test('Scenario I: consumer ← (fwd ← implementer) wac-composed', async () => runWithVerbose(verbose, async () => {
@@ -208,10 +215,12 @@ describe('Integration tests (WAC compositions)', () => {
             true,
         );
         // forwarder-implementer: 27 scoped contexts, 73 instance cache hits
-        expect(composedStats!.createScopedResolverContext).toBe(27);
-        expect(composedStats!.componentSectionCacheHits).toBe(0);
-        expect(composedStats!.componentInstanceCacheHits).toBe(73);
-        expect(composedStats!.coreInstanceCacheHits).toBe(228);
+        if (isDebug) {
+            expect(composedStats!.createScopedResolverContext).toBe(27);
+            expect(composedStats!.componentSectionCacheHits).toBe(0);
+            expect(composedStats!.componentInstanceCacheHits).toBe(73);
+            expect(composedStats!.coreInstanceCacheHits).toBe(228);
+        }
     }));
 
     test('Scenario J: consumer ← (fwd ← fwd ← implementer) wac-composed', async () => runWithVerbose(verbose, async () => {
@@ -228,10 +237,12 @@ describe('Integration tests (WAC compositions)', () => {
             2,
         );
         // double-forwarder-implementer: 27 scoped contexts, 1 section cache hit, 90 instance cache hits
-        expect(composedStats!.createScopedResolverContext).toBe(27);
-        expect(composedStats!.componentSectionCacheHits).toBe(1);
-        expect(composedStats!.componentInstanceCacheHits).toBe(90);
-        expect(composedStats!.coreInstanceCacheHits).toBe(228);
+        if (isDebug) {
+            expect(composedStats!.createScopedResolverContext).toBe(27);
+            expect(composedStats!.componentSectionCacheHits).toBe(1);
+            expect(composedStats!.componentInstanceCacheHits).toBe(90);
+            expect(composedStats!.coreInstanceCacheHits).toBe(228);
+        }
     }));
 
     test('Scenario K: consumer ← (fwd ← (fwd ← implementer)) nested wac', async () => runWithVerbose(verbose, async () => {
@@ -248,10 +259,12 @@ describe('Integration tests (WAC compositions)', () => {
             2,
         );
         // nested-forwarder-implementer: 42 scoped contexts, 153 instance cache hits
-        expect(nestedStats!.createScopedResolverContext).toBe(42);
-        expect(nestedStats!.componentSectionCacheHits).toBe(0);
-        expect(nestedStats!.componentInstanceCacheHits).toBe(153);
-        expect(nestedStats!.coreInstanceCacheHits).toBe(382);
+        if (isDebug) {
+            expect(nestedStats!.createScopedResolverContext).toBe(42);
+            expect(nestedStats!.componentSectionCacheHits).toBe(0);
+            expect(nestedStats!.componentInstanceCacheHits).toBe(153);
+            expect(nestedStats!.coreInstanceCacheHits).toBe(382);
+        }
     }));
 
     test('Scenario L: consumer ← echo-reactor-wat + JS host', async () => runWithVerbose(verbose, async () => {

--- a/src/host/wasip2/integration.test.ts
+++ b/src/host/wasip2/integration.test.ts
@@ -16,7 +16,7 @@
  */
 
 import { createWasiHost } from './index';
-import { setConfiguration } from '../../utils/assert';
+import { initializeAsserts } from '../../utils/assert';
 import { useVerboseOnFailure, runWithVerbose } from '../../test-utils/verbose-logger';
 import {
     yieldToGC, fullWasiConfig, forwardedInterfaces, implementerInterfaces,
@@ -28,7 +28,7 @@ import {
 } from './integration-helpers';
 import type { ImportsMap } from './integration-helpers';
 
-setConfiguration('Debug');
+initializeAsserts();
 
 describe('Integration tests (flat)', () => {
     const verbose = useVerboseOnFailure();

--- a/src/host/wasip2/poll.ts
+++ b/src/host/wasip2/poll.ts
@@ -5,6 +5,8 @@
  * JSPI: block() awaits the internal promise when JSPI is available.
  */
 
+import { SUSPENDING } from '../../constants';
+
 /** wasi:io/poll — pollable resource */
 export interface WasiPollable {
     /** Check if the pollable is ready (non-blocking) */
@@ -119,7 +121,7 @@ export function hasJspi(): boolean {
     if (_jspiCached !== undefined) return _jspiCached;
     try {
         _jspiCached = typeof WebAssembly !== 'undefined'
-            && typeof (WebAssembly as any).Suspending === 'function';
+            && typeof (WebAssembly as any)[SUSPENDING] === 'function';
     } catch {
         _jspiCached = false;
     }

--- a/src/host/wasip2/types.ts
+++ b/src/host/wasip2/types.ts
@@ -16,7 +16,7 @@ export class WasiExit extends Error {
     }
 }
 
-/** Configuration for createWasiHost() */
+/** Configuration for createWasiP2Host() */
 export interface WasiConfig {
     /** Environment variables as [key, value] pairs */
     env?: [string, string][];

--- a/src/host/wasip2/wasi-host.test.ts
+++ b/src/host/wasip2/wasi-host.test.ts
@@ -5,14 +5,14 @@
  * WASI component instantiator (instantiateWasiComponent).
  */
 
-import { createWasiHost } from './index';
+import { createWasiP2Host, WasiConfig } from './index';
 
 // WasiConfig is a type-only export, inline for ESM compatibility
 
-describe('createWasiHost', () => {
+describe('createWasiP2Host', () => {
     describe('structure', () => {
         it('returns an object with WASI interface keys', () => {
-            const host = createWasiHost();
+            const host = createWasiP2Host();
             expect(host['wasi:cli/stdout']).toBeDefined();
             expect(host['wasi:cli/stderr']).toBeDefined();
             expect(host['wasi:cli/stdin']).toBeDefined();
@@ -33,7 +33,7 @@ describe('createWasiHost', () => {
         });
 
         it('registers versioned aliases', () => {
-            const host = createWasiHost();
+            const host = createWasiP2Host();
             // Check a few versioned aliases
             expect(host['wasi:cli/stdout@0.2.0']).toBeDefined();
             expect(host['wasi:cli/stdout@0.2.6']).toBeDefined();
@@ -43,7 +43,7 @@ describe('createWasiHost', () => {
         });
 
         it('all interface values are objects with function members', () => {
-            const host = createWasiHost();
+            const host = createWasiP2Host();
             for (const [_key, iface] of Object.entries(host)) {
                 expect(typeof iface).toBe('object');
                 for (const [_methodName, method] of Object.entries(iface)) {
@@ -55,22 +55,22 @@ describe('createWasiHost', () => {
 
     describe('kebab-case method names', () => {
         it('wasi:cli/stdout has get-stdout', () => {
-            const host = createWasiHost();
+            const host = createWasiP2Host();
             expect(typeof host['wasi:cli/stdout']['get-stdout']).toBe('function');
         });
 
         it('wasi:cli/stdin has get-stdin', () => {
-            const host = createWasiHost();
+            const host = createWasiP2Host();
             expect(typeof host['wasi:cli/stdin']['get-stdin']).toBe('function');
         });
 
         it('wasi:cli/stderr has get-stderr', () => {
-            const host = createWasiHost();
+            const host = createWasiP2Host();
             expect(typeof host['wasi:cli/stderr']['get-stderr']).toBe('function');
         });
 
         it('wasi:cli/environment has get-environment and get-arguments', () => {
-            const host = createWasiHost();
+            const host = createWasiP2Host();
             const env = host['wasi:cli/environment'];
             expect(typeof env['get-environment']).toBe('function');
             expect(typeof env['get-arguments']).toBe('function');
@@ -78,26 +78,26 @@ describe('createWasiHost', () => {
         });
 
         it('wasi:cli/exit has exit', () => {
-            const host = createWasiHost();
+            const host = createWasiP2Host();
             expect(typeof host['wasi:cli/exit']['exit']).toBe('function');
         });
 
         it('wasi:random/random has get-random-bytes and get-random-u64', () => {
-            const host = createWasiHost();
+            const host = createWasiP2Host();
             const random = host['wasi:random/random'];
             expect(typeof random['get-random-bytes']).toBe('function');
             expect(typeof random['get-random-u64']).toBe('function');
         });
 
         it('wasi:clocks/wall-clock has now and resolution', () => {
-            const host = createWasiHost();
+            const host = createWasiP2Host();
             const clock = host['wasi:clocks/wall-clock'];
             expect(typeof clock['now']).toBe('function');
             expect(typeof clock['resolution']).toBe('function');
         });
 
         it('wasi:clocks/monotonic-clock has all methods', () => {
-            const host = createWasiHost();
+            const host = createWasiP2Host();
             const clock = host['wasi:clocks/monotonic-clock'];
             expect(typeof clock['now']).toBe('function');
             expect(typeof clock['resolution']).toBe('function');
@@ -106,14 +106,14 @@ describe('createWasiHost', () => {
         });
 
         it('wasi:io/poll has poll', () => {
-            const host = createWasiHost();
+            const host = createWasiP2Host();
             expect(typeof host['wasi:io/poll']['poll']).toBe('function');
         });
     });
 
     describe('configuration', () => {
         it('default config produces working host', () => {
-            const host = createWasiHost();
+            const host = createWasiP2Host();
             // Environment defaults to empty
             const env = host['wasi:cli/environment']['get-environment']();
             expect(env).toEqual([]);
@@ -125,7 +125,7 @@ describe('createWasiHost', () => {
             const config: WasiConfig = {
                 env: [['FOO', 'bar'], ['PATH', '/usr/bin']],
             };
-            const host = createWasiHost(config);
+            const host = createWasiP2Host(config);
             const env = host['wasi:cli/environment']['get-environment']();
             expect(env).toEqual([['FOO', 'bar'], ['PATH', '/usr/bin']]);
         });
@@ -134,7 +134,7 @@ describe('createWasiHost', () => {
             const config: WasiConfig = {
                 args: ['--verbose', 'input.txt'],
             };
-            const host = createWasiHost(config);
+            const host = createWasiP2Host(config);
             const args = host['wasi:cli/environment']['get-arguments']();
             expect(args).toEqual(['--verbose', 'input.txt']);
         });
@@ -144,7 +144,7 @@ describe('createWasiHost', () => {
             const config: WasiConfig = {
                 stdout: (bytes) => chunks.push(bytes),
             };
-            const host = createWasiHost(config);
+            const host = createWasiP2Host(config);
             const stdout = host['wasi:cli/stdout']['get-stdout']();
             // Write through the output stream
             stdout.blockingWriteAndFlush(new TextEncoder().encode('hello'));
@@ -156,7 +156,7 @@ describe('createWasiHost', () => {
             const config: WasiConfig = {
                 cwd: '/home/user',
             };
-            const host = createWasiHost(config);
+            const host = createWasiP2Host(config);
             const cwd = host['wasi:cli/environment']['initial-cwd']();
             expect(cwd).toBe('/home/user');
         });
@@ -167,7 +167,7 @@ describe('createWasiHost', () => {
                     ['/data/test.txt', new TextEncoder().encode('hello')],
                 ]),
             };
-            const host = createWasiHost(config);
+            const host = createWasiP2Host(config);
             const dirs = host['wasi:filesystem/preopens']['get-directories']();
             expect(dirs.length).toBeGreaterThan(0);
         });
@@ -175,20 +175,20 @@ describe('createWasiHost', () => {
 
     describe('functional behavior', () => {
         it('random bytes returns correct length', () => {
-            const host = createWasiHost();
+            const host = createWasiP2Host();
             const bytes = host['wasi:random/random']['get-random-bytes'](10n);
             expect(bytes).toBeInstanceOf(Uint8Array);
             expect(bytes.length).toBe(10);
         });
 
         it('random u64 returns bigint', () => {
-            const host = createWasiHost();
+            const host = createWasiP2Host();
             const val = host['wasi:random/random']['get-random-u64']();
             expect(typeof val).toBe('bigint');
         });
 
         it('wall-clock now returns datetime', () => {
-            const host = createWasiHost();
+            const host = createWasiP2Host();
             const now = host['wasi:clocks/wall-clock']['now']();
             expect(typeof now.seconds).toBe('bigint');
             expect(typeof now.nanoseconds).toBe('number');
@@ -196,37 +196,37 @@ describe('createWasiHost', () => {
         });
 
         it('monotonic-clock now returns bigint nanoseconds', () => {
-            const host = createWasiHost();
+            const host = createWasiP2Host();
             const now = host['wasi:clocks/monotonic-clock']['now']();
             expect(typeof now).toBe('bigint');
             expect(now).toBeGreaterThan(0n);
         });
 
         it('exit throws WasiExit with status 0 for ok', () => {
-            const host = createWasiHost();
+            const host = createWasiP2Host();
             expect(() => host['wasi:cli/exit']['exit']({ tag: 'ok' })).toThrow('WASI exit with status 0');
         });
 
         it('exit throws WasiExit with status 1 for err', () => {
-            const host = createWasiHost();
+            const host = createWasiP2Host();
             expect(() => host['wasi:cli/exit']['exit']({ tag: 'err' })).toThrow('WASI exit with status 1');
         });
 
         it('socket stubs return not-supported', () => {
-            const host = createWasiHost();
+            const host = createWasiP2Host();
             const result = host['wasi:sockets/tcp-create-socket']['create-tcp-socket']('ipv4');
             expect(result).toEqual({ tag: 'err', val: 'not-supported' });
         });
 
         it('insecure random returns bytes', () => {
-            const host = createWasiHost();
+            const host = createWasiP2Host();
             const bytes = host['wasi:random/insecure']['get-insecure-random-bytes'](5n);
             expect(bytes).toBeInstanceOf(Uint8Array);
             expect(bytes.length).toBe(5);
         });
 
         it('insecure-seed returns tuple of bigints', () => {
-            const host = createWasiHost();
+            const host = createWasiP2Host();
             const seed = host['wasi:random/insecure-seed']['insecure-seed']();
             expect(Array.isArray(seed)).toBe(true);
             expect(seed.length).toBe(2);

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@
 
 import gitHash from 'env:gitHash';
 import configuration from 'env:configuration';
-import { setConfiguration } from './utils/assert';
+import { initializeAsserts } from './utils/assert';
 import './utils/debug-names'; // registers initDebugNames before setConfiguration
 
 export type { WITModel } from './parser';
@@ -26,4 +26,4 @@ export function getBuildInfo() {
     };
 }
 
-setConfiguration(configuration);
+initializeAsserts();

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import gitHash from 'env:gitHash';
 import configuration from 'env:configuration';
 import { initializeAsserts } from './utils/assert';
 import './utils/debug-names'; // registers initDebugNames before setConfiguration
+import { GIT_HASH, CONFIGURATION } from './constants';
 
 export type { WITModel } from './parser';
 export { parse } from './parser';
@@ -21,8 +22,8 @@ export { printWAT } from './utils/wat-printer';
 
 export function getBuildInfo() {
     return {
-        gitHash,
-        configuration,
+        [GIT_HASH]: gitHash,
+        [CONFIGURATION]: configuration,
     };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,10 +7,8 @@ import { initializeAsserts } from './utils/assert';
 import './utils/debug-names'; // registers initDebugNames before setConfiguration
 import { GIT_HASH, CONFIGURATION } from './constants';
 
-export type { WITModel } from './parser';
 export { parse } from './parser';
 export { instantiateComponent, createComponent } from './resolver';
-export { createLifting, createLowering } from './resolver/binding';
 export { createWasiHost } from './host/wasip2';
 export { instantiateWasiComponent } from './host/wasip2/instantiate';
 export type { WasiInstantiateOptions } from './host/wasip2/instantiate';
@@ -18,7 +16,6 @@ export type { WasiConfig } from './host/wasip2/types';
 export type { WasmComponent, WasmComponentInstance, ResolutionStats } from './resolver/api-types';
 export { LogLevel, setLogger } from './utils/assert';
 export type { Verbosity, LogFn } from './utils/assert';
-export { printWAT } from './utils/wat-printer';
 
 export function getBuildInfo() {
     return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,15 +7,13 @@ import { initializeAsserts } from './utils/assert';
 import './utils/debug-names'; // registers initDebugNames before setConfiguration
 import { GIT_HASH, CONFIGURATION } from './constants';
 
-export { parse } from './parser';
-export { instantiateComponent, createComponent } from './resolver';
-export { createWasiHost } from './host/wasip2';
-export { instantiateWasiComponent } from './host/wasip2/instantiate';
 export type { WasiInstantiateOptions } from './host/wasip2/instantiate';
 export type { WasiConfig } from './host/wasip2/types';
-export type { WasmComponent, WasmComponentInstance, ResolutionStats } from './resolver/api-types';
+export type { WasmComponent, WasmComponentInstance } from './resolver/api-types';
+export { instantiateComponent, createComponent } from './resolver';
+export { createWasiP2Host } from './host/wasip2';
+export { instantiateWasiComponent } from './host/wasip2/instantiate';
 export { LogLevel, setLogger } from './utils/assert';
-export type { Verbosity, LogFn } from './utils/assert';
 
 export function getBuildInfo() {
     return {

--- a/src/model/tags.ts
+++ b/src/model/tags.ts
@@ -1,4 +1,4 @@
-import { CustomSection, SkippedSection, ComponentSection, CoreModule } from '../parser/types';
+import { SkippedSection, ComponentSection, CoreModule, CustomSection } from '../parser/types';
 import { ComponentAlias } from './aliases';
 import { CanonicalFunction } from './canonicals';
 import { ComponentExport } from './exports';
@@ -12,7 +12,7 @@ export const enum ModelTag {
     ModelElement,
 
     /// sections
-    CustomSection,
+    CustomSection = 2,
     CoreModule,
     SkippedSection,
     ComponentSection,

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -55,6 +55,7 @@ async function parseWIT(src: Source & Closeable, options?: ParserOptions): Promi
             processCustomSection: options?.[PROCESS_CUSTOM_SECTION] ?? undefined,
             verbose: { ...defaultVerbosity, ...options?.[VERBOSE] },
             logger: options?.[LOGGER] ?? defaultLogger,
+            depth: 0,
         };
 
         const model: WITSection[] = [];
@@ -150,26 +151,36 @@ function parseSectionStart(src: SyncSource): WITSection[] {
     return [readStartFunction(src)];
 }
 
+const MAX_NESTING_DEPTH = 100;
+
 async function parseSectionComponent(
     ctx: ParserContext,
     src: Source,
     size: number
 ): Promise<ComponentSection[]> {
-    const end = src.pos + size;
-    await checkPreamble(src);
-    let model: WITSection[] = [];
-    for (; ;) {
-        if (src.pos == end) {
-            break;
-        }
-        const sections = await parseSection(ctx, src);
-        if (sections === null) {
-            break;
-        }
-        model = [...model, ...sections];
+    if (ctx.depth >= MAX_NESTING_DEPTH) {
+        throw new Error(`component nesting depth exceeds ${MAX_NESTING_DEPTH}`);
     }
-    return [{
-        tag: ModelTag.ComponentSection,
-        sections: model,
-    }];
+    ctx.depth++;
+    try {
+        const end = src.pos + size;
+        await checkPreamble(src);
+        let model: WITSection[] = [];
+        for (; ;) {
+            if (src.pos == end) {
+                break;
+            }
+            const sections = await parseSection(ctx, src);
+            if (sections === null) {
+                break;
+            }
+            model = [...model, ...sections];
+        }
+        return [{
+            tag: ModelTag.ComponentSection,
+            sections: model,
+        }];
+    } finally {
+        ctx.depth--;
+    }
 }

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -10,6 +10,7 @@ import { parseSectionExport } from './export';
 import { parseModule } from './module';
 import { readU32Async, readU32, readCoreType, readStartFunction } from './values';
 import { parseSectionAlias } from './alias';
+import { OTHER_SECTION_DATA, COMPILE_STREAMING, PROCESS_CUSTOM_SECTION, VERBOSE, LOGGER } from '../constants';
 import { parseSectionImport } from './import';
 import { parseSectionType } from './type';
 import { parseSectionCanon } from './canon';
@@ -49,11 +50,11 @@ async function parseWIT(src: Source & Closeable, options?: ParserOptions): Promi
         // eslint-disable-next-line no-console
         const defaultLogger: LogFn = (phase, _level, ...args) => console.log(`[${phase}]`, ...args);
         const ctx: ParserContext = {
-            otherSectionData: options?.otherSectionData ?? false,
-            compileStreaming: options?.compileStreaming ?? WebAssembly.compileStreaming,
-            processCustomSection: options?.processCustomSection ?? undefined,
-            verbose: { ...defaultVerbosity, ...options?.verbose },
-            logger: options?.logger ?? defaultLogger,
+            otherSectionData: options?.[OTHER_SECTION_DATA] ?? false,
+            compileStreaming: options?.[COMPILE_STREAMING] ?? WebAssembly.compileStreaming,
+            processCustomSection: options?.[PROCESS_CUSTOM_SECTION] ?? undefined,
+            verbose: { ...defaultVerbosity, ...options?.[VERBOSE] },
+            logger: options?.[LOGGER] ?? defaultLogger,
         };
 
         const model: WITSection[] = [];

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -53,8 +53,8 @@ async function parseWIT(src: Source & Closeable, options?: ParserOptions): Promi
             otherSectionData: options?.[OTHER_SECTION_DATA] ?? false,
             compileStreaming: options?.[COMPILE_STREAMING] ?? WebAssembly.compileStreaming,
             processCustomSection: options?.[PROCESS_CUSTOM_SECTION] ?? undefined,
-            verbose: { ...defaultVerbosity, ...options?.[VERBOSE] },
-            logger: options?.[LOGGER] ?? defaultLogger,
+            verbose: { ...defaultVerbosity, ...(options as any)?.[VERBOSE] },
+            logger: (options as any)?.[LOGGER] ?? defaultLogger,
             depth: 0,
         };
 

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -1,6 +1,7 @@
+import isDebug from 'env:isDebug';
 import type { WITModel, ParserContext, ParserOptions, ComponentSection } from './types';
 import { fetchLike, getBodyIfResponse } from '../utils/fetch-like';
-import { defaultVerbosity, isDebug, LogLevel } from '../utils/assert';
+import { defaultVerbosity, LogLevel } from '../utils/assert';
 import type { LogFn } from '../utils/assert';
 import { printWAT } from '../utils/wat-printer';
 import { SyncSource, bufferToHex, Closeable, Source, newSource } from '../utils/streaming';

--- a/src/parser/security.test.ts
+++ b/src/parser/security.test.ts
@@ -187,10 +187,10 @@ describe('parser security', () => {
             // Import section (10): count=1, extern name type=0x00, name length = 0xFFFF (huge)
             // but section only has a few bytes
             const wasm = componentWithSection(10, [
-                0x01,       // count = 1
-                0x00,       // extern name type = kebab
+                0x01, // count = 1
+                0x00, // extern name type = kebab
                 0xFF, 0xFF, 0x03, // name length = 65535 (LEB128)
-                0x41        // only 1 byte of name data
+                0x41 // only 1 byte of name data
             ]);
             await expect(parse(wasm)).rejects.toThrow('unexpected EOF');
         });
@@ -198,10 +198,10 @@ describe('parser security', () => {
         test('name with u32 max length', async () => {
             // Import section (10): count=1, extern name type=0x00, name length = 0xFFFFFFFF
             const wasm = componentWithSection(10, [
-                0x01,       // count = 1
-                0x00,       // extern name type = kebab
+                0x01, // count = 1
+                0x00, // extern name type = kebab
                 0xFF, 0xFF, 0xFF, 0xFF, 0x0F, // name length = 4294967295 (u32 max in LEB128)
-                0x41        // only 1 byte
+                0x41 // only 1 byte
             ]);
             await expect(parse(wasm)).rejects.toThrow('unexpected EOF');
         });
@@ -209,10 +209,10 @@ describe('parser security', () => {
         test('zero-length name is accepted', async () => {
             // Type section (7): count=1, type 0x6d (enum), members count=1, name length=0
             const wasm = componentWithSection(7, [
-                0x01,       // count = 1 type
-                0x6d,       // enum
-                0x01,       // 1 member
-                0x00,       // member name length = 0
+                0x01, // count = 1 type
+                0x6d, // enum
+                0x01, // 1 member
+                0x00, // member name length = 0
             ]);
             const model = await parse(wasm);
             expect(model.length).toBe(1);
@@ -222,9 +222,9 @@ describe('parser security', () => {
             // Type section (7): count=1, type 0x6d (enum), members count=1, name = "café" (5 UTF-8 bytes)
             const nameBytes = [...new TextEncoder().encode('café')];
             const wasm = componentWithSection(7, [
-                0x01,       // count = 1 type
-                0x6d,       // enum
-                0x01,       // 1 member
+                0x01, // count = 1 type
+                0x6d, // enum
+                0x01, // 1 member
                 ...leb128U32(nameBytes.length),
                 ...nameBytes,
             ]);
@@ -235,8 +235,8 @@ describe('parser security', () => {
         test('unknown extern name type', async () => {
             // Import section (10): count=1, extern name type=0x05 (invalid)
             const wasm = componentWithSection(10, [
-                0x01,       // count = 1
-                0x05,       // invalid extern name type
+                0x01, // count = 1
+                0x05, // invalid extern name type
                 ...encodeName('test'),
                 // type ref follows but won't be reached
             ]);
@@ -250,7 +250,7 @@ describe('parser security', () => {
         test('overlong LEB128 (6 continuation bytes)', async () => {
             // Type section (7): count encoded as 6-byte LEB128 with unnecessary continuation bits
             const wasm = componentWithSection(7, [
-                0x80, 0x80, 0x80, 0x80, 0x80, 0x00  // overlong encoding of 0
+                0x80, 0x80, 0x80, 0x80, 0x80, 0x00 // overlong encoding of 0
             ]);
             // readRawInteger only reads maxLen=5 bytes, so it won't see the terminator
             // The 5th byte (0x80) has continuation bit set, so the LEB128 has no terminator in 5 bytes
@@ -268,8 +268,8 @@ describe('parser security', () => {
         test('component valtype LEB128 overflow', async () => {
             // Type section (7): count=1, type 0x70 (list), then a valtype index with >5 LEB128 bytes
             const wasm = componentWithSection(7, [
-                0x01,       // count = 1 type
-                0x70,       // list
+                0x01, // count = 1 type
+                0x70, // list
                 // valtype index: 6 continuation bytes (triggers our count > 5 check)
                 0x80, 0x80, 0x80, 0x80, 0x80, 0x00,
             ]);
@@ -283,11 +283,11 @@ describe('parser security', () => {
         test('unknown core val type', async () => {
             // Core type section (3): count=1, tag=0x60 (func), param count=1, invalid val type
             const wasm = componentWithSection(3, [
-                0x01,       // count = 1
-                0x60,       // core func type
-                0x01,       // 1 param
-                0x50,       // invalid core val type
-                0x00,       // 0 results
+                0x01, // count = 1
+                0x60, // core func type
+                0x01, // 1 param
+                0x50, // invalid core val type
+                0x00, // 0 results
             ]);
             await expect(parse(wasm)).rejects.toThrow('unknown core val type');
         });
@@ -295,8 +295,8 @@ describe('parser security', () => {
         test('unknown core type tag', async () => {
             // Core type section (3): count=1, tag=0xFF (unknown)
             const wasm = componentWithSection(3, [
-                0x01,       // count = 1
-                0xFF,       // invalid core type tag — but 0xFF has continuation bit, so it's LEB128
+                0x01, // count = 1
+                0xFF, // invalid core type tag — but 0xFF has continuation bit, so it's LEB128
             ]);
             // The tag 0xFF is read as a byte (src.read()), not LEB128
             // Actually readCoreType reads tag via src.read(), so 0xFF is unknown
@@ -306,8 +306,8 @@ describe('parser security', () => {
         test('unknown component type defined tag', async () => {
             // Type section (7): count=1, type byte 0x50 (not in 0x68-0x72 or 0x73-0x7F ranges)
             const wasm = componentWithSection(7, [
-                0x01,       // count = 1
-                0x50,       // invalid component type defined tag
+                0x01, // count = 1
+                0x50, // invalid component type defined tag
             ]);
             await expect(parse(wasm)).rejects.toThrow('Unrecognized type in readComponentTypeDefined');
         });
@@ -315,8 +315,8 @@ describe('parser security', () => {
         test('unknown canonical function type', async () => {
             // Canon section (8): count=1, type=0x0F (unknown)
             const wasm = componentWithSection(8, [
-                0x01,       // count = 1
-                0x0F,       // invalid canonical function type
+                0x01, // count = 1
+                0x0F, // invalid canonical function type
             ]);
             await expect(parse(wasm)).rejects.toThrow('Unrecognized type in readCanonicalFunction');
         });
@@ -325,11 +325,11 @@ describe('parser security', () => {
             // Canon section (8): count=1, type=0x00 (lift), control=0x00, core_func_index=0,
             // options count=1, option type=0xFF (unknown)
             const wasm = componentWithSection(8, [
-                0x01,       // count = 1
-                0x00,       // lift
-                0x00,       // control byte
-                0x00,       // core_func_index = 0
-                0x01,       // 1 option
+                0x01, // count = 1
+                0x00, // lift
+                0x00, // control byte
+                0x00, // core_func_index = 0
+                0x01, // 1 option
                 0xFF, 0x01, // option type 0xFF — but read as src.read(), so just 0xFF
             ]);
             // readCanonicalOption reads type via src.read() which returns the raw byte
@@ -339,9 +339,9 @@ describe('parser security', () => {
         test('unknown component external kind', async () => {
             // Export section (11): count=1, extern name, kind=0x09 (unknown)
             const wasm = componentWithSection(11, [
-                0x01,       // count = 1
+                0x01, // count = 1
                 ...externNameKebab('test'),
-                0x09,       // invalid component external kind (readU32 returns 9)
+                0x09, // invalid component external kind (readU32 returns 9)
             ]);
             await expect(parse(wasm)).rejects.toThrow('unknown component external kind');
         });
@@ -351,12 +351,12 @@ describe('parser security', () => {
             // module type declarations: count=1, kind=0x03 (export),
             // name, then a TypeRef with invalid external kind byte
             const wasm = componentWithSection(3, [
-                0x01,       // count = 1
-                0x50,       // module type
-                0x01,       // 1 declaration
-                0x03,       // kind = export declaration
+                0x01, // count = 1
+                0x50, // module type
+                0x01, // 1 declaration
+                0x03, // kind = export declaration
                 ...encodeName('test'),
-                0x0F,       // invalid TypeRef kind byte (not 0x00-0x04)
+                0x0F, // invalid TypeRef kind byte (not 0x00-0x04)
             ]);
             // readCoreTypeRef switch expects 0x00-0x04, so 0x0F is unknown
             await expect(parse(wasm)).rejects.toThrow();
@@ -365,10 +365,10 @@ describe('parser security', () => {
         test('unknown instance declaration kind', async () => {
             // Type section (7): count=1, type=0x42 (instance type), count=1, kind=0x0F (unknown)
             const wasm = componentWithSection(7, [
-                0x01,       // count = 1
-                0x42,       // instance type
-                0x01,       // 1 declaration
-                0x0F,       // invalid instance decl kind
+                0x01, // count = 1
+                0x42, // instance type
+                0x01, // 1 declaration
+                0x0F, // invalid instance decl kind
             ]);
             await expect(parse(wasm)).rejects.toThrow('unknown instance type declaration kind');
         });
@@ -376,10 +376,10 @@ describe('parser security', () => {
         test('unknown component func result type', async () => {
             // Type section (7): count=1, type=0x40 (func), 0 params, result type=0x05 (unknown)
             const wasm = componentWithSection(7, [
-                0x01,       // count = 1
-                0x40,       // func type
-                0x00,       // 0 params
-                0x05,       // invalid func result type
+                0x01, // count = 1
+                0x40, // func type
+                0x00, // 0 params
+                0x05, // invalid func result type
             ]);
             await expect(parse(wasm)).rejects.toThrow('unknown ComponentFuncResult type');
         });
@@ -388,13 +388,13 @@ describe('parser security', () => {
             // Core instance section (2): count=1, type=0x00 (instantiate), module_index=0,
             // args count=1, name, kind=0x00 (invalid, should be 0x12)
             const wasm = componentWithSection(2, [
-                0x01,       // count = 1
-                0x00,       // instantiate
-                0x00,       // module_index = 0
-                0x01,       // 1 arg
+                0x01, // count = 1
+                0x00, // instantiate
+                0x00, // module_index = 0
+                0x01, // 1 arg
                 ...encodeName('arg'),
-                0x00,       // invalid kind (should be 0x12)
-                0x00,       // index = 0
+                0x00, // invalid kind (should be 0x12)
+                0x00, // index = 0
             ]);
             await expect(parse(wasm)).rejects.toThrow('Unrecognized kind in readInstantiationArgKind');
         });
@@ -402,10 +402,10 @@ describe('parser security', () => {
         test('unknown type bounds discriminant', async () => {
             // Import section (10): count=1, extern name, type ref = 0x03 (type), bounds=0x05 (unknown)
             const wasm = componentWithSection(10, [
-                0x01,       // count = 1
+                0x01, // count = 1
                 ...externNameKebab('test'),
-                0x03,       // type ref = Type
-                0x05,       // invalid type bounds discriminant
+                0x03, // type ref = Type
+                0x05, // invalid type bounds discriminant
             ]);
             await expect(parse(wasm)).rejects.toThrow('unknown type bounds');
         });
@@ -413,8 +413,8 @@ describe('parser security', () => {
         test('unknown component instance type', async () => {
             // Instance section (5): count=1, type=0x05 (unknown)
             const wasm = componentWithSection(5, [
-                0x01,       // count = 1
-                0x05,       // invalid instance type
+                0x01, // count = 1
+                0x05, // invalid instance type
             ]);
             await expect(parse(wasm)).rejects.toThrow('Unrecognized type in parseSectionInstance');
         });
@@ -422,8 +422,8 @@ describe('parser security', () => {
         test('unknown core instance type', async () => {
             // Core instance section (2): count=1, type=0x05 (unknown)
             const wasm = componentWithSection(2, [
-                0x01,       // count = 1
-                0x05,       // invalid core instance type
+                0x01, // count = 1
+                0x05, // invalid core instance type
             ]);
             await expect(parse(wasm)).rejects.toThrow('Unrecognized type in readCoreInstance');
         });
@@ -431,9 +431,9 @@ describe('parser security', () => {
         test('unknown alias target', async () => {
             // Alias section (6): count=1, b1=0x01 (func), target=0x05 (unknown)
             const wasm = componentWithSection(6, [
-                0x01,       // count = 1
-                0x01,       // sort b1 = func
-                0x05,       // invalid target type
+                0x01, // count = 1
+                0x01, // sort b1 = func
+                0x05, // invalid target type
             ]);
             await expect(parse(wasm)).rejects.toThrow('unknown target type');
         });
@@ -442,9 +442,9 @@ describe('parser security', () => {
             // Type section (7): count=1, type=0x6a (result),
             // ok: flag = 0x05 (invalid, should be 0x00 or 0x01)
             const wasm = componentWithSection(7, [
-                0x01,       // count = 1
-                0x6a,       // result type
-                0x05,       // invalid optional valtype flag
+                0x01, // count = 1
+                0x6a, // result type
+                0x05, // invalid optional valtype flag
             ]);
             await expect(parse(wasm)).rejects.toThrow('invalid optional valtype flag');
         });
@@ -453,12 +453,12 @@ describe('parser security', () => {
             // Type section (7): count=1, type=0x71 (variant), count=1,
             // name, optional valtype=0x00 (absent), refinement flag=0x05 (invalid)
             const wasm = componentWithSection(7, [
-                0x01,       // count = 1
-                0x71,       // variant
-                0x01,       // 1 variant case
+                0x01, // count = 1
+                0x71, // variant
+                0x01, // 1 variant case
                 ...encodeName('case1'),
-                0x00,       // optional valtype absent
-                0x05,       // invalid refinement flag
+                0x00, // optional valtype absent
+                0x05, // invalid refinement flag
             ]);
             await expect(parse(wasm)).rejects.toThrow('invalid optional refinement flag');
         });
@@ -474,37 +474,28 @@ describe('parser security', () => {
             // All those are valid. We need a byte like 0x72 which is 'record', not a primitive,
             // or 0x67 which falls into default of readComponentTypeDefined.
             const wasm = componentWithSection(7, [
-                0x01,       // count = 1
-                0x67,       // invalid tag — not in 0x68-0x72 and not in 0x73-0x7F
+                0x01, // count = 1
+                0x67, // invalid tag — not in 0x68-0x72 and not in 0x73-0x7F
             ]);
             await expect(parse(wasm)).rejects.toThrow('Unrecognized type in readComponentTypeDefined');
         });
 
         test('invalid resource destructor flag', async () => {
-            // Type section (7): count=1, type=0x3F (resource), rep=0x7F (i32), dtor flag=0x05 (invalid)
             const wasm = componentWithSection(7, [
-                0x01,       // count = 1
-                0x3F,       // resource
-                0x7F,       // rep = i32 core val type
+                0x01, // count = 1
+                0x3F, // resource
+                0x00, // rep = 0
+                0x05, // invalid destructor flag
             ]);
-            // readDestructor reads a byte — but 0x3F resource type reads rep via readU32
-            // Let me check: readComponentType case 0x3F: rep: readU32(src), dtor: readDestructor(src)
-            // So rep is a u32 (LEB128), then destructor is a byte
-            const wasm2 = componentWithSection(7, [
-                0x01,       // count = 1
-                0x3F,       // resource
-                0x00,       // rep = 0
-                0x05,       // invalid destructor flag
-            ]);
-            await expect(parse(wasm2)).rejects.toThrow('Invalid leading byte in resource destructor');
+            await expect(parse(wasm)).rejects.toThrow('Invalid leading byte in resource destructor');
         });
 
         test('invalid canon lift control byte', async () => {
             // Canon section (8): count=1, type=0x00 (lift), control byte=0x05 (should be 0x00)
             const wasm = componentWithSection(8, [
-                0x01,       // count = 1
-                0x00,       // lift
-                0x05,       // invalid control byte
+                0x01, // count = 1
+                0x00, // lift
+                0x05, // invalid control byte
             ]);
             await expect(parse(wasm)).rejects.toThrow('Unrecognized byte for CanonicalFunctionLift');
         });
@@ -512,9 +503,9 @@ describe('parser security', () => {
         test('invalid canon lower control byte', async () => {
             // Canon section (8): count=1, type=0x01 (lower), control byte=0x05 (should be 0x00)
             const wasm = componentWithSection(8, [
-                0x01,       // count = 1
-                0x01,       // lower
-                0x05,       // invalid control byte
+                0x01, // count = 1
+                0x01, // lower
+                0x05, // invalid control byte
             ]);
             await expect(parse(wasm)).rejects.toThrow('Unrecognized byte for CanonicalFunctionLower');
         });
@@ -526,21 +517,21 @@ describe('parser security', () => {
         test('huge item count in type section', async () => {
             // Type section (7): count = 0xFFFFFFFF (4294967295) but no data
             const wasm = componentWithSection(7, [
-                0xFF, 0xFF, 0xFF, 0xFF, 0x0F  // count = u32 max
+                0xFF, 0xFF, 0xFF, 0xFF, 0x0F // count = u32 max
             ]);
             await expect(parse(wasm)).rejects.toThrow('unexpected EOF');
         });
 
         test('huge item count in import section', async () => {
             const wasm = componentWithSection(10, [
-                0xFF, 0xFF, 0xFF, 0xFF, 0x0F  // count = u32 max
+                0xFF, 0xFF, 0xFF, 0xFF, 0x0F // count = u32 max
             ]);
             await expect(parse(wasm)).rejects.toThrow('unexpected EOF');
         });
 
         test('huge item count in export section', async () => {
             const wasm = componentWithSection(11, [
-                0xFF, 0xFF, 0xFF, 0xFF, 0x0F  // count = u32 max
+                0xFF, 0xFF, 0xFF, 0xFF, 0x0F // count = u32 max
             ]);
             await expect(parse(wasm)).rejects.toThrow('unexpected EOF');
         });
@@ -549,8 +540,8 @@ describe('parser security', () => {
             // Type section (7): count=1, type=0x6e (flags), members count = u32 max
             const wasm = componentWithSection(7, [
                 0x01,
-                0x6e,  // flags
-                0xFF, 0xFF, 0xFF, 0xFF, 0x0F  // members count = u32 max
+                0x6e, // flags
+                0xFF, 0xFF, 0xFF, 0xFF, 0x0F // members count = u32 max
             ]);
             await expect(parse(wasm)).rejects.toThrow('unexpected EOF');
         });
@@ -559,8 +550,8 @@ describe('parser security', () => {
             // Type section (7): count=1, type=0x71 (variant), case count = u32 max
             const wasm = componentWithSection(7, [
                 0x01,
-                0x71,  // variant
-                0xFF, 0xFF, 0xFF, 0xFF, 0x0F  // case count = u32 max
+                0x71, // variant
+                0xFF, 0xFF, 0xFF, 0xFF, 0x0F // case count = u32 max
             ]);
             await expect(parse(wasm)).rejects.toThrow('unexpected EOF');
         });
@@ -569,8 +560,8 @@ describe('parser security', () => {
             // Type section (7): count=1, type=0x72 (record), member count = u32 max
             const wasm = componentWithSection(7, [
                 0x01,
-                0x72,  // record
-                0xFF, 0xFF, 0xFF, 0xFF, 0x0F  // member count = u32 max
+                0x72, // record
+                0xFF, 0xFF, 0xFF, 0xFF, 0x0F // member count = u32 max
             ]);
             await expect(parse(wasm)).rejects.toThrow('unexpected EOF');
         });
@@ -579,8 +570,8 @@ describe('parser security', () => {
             // Type section (7): count=1, type=0x6f (tuple), member count = u32 max
             const wasm = componentWithSection(7, [
                 0x01,
-                0x6f,  // tuple
-                0xFF, 0xFF, 0xFF, 0xFF, 0x0F  // member count = u32 max
+                0x6f, // tuple
+                0xFF, 0xFF, 0xFF, 0xFF, 0x0F // member count = u32 max
             ]);
             await expect(parse(wasm)).rejects.toThrow('unexpected EOF');
         });
@@ -589,8 +580,8 @@ describe('parser security', () => {
             // Type section (7): count=1, type=0x40 (func), param count = u32 max
             const wasm = componentWithSection(7, [
                 0x01,
-                0x40,  // func
-                0xFF, 0xFF, 0xFF, 0xFF, 0x0F  // param count = u32 max
+                0x40, // func
+                0xFF, 0xFF, 0xFF, 0xFF, 0x0F // param count = u32 max
             ]);
             await expect(parse(wasm)).rejects.toThrow('unexpected EOF');
         });
@@ -600,9 +591,9 @@ describe('parser security', () => {
             // options count = u32 max
             const wasm = componentWithSection(8, [
                 0x01,
-                0x00, 0x00,  // lift, control byte
-                0x00,        // core_func_index = 0
-                0xFF, 0xFF, 0xFF, 0xFF, 0x0F  // options count = u32 max
+                0x00, 0x00, // lift, control byte
+                0x00, // core_func_index = 0
+                0xFF, 0xFF, 0xFF, 0xFF, 0x0F // options count = u32 max
             ]);
             await expect(parse(wasm)).rejects.toThrow('unexpected EOF');
         });
@@ -610,9 +601,9 @@ describe('parser security', () => {
         test('huge export count', async () => {
             // Core instance from exports: count=1, type=0x01, exports count = huge
             const wasm = componentWithSection(2, [
-                0x01,       // count = 1
-                0x01,       // from-exports
-                0xFF, 0xFF, 0xFF, 0xFF, 0x0F  // exports count = u32 max
+                0x01, // count = 1
+                0x01, // from-exports
+                0xFF, 0xFF, 0xFF, 0xFF, 0x0F // exports count = u32 max
             ]);
             await expect(parse(wasm)).rejects.toThrow('unexpected EOF');
         });
@@ -620,10 +611,10 @@ describe('parser security', () => {
         test('huge instantiation args count', async () => {
             // Core instance instantiate: count=1, type=0x00, module=0, args count = huge
             const wasm = componentWithSection(2, [
-                0x01,       // count = 1
-                0x00,       // instantiate
-                0x00,       // module_index = 0
-                0xFF, 0xFF, 0xFF, 0xFF, 0x0F  // args count = u32 max
+                0x01, // count = 1
+                0x00, // instantiate
+                0x00, // module_index = 0
+                0xFF, 0xFF, 0xFF, 0xFF, 0x0F // args count = u32 max
             ]);
             await expect(parse(wasm)).rejects.toThrow('unexpected EOF');
         });
@@ -631,10 +622,10 @@ describe('parser security', () => {
         test('huge component instantiation args count', async () => {
             // Instance section (5): count=1, type=0x00 (instantiate), component=0, args count = huge
             const wasm = componentWithSection(5, [
-                0x01,       // count = 1
-                0x00,       // instantiate
-                0x00,       // component_index = 0
-                0xFF, 0xFF, 0xFF, 0xFF, 0x0F  // args count = u32 max
+                0x01, // count = 1
+                0x00, // instantiate
+                0x00, // component_index = 0
+                0xFF, 0xFF, 0xFF, 0xFF, 0x0F // args count = u32 max
             ]);
             await expect(parse(wasm)).rejects.toThrow('unexpected EOF');
         });
@@ -643,8 +634,8 @@ describe('parser security', () => {
             // Type section (7): count=1, type=0x42 (instance), declarations count = huge
             const wasm = componentWithSection(7, [
                 0x01,
-                0x42,  // instance type
-                0xFF, 0xFF, 0xFF, 0xFF, 0x0F  // declarations count = u32 max
+                0x42, // instance type
+                0xFF, 0xFF, 0xFF, 0xFF, 0x0F // declarations count = u32 max
             ]);
             await expect(parse(wasm)).rejects.toThrow('unexpected EOF');
         });
@@ -652,8 +643,8 @@ describe('parser security', () => {
         test('huge start function args count', async () => {
             // Start section (9): func_index=0, argCount = u32 max
             const wasm = componentWithSection(9, [
-                0x00,  // func_index = 0
-                0xFF, 0xFF, 0xFF, 0xFF, 0x0F  // arg count = u32 max
+                0x00, // func_index = 0
+                0xFF, 0xFF, 0xFF, 0xFF, 0x0F // arg count = u32 max
             ]);
             await expect(parse(wasm)).rejects.toThrow('unexpected EOF');
         });
@@ -666,8 +657,8 @@ describe('parser security', () => {
             // Type section (7): count=1, type=0x70 (list), element = type index 0xFFFFFFFF
             const wasm = componentWithSection(7, [
                 0x01,
-                0x70,       // list
-                0xFF, 0xFF, 0xFF, 0xFF, 0x0F  // type index = u32 max
+                0x70, // list
+                0xFF, 0xFF, 0xFF, 0xFF, 0x0F // type index = u32 max
             ]);
             // Parser doesn't validate index ranges — this should parse without error
             const model = await parse(wasm);
@@ -678,10 +669,10 @@ describe('parser security', () => {
             // Canon section (8): count=1, lift with huge core func index
             const wasm = componentWithSection(8, [
                 0x01,
-                0x00, 0x00,  // lift, control byte
-                0xFF, 0xFF, 0xFF, 0xFF, 0x0F,  // core_func_index = u32 max
-                0x00,        // 0 options
-                0x00,        // type_index = 0
+                0x00, 0x00, // lift, control byte
+                0xFF, 0xFF, 0xFF, 0xFF, 0x0F, // core_func_index = u32 max
+                0x00, // 0 options
+                0x00, // type_index = 0
             ]);
             const model = await parse(wasm);
             expect(model.length).toBe(1);
@@ -691,9 +682,9 @@ describe('parser security', () => {
             // Canon section (8): count=1, lower with huge func index
             const wasm = componentWithSection(8, [
                 0x01,
-                0x01, 0x00,  // lower, control byte
-                0xFF, 0xFF, 0xFF, 0xFF, 0x0F,  // func_index = u32 max
-                0x00,        // 0 options
+                0x01, 0x00, // lower, control byte
+                0xFF, 0xFF, 0xFF, 0xFF, 0x0F, // func_index = u32 max
+                0x00, // 0 options
             ]);
             const model = await parse(wasm);
             expect(model.length).toBe(1);
@@ -703,9 +694,9 @@ describe('parser security', () => {
             // Core instance section (2): count=1, instantiate, module index = huge
             const wasm = componentWithSection(2, [
                 0x01,
-                0x00,       // instantiate
-                0xFF, 0xFF, 0xFF, 0xFF, 0x0F,  // module_index = u32 max
-                0x00,       // 0 args
+                0x00, // instantiate
+                0xFF, 0xFF, 0xFF, 0xFF, 0x0F, // module_index = u32 max
+                0x00, // 0 args
             ]);
             const model = await parse(wasm);
             expect(model.length).toBe(1);
@@ -715,9 +706,9 @@ describe('parser security', () => {
             // Instance section (5): count=1, instantiate, component index = huge
             const wasm = componentWithSection(5, [
                 0x01,
-                0x00,       // instantiate
-                0xFF, 0xFF, 0xFF, 0xFF, 0x0F,  // component_index = u32 max
-                0x00,       // 0 args
+                0x00, // instantiate
+                0xFF, 0xFF, 0xFF, 0xFF, 0x0F, // component_index = u32 max
+                0x00, // 0 args
             ]);
             const model = await parse(wasm);
             expect(model.length).toBe(1);
@@ -727,8 +718,8 @@ describe('parser security', () => {
             // Canon section (8): count=1, resource.new with huge resource index
             const wasm = componentWithSection(8, [
                 0x01,
-                0x02,       // resource.new
-                0xFF, 0xFF, 0xFF, 0xFF, 0x0F,  // resource = u32 max
+                0x02, // resource.new
+                0xFF, 0xFF, 0xFF, 0xFF, 0x0F, // resource = u32 max
             ]);
             const model = await parse(wasm);
             expect(model.length).toBe(1);
@@ -737,8 +728,8 @@ describe('parser security', () => {
         test('resource index at u32 max in resource.drop', async () => {
             const wasm = componentWithSection(8, [
                 0x01,
-                0x03,       // resource.drop
-                0xFF, 0xFF, 0xFF, 0xFF, 0x0F,  // resource = u32 max
+                0x03, // resource.drop
+                0xFF, 0xFF, 0xFF, 0xFF, 0x0F, // resource = u32 max
             ]);
             const model = await parse(wasm);
             expect(model.length).toBe(1);
@@ -747,8 +738,8 @@ describe('parser security', () => {
         test('resource index at u32 max in resource.rep', async () => {
             const wasm = componentWithSection(8, [
                 0x01,
-                0x04,       // resource.rep
-                0xFF, 0xFF, 0xFF, 0xFF, 0x0F,  // resource = u32 max
+                0x04, // resource.rep
+                0xFF, 0xFF, 0xFF, 0xFF, 0x0F, // resource = u32 max
             ]);
             const model = await parse(wasm);
             expect(model.length).toBe(1);
@@ -758,10 +749,10 @@ describe('parser security', () => {
             // Alias section (6): count=1, sort=0x01 (func), target=0x00 (instance export),
             // instance index = huge, name
             const wasm = componentWithSection(6, [
-                0x01,       // count = 1
-                0x01,       // sort b1 = func
-                0x00,       // target = instance export
-                0xFF, 0xFF, 0xFF, 0xFF, 0x0F,  // instance_index = u32 max
+                0x01, // count = 1
+                0x01, // sort b1 = func
+                0x00, // target = instance export
+                0xFF, 0xFF, 0xFF, 0xFF, 0x0F, // instance_index = u32 max
                 ...encodeName('x'),
             ]);
             const model = await parse(wasm);
@@ -772,11 +763,11 @@ describe('parser security', () => {
             // Alias section (6): count=1, sort=0x00, sub=0x00 (func), target=0x01 (core instance export)
             // core instance index = huge, name
             const wasm = componentWithSection(6, [
-                0x01,       // count = 1
-                0x00,       // sort b1 = core
-                0x00,       // sort b2 = func (ExternalKind.Func)
-                0x01,       // target = core instance export
-                0xFF, 0xFF, 0xFF, 0xFF, 0x0F,  // core_instance_index = u32 max
+                0x01, // count = 1
+                0x00, // sort b1 = core
+                0x00, // sort b2 = func (ExternalKind.Func)
+                0x01, // target = core instance export
+                0xFF, 0xFF, 0xFF, 0xFF, 0x0F, // core_instance_index = u32 max
                 ...encodeName('x'),
             ]);
             const model = await parse(wasm);
@@ -787,11 +778,11 @@ describe('parser security', () => {
             // Alias section (6): count=1, sort=0x03 (type), target=0x02 (outer),
             // count = huge, index = huge
             const wasm = componentWithSection(6, [
-                0x01,       // count = 1
-                0x03,       // sort b1 = Type outer alias kind
-                0x02,       // target = outer
-                0xFF, 0xFF, 0xFF, 0xFF, 0x0F,  // count = u32 max
-                0xFF, 0xFF, 0xFF, 0xFF, 0x0F,  // index = u32 max
+                0x01, // count = 1
+                0x03, // sort b1 = Type outer alias kind
+                0x02, // target = outer
+                0xFF, 0xFF, 0xFF, 0xFF, 0x0F, // count = u32 max
+                0xFF, 0xFF, 0xFF, 0xFF, 0x0F, // index = u32 max
             ]);
             const model = await parse(wasm);
             expect(model.length).toBe(1);
@@ -800,11 +791,11 @@ describe('parser security', () => {
         test('export index at u32 max', async () => {
             // Export section (11): count=1, name, kind=func, index=huge, no type bound
             const wasm = componentWithSection(11, [
-                0x01,       // count = 1
+                0x01, // count = 1
                 ...externNameKebab('test'),
-                0x01,       // kind = func
-                0xFF, 0xFF, 0xFF, 0xFF, 0x0F,  // index = u32 max
-                0x00,       // no type bound
+                0x01, // kind = func
+                0xFF, 0xFF, 0xFF, 0xFF, 0x0F, // index = u32 max
+                0x00, // no type bound
             ]);
             const model = await parse(wasm);
             expect(model.length).toBe(1);
@@ -813,10 +804,10 @@ describe('parser security', () => {
         test('type ref index at u32 max in import', async () => {
             // Import section (10): count=1, name, type ref = func, index = huge
             const wasm = componentWithSection(10, [
-                0x01,       // count = 1
+                0x01, // count = 1
                 ...externNameKebab('test'),
-                0x01,       // type ref = Func
-                0xFF, 0xFF, 0xFF, 0xFF, 0x0F,  // func type index = u32 max
+                0x01, // type ref = Func
+                0xFF, 0xFF, 0xFF, 0xFF, 0x0F, // func type index = u32 max
             ]);
             const model = await parse(wasm);
             expect(model.length).toBe(1);
@@ -827,12 +818,12 @@ describe('parser security', () => {
             // 1 option: memory with huge index, type_index=0
             const wasm = componentWithSection(8, [
                 0x01,
-                0x00, 0x00,  // lift, control byte
-                0x00,        // core_func_index = 0
-                0x01,        // 1 option
-                0x03,        // memory option
-                0xFF, 0xFF, 0xFF, 0xFF, 0x0F,  // memory index = u32 max
-                0x00,        // type_index = 0
+                0x00, 0x00, // lift, control byte
+                0x00, // core_func_index = 0
+                0x01, // 1 option
+                0x03, // memory option
+                0xFF, 0xFF, 0xFF, 0xFF, 0x0F, // memory index = u32 max
+                0x00, // type_index = 0
             ]);
             const model = await parse(wasm);
             expect(model.length).toBe(1);
@@ -842,11 +833,11 @@ describe('parser security', () => {
             // Start section (9): func=huge, argCount=2, arg0=huge, arg1=huge, results=huge
             const huge = [0xFF, 0xFF, 0xFF, 0xFF, 0x0F];
             const wasm = componentWithSection(9, [
-                ...huge,    // func_index
-                0x02,       // 2 args
-                ...huge,    // arg[0]
-                ...huge,    // arg[1]
-                ...huge,    // results
+                ...huge, // func_index
+                0x02, // 2 args
+                ...huge, // arg[0]
+                ...huge, // arg[1]
+                ...huge, // results
             ]);
             const model = await parse(wasm);
             expect(model.length).toBe(1);
@@ -858,11 +849,11 @@ describe('parser security', () => {
             // [1]: own with huge index
             const huge = [0xFF, 0xFF, 0xFF, 0xFF, 0x0F];
             const wasm = componentWithSection(7, [
-                0x02,       // count = 2
-                0x68,       // borrow
-                ...huge,    // type index
-                0x69,       // own
-                ...huge,    // type index
+                0x02, // count = 2
+                0x68, // borrow
+                ...huge, // type index
+                0x69, // own
+                ...huge, // type index
             ]);
             const model = await parse(wasm);
             expect(model.length).toBe(2);
@@ -874,10 +865,10 @@ describe('parser security', () => {
             // kind 0x00 = module, kind 0x01 = func, kind 0x04 = component, kind 0x05 = instance
             for (const kind of [0x00, 0x01, 0x04, 0x05]) {
                 const wasm = componentWithSection(10, [
-                    0x01,       // count = 1
+                    0x01, // count = 1
                     ...externNameKebab('test'),
-                    kind,       // type ref kind
-                    ...huge,    // type index = u32 max
+                    kind, // type ref kind
+                    ...huge, // type index = u32 max
                 ]);
                 const model = await parse(wasm);
                 expect(model.length).toBe(1);
@@ -891,10 +882,10 @@ describe('parser security', () => {
         test('readExact with n=0 returns empty array', async () => {
             // A zero-length name should work (length=0 means readExact(0))
             const wasm = componentWithSection(7, [
-                0x01,       // count = 1
-                0x6e,       // flags
-                0x01,       // 1 member
-                0x00,       // member name length = 0
+                0x01, // count = 1
+                0x6e, // flags
+                0x01, // 1 member
+                0x00, // member name length = 0
             ]);
             const model = await parse(wasm);
             expect(model.length).toBe(1);
@@ -947,12 +938,12 @@ describe('parser security', () => {
             // The deepest fails when depth >= 100
 
             // Build from inside out
-            let inner = new Uint8Array(PREAMBLE);  // innermost empty component
+            let inner = new Uint8Array(PREAMBLE); // innermost empty component
             for (let i = 0; i < 101; i++) {
                 const sizeBytes = leb128U32(inner.length);
                 const outer = new Uint8Array([
                     ...PREAMBLE,
-                    4,  // component section
+                    4, // component section
                     ...sizeBytes,
                     ...inner
                 ]);
@@ -985,9 +976,9 @@ describe('parser security', () => {
             // Type section (7): count=1, result with ok=absent, err=absent
             const wasm = componentWithSection(7, [
                 0x01,
-                0x6a,       // result
-                0x00,       // ok absent
-                0x00,       // err absent
+                0x6a, // result
+                0x00, // ok absent
+                0x00, // err absent
             ]);
             const model = await parse(wasm);
             expect(model.length).toBe(1);
@@ -997,7 +988,7 @@ describe('parser security', () => {
             // Type section (7): count=1, result with ok=string, err=string
             const wasm = componentWithSection(7, [
                 0x01,
-                0x6a,       // result
+                0x6a, // result
                 0x01, 0x73, // ok = present, string primitive
                 0x01, 0x73, // err = present, string primitive
             ]);
@@ -1008,8 +999,8 @@ describe('parser security', () => {
         test('option type with type index 0', async () => {
             const wasm = componentWithSection(7, [
                 0x01,
-                0x6b,       // option
-                0x00,       // type index 0
+                0x6b, // option
+                0x00, // type index 0
             ]);
             const model = await parse(wasm);
             expect(model.length).toBe(1);
@@ -1018,8 +1009,8 @@ describe('parser security', () => {
         test('empty enum (0 members)', async () => {
             const wasm = componentWithSection(7, [
                 0x01,
-                0x6d,       // enum
-                0x00,       // 0 members
+                0x6d, // enum
+                0x00, // 0 members
             ]);
             const model = await parse(wasm);
             expect(model.length).toBe(1);
@@ -1028,8 +1019,8 @@ describe('parser security', () => {
         test('empty flags (0 members)', async () => {
             const wasm = componentWithSection(7, [
                 0x01,
-                0x6e,       // flags
-                0x00,       // 0 members
+                0x6e, // flags
+                0x00, // 0 members
             ]);
             const model = await parse(wasm);
             expect(model.length).toBe(1);
@@ -1038,8 +1029,8 @@ describe('parser security', () => {
         test('empty tuple (0 members)', async () => {
             const wasm = componentWithSection(7, [
                 0x01,
-                0x6f,       // tuple
-                0x00,       // 0 members
+                0x6f, // tuple
+                0x00, // 0 members
             ]);
             const model = await parse(wasm);
             expect(model.length).toBe(1);
@@ -1048,8 +1039,8 @@ describe('parser security', () => {
         test('empty variant (0 cases)', async () => {
             const wasm = componentWithSection(7, [
                 0x01,
-                0x71,       // variant
-                0x00,       // 0 cases
+                0x71, // variant
+                0x00, // 0 cases
             ]);
             const model = await parse(wasm);
             expect(model.length).toBe(1);
@@ -1058,8 +1049,8 @@ describe('parser security', () => {
         test('empty record (0 members)', async () => {
             const wasm = componentWithSection(7, [
                 0x01,
-                0x72,       // record
-                0x00,       // 0 members
+                0x72, // record
+                0x00, // 0 members
             ]);
             const model = await parse(wasm);
             expect(model.length).toBe(1);
@@ -1068,10 +1059,10 @@ describe('parser security', () => {
         test('func type with 0 params and unnamed result', async () => {
             const wasm = componentWithSection(7, [
                 0x01,
-                0x40,       // func
-                0x00,       // 0 params
-                0x00,       // unnamed result
-                0x73,       // result type = string
+                0x40, // func
+                0x00, // 0 params
+                0x00, // unnamed result
+                0x73, // result type = string
             ]);
             const model = await parse(wasm);
             expect(model.length).toBe(1);
@@ -1080,12 +1071,12 @@ describe('parser security', () => {
         test('func type with named results', async () => {
             const wasm = componentWithSection(7, [
                 0x01,
-                0x40,       // func
-                0x00,       // 0 params
-                0x01,       // named results
-                0x01,       // 1 named value
+                0x40, // func
+                0x00, // 0 params
+                0x01, // named results
+                0x01, // 1 named value
                 ...encodeName('r'),
-                0x73,       // type = string
+                0x73, // type = string
             ]);
             const model = await parse(wasm);
             expect(model.length).toBe(1);
@@ -1095,7 +1086,7 @@ describe('parser security', () => {
             // 0x41 = component type (no declarations to read)
             const wasm = componentWithSection(7, [
                 0x01,
-                0x41,       // component type
+                0x41, // component type
             ]);
             const model = await parse(wasm);
             expect(model.length).toBe(1);
@@ -1106,15 +1097,15 @@ describe('parser security', () => {
             // 0x00 = core type, 0x01 = type, 0x03 = import, 0x04 = export
             const wasm = componentWithSection(7, [
                 0x01,
-                0x42,       // instance type
-                0x02,       // 2 declarations
+                0x42, // instance type
+                0x02, // 2 declarations
                 // decl 0: type (kind=0x01) -> primitive string
                 0x01, 0x73,
                 // decl 1: export (kind=0x04) -> name + type ref
                 0x04,
                 ...externNameKebab('x'),
-                0x01,       // type ref = func
-                0x00,       // func type index = 0
+                0x01, // type ref = func
+                0x00, // func type index = 0
             ]);
             const model = await parse(wasm);
             expect(model.length).toBe(1);

--- a/src/parser/security.test.ts
+++ b/src/parser/security.test.ts
@@ -1,0 +1,1181 @@
+import { parse, WIT_MAGIC, WIT_VERSION, WIT_LAYER } from './index';
+
+// Component model binary preamble
+const PREAMBLE = [...WIT_MAGIC, ...WIT_VERSION, ...WIT_LAYER];
+
+/**
+ * Build a minimal component binary with one section.
+ * @param sectionId - section type byte (0–11)
+ * @param payload - raw section payload bytes (length is auto-prefixed as LEB128 u32)
+ */
+function componentWithSection(sectionId: number, payload: number[]): Uint8Array {
+    return new Uint8Array([...PREAMBLE, sectionId, ...leb128U32(payload.length), ...payload]);
+}
+
+/** Encode a u32 value as LEB128 bytes. */
+function leb128U32(value: number): number[] {
+    const result: number[] = [];
+    do {
+        let byte = value & 0x7f;
+        value >>>= 7;
+        if (value !== 0) byte |= 0x80;
+        result.push(byte);
+    } while (value !== 0);
+    return result;
+}
+
+/** Encode a name string as length-prefixed UTF-8 (the component-model name encoding). */
+function encodeName(name: string): number[] {
+    const utf8 = new TextEncoder().encode(name);
+    return [...leb128U32(utf8.length), ...utf8];
+}
+
+/** Build a ComponentExternName (kebab-case, discriminant 0x00). */
+function externNameKebab(name: string): number[] {
+    return [0x00, ...encodeName(name)];
+}
+
+describe('parser security', () => {
+    // ─── Preamble validation ───
+
+    describe('preamble', () => {
+        test('empty input', async () => {
+            await expect(parse(new Uint8Array([]))).rejects.toThrow('unexpected EOF');
+        });
+
+        test('truncated magic (3 bytes)', async () => {
+            await expect(parse(new Uint8Array([0x00, 0x61, 0x73]))).rejects.toThrow('unexpected EOF');
+        });
+
+        test('missing layer bytes', async () => {
+            // only magic + version (6 bytes), missing layer
+            await expect(parse(new Uint8Array([...WIT_MAGIC, ...WIT_VERSION]))).rejects.toThrow('unexpected EOF');
+        });
+
+        test('wrong magic', async () => {
+            const wasm = new Uint8Array([0x00, 0x00, 0x00, 0x00, ...WIT_VERSION, ...WIT_LAYER]);
+            await expect(parse(wasm)).rejects.toThrow('unexpected magic, version or layer.');
+        });
+
+        test('wrong version', async () => {
+            const wasm = new Uint8Array([...WIT_MAGIC, 0xFF, 0x00, ...WIT_LAYER]);
+            await expect(parse(wasm)).rejects.toThrow('unexpected magic, version or layer.');
+        });
+
+        test('wrong layer', async () => {
+            const wasm = new Uint8Array([...WIT_MAGIC, ...WIT_VERSION, 0x00, 0x00]);
+            await expect(parse(wasm)).rejects.toThrow('unexpected magic, version or layer.');
+        });
+
+        test('core wasm module header (layer 0)', async () => {
+            // layer = [0x00, 0x00] instead of [0x01, 0x00]
+            const wasm = new Uint8Array([...WIT_MAGIC, 0x01, 0x00, 0x00, 0x00]);
+            await expect(parse(wasm)).rejects.toThrow('unexpected magic, version or layer.');
+        });
+    });
+
+    // ─── Unknown / invalid section IDs ───
+
+    describe('unknown section types', () => {
+        test('section ID 12 (out of range)', async () => {
+            const wasm = componentWithSection(12, []);
+            await expect(parse(wasm)).rejects.toThrow('unknown section: 12');
+        });
+
+        test('section ID 0xFF', async () => {
+            const wasm = componentWithSection(0xFF, []);
+            await expect(parse(wasm)).rejects.toThrow('unknown section: 255');
+        });
+
+        test('section ID 42', async () => {
+            const wasm = componentWithSection(42, []);
+            await expect(parse(wasm)).rejects.toThrow('unknown section: 42');
+        });
+    });
+
+    // ─── Section size mismatches ───
+
+    describe('section size', () => {
+        test('declared size larger than available data', async () => {
+            // Type section (7) with declared size 100 but only 2 bytes of payload
+            const wasm = new Uint8Array([...PREAMBLE, 7, ...leb128U32(100), 0x01, 0x73]);
+            await expect(parse(wasm)).rejects.toThrow('unexpected EOF');
+        });
+
+        test('declared size smaller than actual content', async () => {
+            // Type section (7): count=1, one primitive type (0x73) - but section size = 1 (only covers count)
+            const wasm = new Uint8Array([...PREAMBLE, 7, ...leb128U32(1), 0x01, 0x73]);
+            // size=1 means only 1 byte is read into SyncArraySource, so reading the type will EOF
+            await expect(parse(wasm)).rejects.toThrow();
+        });
+
+        test('zero-length section for type section', async () => {
+            // Type section (7) with 0 bytes of payload - can't even read the count
+            const wasm = componentWithSection(7, []);
+            await expect(parse(wasm)).rejects.toThrow('unexpected EOF');
+        });
+
+        test('extra bytes after section content', async () => {
+            // Type section with count=0 + an extra trailing byte
+            const wasm = componentWithSection(7, [0x00, 0xFF]);
+            await expect(parse(wasm)).rejects.toThrow('invalid size after reading section 7');
+        });
+    });
+
+    // ─── Truncated section payloads ───
+
+    describe('truncated sections', () => {
+        test('import section: truncated after count', async () => {
+            // Import section (10): count=1 but no import data
+            const wasm = componentWithSection(10, [0x01]);
+            await expect(parse(wasm)).rejects.toThrow('unexpected EOF');
+        });
+
+        test('export section: truncated mid-name', async () => {
+            // Export section (11): count=1, extern name type=0x00, name length=10, but only 3 bytes of name
+            const wasm = componentWithSection(11, [0x01, 0x00, 0x0A, 0x41, 0x42, 0x43]);
+            await expect(parse(wasm)).rejects.toThrow('unexpected EOF');
+        });
+
+        test('alias section: truncated after sort byte', async () => {
+            // Alias section (6): count=1, sort b1=0x01 (func), then nothing
+            const wasm = componentWithSection(6, [0x01, 0x01]);
+            await expect(parse(wasm)).rejects.toThrow('unexpected EOF');
+        });
+
+        test('canon section: truncated after function type', async () => {
+            // Canon section (8): count=1, type=0x00 (lift), then nothing
+            const wasm = componentWithSection(8, [0x01, 0x00]);
+            await expect(parse(wasm)).rejects.toThrow('unexpected EOF');
+        });
+
+        test('start section: truncated mid-arguments', async () => {
+            // Start section (9): func_index=0, argCount=5, but no arg data
+            const wasm = componentWithSection(9, [0x00, 0x05]);
+            await expect(parse(wasm)).rejects.toThrow('unexpected EOF');
+        });
+
+        test('core instance section: truncated', async () => {
+            // Core instance section (2): count=1, type=0x00 (instantiate), then nothing
+            const wasm = componentWithSection(2, [0x01, 0x00]);
+            await expect(parse(wasm)).rejects.toThrow('unexpected EOF');
+        });
+
+        test('instance section: truncated', async () => {
+            // Instance section (5): count=1, type=0x00 (instantiate), then nothing
+            const wasm = componentWithSection(5, [0x01, 0x00]);
+            await expect(parse(wasm)).rejects.toThrow('unexpected EOF');
+        });
+
+        test('type section: truncated after type tag', async () => {
+            // Type section (7): count=1, type tag 0x72 (record), then nothing
+            const wasm = componentWithSection(7, [0x01, 0x72]);
+            await expect(parse(wasm)).rejects.toThrow('unexpected EOF');
+        });
+
+        test('truncated LEB128 mid-byte', async () => {
+            // Type section (7) with a LEB128 count that has continuation bit set but no more bytes
+            const wasm = componentWithSection(7, [0x80]);
+            await expect(parse(wasm)).rejects.toThrow('unexpected EOF');
+        });
+    });
+
+    // ─── String / name validation ───
+
+    describe('string and name handling', () => {
+        test('name length exceeds section bounds', async () => {
+            // Import section (10): count=1, extern name type=0x00, name length = 0xFFFF (huge)
+            // but section only has a few bytes
+            const wasm = componentWithSection(10, [
+                0x01,       // count = 1
+                0x00,       // extern name type = kebab
+                0xFF, 0xFF, 0x03, // name length = 65535 (LEB128)
+                0x41        // only 1 byte of name data
+            ]);
+            await expect(parse(wasm)).rejects.toThrow('unexpected EOF');
+        });
+
+        test('name with u32 max length', async () => {
+            // Import section (10): count=1, extern name type=0x00, name length = 0xFFFFFFFF
+            const wasm = componentWithSection(10, [
+                0x01,       // count = 1
+                0x00,       // extern name type = kebab
+                0xFF, 0xFF, 0xFF, 0xFF, 0x0F, // name length = 4294967295 (u32 max in LEB128)
+                0x41        // only 1 byte
+            ]);
+            await expect(parse(wasm)).rejects.toThrow('unexpected EOF');
+        });
+
+        test('zero-length name is accepted', async () => {
+            // Type section (7): count=1, type 0x6d (enum), members count=1, name length=0
+            const wasm = componentWithSection(7, [
+                0x01,       // count = 1 type
+                0x6d,       // enum
+                0x01,       // 1 member
+                0x00,       // member name length = 0
+            ]);
+            const model = await parse(wasm);
+            expect(model.length).toBe(1);
+        });
+
+        test('name with valid multi-byte UTF-8', async () => {
+            // Type section (7): count=1, type 0x6d (enum), members count=1, name = "café" (5 UTF-8 bytes)
+            const nameBytes = [...new TextEncoder().encode('café')];
+            const wasm = componentWithSection(7, [
+                0x01,       // count = 1 type
+                0x6d,       // enum
+                0x01,       // 1 member
+                ...leb128U32(nameBytes.length),
+                ...nameBytes,
+            ]);
+            const model = await parse(wasm);
+            expect(model.length).toBe(1);
+        });
+
+        test('unknown extern name type', async () => {
+            // Import section (10): count=1, extern name type=0x05 (invalid)
+            const wasm = componentWithSection(10, [
+                0x01,       // count = 1
+                0x05,       // invalid extern name type
+                ...encodeName('test'),
+                // type ref follows but won't be reached
+            ]);
+            await expect(parse(wasm)).rejects.toThrow('unknown ComponentExternName');
+        });
+    });
+
+    // ─── LEB128 encoding attacks ───
+
+    describe('LEB128 encoding', () => {
+        test('overlong LEB128 (6 continuation bytes)', async () => {
+            // Type section (7): count encoded as 6-byte LEB128 with unnecessary continuation bits
+            const wasm = componentWithSection(7, [
+                0x80, 0x80, 0x80, 0x80, 0x80, 0x00  // overlong encoding of 0
+            ]);
+            // readRawInteger only reads maxLen=5 bytes, so it won't see the terminator
+            // The 5th byte (0x80) has continuation bit set, so the LEB128 has no terminator in 5 bytes
+            await expect(parse(wasm)).rejects.toThrow();
+        });
+
+        test('LEB128 all continuation bits, no terminator', async () => {
+            // section payload is 5 bytes all with continuation bit set
+            const wasm = componentWithSection(7, [
+                0x80, 0x80, 0x80, 0x80, 0x80
+            ]);
+            await expect(parse(wasm)).rejects.toThrow();
+        });
+
+        test('component valtype LEB128 overflow', async () => {
+            // Type section (7): count=1, type 0x70 (list), then a valtype index with >5 LEB128 bytes
+            const wasm = componentWithSection(7, [
+                0x01,       // count = 1 type
+                0x70,       // list
+                // valtype index: 6 continuation bytes (triggers our count > 5 check)
+                0x80, 0x80, 0x80, 0x80, 0x80, 0x00,
+            ]);
+            await expect(parse(wasm)).rejects.toThrow('LEB128 overflow in component val type index');
+        });
+    });
+
+    // ─── Invalid discriminant / type tags ───
+
+    describe('invalid type discriminants', () => {
+        test('unknown core val type', async () => {
+            // Core type section (3): count=1, tag=0x60 (func), param count=1, invalid val type
+            const wasm = componentWithSection(3, [
+                0x01,       // count = 1
+                0x60,       // core func type
+                0x01,       // 1 param
+                0x50,       // invalid core val type
+                0x00,       // 0 results
+            ]);
+            await expect(parse(wasm)).rejects.toThrow('unknown core val type');
+        });
+
+        test('unknown core type tag', async () => {
+            // Core type section (3): count=1, tag=0xFF (unknown)
+            const wasm = componentWithSection(3, [
+                0x01,       // count = 1
+                0xFF,       // invalid core type tag — but 0xFF has continuation bit, so it's LEB128
+            ]);
+            // The tag 0xFF is read as a byte (src.read()), not LEB128
+            // Actually readCoreType reads tag via src.read(), so 0xFF is unknown
+            await expect(parse(wasm)).rejects.toThrow('unknown core type tag');
+        });
+
+        test('unknown component type defined tag', async () => {
+            // Type section (7): count=1, type byte 0x50 (not in 0x68-0x72 or 0x73-0x7F ranges)
+            const wasm = componentWithSection(7, [
+                0x01,       // count = 1
+                0x50,       // invalid component type defined tag
+            ]);
+            await expect(parse(wasm)).rejects.toThrow('Unrecognized type in readComponentTypeDefined');
+        });
+
+        test('unknown canonical function type', async () => {
+            // Canon section (8): count=1, type=0x0F (unknown)
+            const wasm = componentWithSection(8, [
+                0x01,       // count = 1
+                0x0F,       // invalid canonical function type
+            ]);
+            await expect(parse(wasm)).rejects.toThrow('Unrecognized type in readCanonicalFunction');
+        });
+
+        test('unknown canonical option type', async () => {
+            // Canon section (8): count=1, type=0x00 (lift), control=0x00, core_func_index=0,
+            // options count=1, option type=0xFF (unknown)
+            const wasm = componentWithSection(8, [
+                0x01,       // count = 1
+                0x00,       // lift
+                0x00,       // control byte
+                0x00,       // core_func_index = 0
+                0x01,       // 1 option
+                0xFF, 0x01, // option type 0xFF — but read as src.read(), so just 0xFF
+            ]);
+            // readCanonicalOption reads type via src.read() which returns the raw byte
+            await expect(parse(wasm)).rejects.toThrow('Unrecognized type in readCanonicalOption');
+        });
+
+        test('unknown component external kind', async () => {
+            // Export section (11): count=1, extern name, kind=0x09 (unknown)
+            const wasm = componentWithSection(11, [
+                0x01,       // count = 1
+                ...externNameKebab('test'),
+                0x09,       // invalid component external kind (readU32 returns 9)
+            ]);
+            await expect(parse(wasm)).rejects.toThrow('unknown component external kind');
+        });
+
+        test('unknown external kind (core)', async () => {
+            // Core type section (3): count=1, tag=0x50 (module),
+            // module type declarations: count=1, kind=0x03 (export),
+            // name, then a TypeRef with invalid external kind byte
+            const wasm = componentWithSection(3, [
+                0x01,       // count = 1
+                0x50,       // module type
+                0x01,       // 1 declaration
+                0x03,       // kind = export declaration
+                ...encodeName('test'),
+                0x0F,       // invalid TypeRef kind byte (not 0x00-0x04)
+            ]);
+            // readCoreTypeRef switch expects 0x00-0x04, so 0x0F is unknown
+            await expect(parse(wasm)).rejects.toThrow();
+        });
+
+        test('unknown instance declaration kind', async () => {
+            // Type section (7): count=1, type=0x42 (instance type), count=1, kind=0x0F (unknown)
+            const wasm = componentWithSection(7, [
+                0x01,       // count = 1
+                0x42,       // instance type
+                0x01,       // 1 declaration
+                0x0F,       // invalid instance decl kind
+            ]);
+            await expect(parse(wasm)).rejects.toThrow('unknown instance type declaration kind');
+        });
+
+        test('unknown component func result type', async () => {
+            // Type section (7): count=1, type=0x40 (func), 0 params, result type=0x05 (unknown)
+            const wasm = componentWithSection(7, [
+                0x01,       // count = 1
+                0x40,       // func type
+                0x00,       // 0 params
+                0x05,       // invalid func result type
+            ]);
+            await expect(parse(wasm)).rejects.toThrow('unknown ComponentFuncResult type');
+        });
+
+        test('unknown instantiation arg kind', async () => {
+            // Core instance section (2): count=1, type=0x00 (instantiate), module_index=0,
+            // args count=1, name, kind=0x00 (invalid, should be 0x12)
+            const wasm = componentWithSection(2, [
+                0x01,       // count = 1
+                0x00,       // instantiate
+                0x00,       // module_index = 0
+                0x01,       // 1 arg
+                ...encodeName('arg'),
+                0x00,       // invalid kind (should be 0x12)
+                0x00,       // index = 0
+            ]);
+            await expect(parse(wasm)).rejects.toThrow('Unrecognized kind in readInstantiationArgKind');
+        });
+
+        test('unknown type bounds discriminant', async () => {
+            // Import section (10): count=1, extern name, type ref = 0x03 (type), bounds=0x05 (unknown)
+            const wasm = componentWithSection(10, [
+                0x01,       // count = 1
+                ...externNameKebab('test'),
+                0x03,       // type ref = Type
+                0x05,       // invalid type bounds discriminant
+            ]);
+            await expect(parse(wasm)).rejects.toThrow('unknown type bounds');
+        });
+
+        test('unknown component instance type', async () => {
+            // Instance section (5): count=1, type=0x05 (unknown)
+            const wasm = componentWithSection(5, [
+                0x01,       // count = 1
+                0x05,       // invalid instance type
+            ]);
+            await expect(parse(wasm)).rejects.toThrow('Unrecognized type in parseSectionInstance');
+        });
+
+        test('unknown core instance type', async () => {
+            // Core instance section (2): count=1, type=0x05 (unknown)
+            const wasm = componentWithSection(2, [
+                0x01,       // count = 1
+                0x05,       // invalid core instance type
+            ]);
+            await expect(parse(wasm)).rejects.toThrow('Unrecognized type in readCoreInstance');
+        });
+
+        test('unknown alias target', async () => {
+            // Alias section (6): count=1, b1=0x01 (func), target=0x05 (unknown)
+            const wasm = componentWithSection(6, [
+                0x01,       // count = 1
+                0x01,       // sort b1 = func
+                0x05,       // invalid target type
+            ]);
+            await expect(parse(wasm)).rejects.toThrow('unknown target type');
+        });
+
+        test('invalid optional valtype flag', async () => {
+            // Type section (7): count=1, type=0x6a (result),
+            // ok: flag = 0x05 (invalid, should be 0x00 or 0x01)
+            const wasm = componentWithSection(7, [
+                0x01,       // count = 1
+                0x6a,       // result type
+                0x05,       // invalid optional valtype flag
+            ]);
+            await expect(parse(wasm)).rejects.toThrow('invalid optional valtype flag');
+        });
+
+        test('invalid optional refinement flag', async () => {
+            // Type section (7): count=1, type=0x71 (variant), count=1,
+            // name, optional valtype=0x00 (absent), refinement flag=0x05 (invalid)
+            const wasm = componentWithSection(7, [
+                0x01,       // count = 1
+                0x71,       // variant
+                0x01,       // 1 variant case
+                ...encodeName('case1'),
+                0x00,       // optional valtype absent
+                0x05,       // invalid refinement flag
+            ]);
+            await expect(parse(wasm)).rejects.toThrow('invalid optional refinement flag');
+        });
+
+        test('invalid primitive val type', async () => {
+            // Type section (7): count=1, type=0x70 (list), element type = 0x60 (invalid primitive)
+            // 0x60 is below 0x73 (String) and not a valid index (it would be index 96 which is fine as type ref)
+            // To test primitive validation, we need a byte in the 0x73-0x7F range that isn't valid
+            // But all 0x73-0x7F are valid primitives... Instead, test with parsePrimitiveValType's range.
+            // The primitive range is 0x73-0x7F. readComponentValType only checks 0x73-0x7F for primitives.
+            // So any byte <0x73 with high bit clear is a type index. Nothing to reject here for valtype.
+            // However, readComponentTypeDefined with 0x73 <= type <= 0x7f calls parsePrimitiveValType.
+            // All those are valid. We need a byte like 0x72 which is 'record', not a primitive,
+            // or 0x67 which falls into default of readComponentTypeDefined.
+            const wasm = componentWithSection(7, [
+                0x01,       // count = 1
+                0x67,       // invalid tag — not in 0x68-0x72 and not in 0x73-0x7F
+            ]);
+            await expect(parse(wasm)).rejects.toThrow('Unrecognized type in readComponentTypeDefined');
+        });
+
+        test('invalid resource destructor flag', async () => {
+            // Type section (7): count=1, type=0x3F (resource), rep=0x7F (i32), dtor flag=0x05 (invalid)
+            const wasm = componentWithSection(7, [
+                0x01,       // count = 1
+                0x3F,       // resource
+                0x7F,       // rep = i32 core val type
+            ]);
+            // readDestructor reads a byte — but 0x3F resource type reads rep via readU32
+            // Let me check: readComponentType case 0x3F: rep: readU32(src), dtor: readDestructor(src)
+            // So rep is a u32 (LEB128), then destructor is a byte
+            const wasm2 = componentWithSection(7, [
+                0x01,       // count = 1
+                0x3F,       // resource
+                0x00,       // rep = 0
+                0x05,       // invalid destructor flag
+            ]);
+            await expect(parse(wasm2)).rejects.toThrow('Invalid leading byte in resource destructor');
+        });
+
+        test('invalid canon lift control byte', async () => {
+            // Canon section (8): count=1, type=0x00 (lift), control byte=0x05 (should be 0x00)
+            const wasm = componentWithSection(8, [
+                0x01,       // count = 1
+                0x00,       // lift
+                0x05,       // invalid control byte
+            ]);
+            await expect(parse(wasm)).rejects.toThrow('Unrecognized byte for CanonicalFunctionLift');
+        });
+
+        test('invalid canon lower control byte', async () => {
+            // Canon section (8): count=1, type=0x01 (lower), control byte=0x05 (should be 0x00)
+            const wasm = componentWithSection(8, [
+                0x01,       // count = 1
+                0x01,       // lower
+                0x05,       // invalid control byte
+            ]);
+            await expect(parse(wasm)).rejects.toThrow('Unrecognized byte for CanonicalFunctionLower');
+        });
+    });
+
+    // ─── Large counts / resource exhaustion ───
+
+    describe('large counts', () => {
+        test('huge item count in type section', async () => {
+            // Type section (7): count = 0xFFFFFFFF (4294967295) but no data
+            const wasm = componentWithSection(7, [
+                0xFF, 0xFF, 0xFF, 0xFF, 0x0F  // count = u32 max
+            ]);
+            await expect(parse(wasm)).rejects.toThrow('unexpected EOF');
+        });
+
+        test('huge item count in import section', async () => {
+            const wasm = componentWithSection(10, [
+                0xFF, 0xFF, 0xFF, 0xFF, 0x0F  // count = u32 max
+            ]);
+            await expect(parse(wasm)).rejects.toThrow('unexpected EOF');
+        });
+
+        test('huge item count in export section', async () => {
+            const wasm = componentWithSection(11, [
+                0xFF, 0xFF, 0xFF, 0xFF, 0x0F  // count = u32 max
+            ]);
+            await expect(parse(wasm)).rejects.toThrow('unexpected EOF');
+        });
+
+        test('huge string array count in flags', async () => {
+            // Type section (7): count=1, type=0x6e (flags), members count = u32 max
+            const wasm = componentWithSection(7, [
+                0x01,
+                0x6e,  // flags
+                0xFF, 0xFF, 0xFF, 0xFF, 0x0F  // members count = u32 max
+            ]);
+            await expect(parse(wasm)).rejects.toThrow('unexpected EOF');
+        });
+
+        test('huge variant case count', async () => {
+            // Type section (7): count=1, type=0x71 (variant), case count = u32 max
+            const wasm = componentWithSection(7, [
+                0x01,
+                0x71,  // variant
+                0xFF, 0xFF, 0xFF, 0xFF, 0x0F  // case count = u32 max
+            ]);
+            await expect(parse(wasm)).rejects.toThrow('unexpected EOF');
+        });
+
+        test('huge record member count', async () => {
+            // Type section (7): count=1, type=0x72 (record), member count = u32 max
+            const wasm = componentWithSection(7, [
+                0x01,
+                0x72,  // record
+                0xFF, 0xFF, 0xFF, 0xFF, 0x0F  // member count = u32 max
+            ]);
+            await expect(parse(wasm)).rejects.toThrow('unexpected EOF');
+        });
+
+        test('huge tuple member count', async () => {
+            // Type section (7): count=1, type=0x6f (tuple), member count = u32 max
+            const wasm = componentWithSection(7, [
+                0x01,
+                0x6f,  // tuple
+                0xFF, 0xFF, 0xFF, 0xFF, 0x0F  // member count = u32 max
+            ]);
+            await expect(parse(wasm)).rejects.toThrow('unexpected EOF');
+        });
+
+        test('huge named values count (func params)', async () => {
+            // Type section (7): count=1, type=0x40 (func), param count = u32 max
+            const wasm = componentWithSection(7, [
+                0x01,
+                0x40,  // func
+                0xFF, 0xFF, 0xFF, 0xFF, 0x0F  // param count = u32 max
+            ]);
+            await expect(parse(wasm)).rejects.toThrow('unexpected EOF');
+        });
+
+        test('huge canon options count', async () => {
+            // Canon section (8): count=1, type=0x00 (lift), control=0x00, core_func=0,
+            // options count = u32 max
+            const wasm = componentWithSection(8, [
+                0x01,
+                0x00, 0x00,  // lift, control byte
+                0x00,        // core_func_index = 0
+                0xFF, 0xFF, 0xFF, 0xFF, 0x0F  // options count = u32 max
+            ]);
+            await expect(parse(wasm)).rejects.toThrow('unexpected EOF');
+        });
+
+        test('huge export count', async () => {
+            // Core instance from exports: count=1, type=0x01, exports count = huge
+            const wasm = componentWithSection(2, [
+                0x01,       // count = 1
+                0x01,       // from-exports
+                0xFF, 0xFF, 0xFF, 0xFF, 0x0F  // exports count = u32 max
+            ]);
+            await expect(parse(wasm)).rejects.toThrow('unexpected EOF');
+        });
+
+        test('huge instantiation args count', async () => {
+            // Core instance instantiate: count=1, type=0x00, module=0, args count = huge
+            const wasm = componentWithSection(2, [
+                0x01,       // count = 1
+                0x00,       // instantiate
+                0x00,       // module_index = 0
+                0xFF, 0xFF, 0xFF, 0xFF, 0x0F  // args count = u32 max
+            ]);
+            await expect(parse(wasm)).rejects.toThrow('unexpected EOF');
+        });
+
+        test('huge component instantiation args count', async () => {
+            // Instance section (5): count=1, type=0x00 (instantiate), component=0, args count = huge
+            const wasm = componentWithSection(5, [
+                0x01,       // count = 1
+                0x00,       // instantiate
+                0x00,       // component_index = 0
+                0xFF, 0xFF, 0xFF, 0xFF, 0x0F  // args count = u32 max
+            ]);
+            await expect(parse(wasm)).rejects.toThrow('unexpected EOF');
+        });
+
+        test('huge instance type declarations count', async () => {
+            // Type section (7): count=1, type=0x42 (instance), declarations count = huge
+            const wasm = componentWithSection(7, [
+                0x01,
+                0x42,  // instance type
+                0xFF, 0xFF, 0xFF, 0xFF, 0x0F  // declarations count = u32 max
+            ]);
+            await expect(parse(wasm)).rejects.toThrow('unexpected EOF');
+        });
+
+        test('huge start function args count', async () => {
+            // Start section (9): func_index=0, argCount = u32 max
+            const wasm = componentWithSection(9, [
+                0x00,  // func_index = 0
+                0xFF, 0xFF, 0xFF, 0xFF, 0x0F  // arg count = u32 max
+            ]);
+            await expect(parse(wasm)).rejects.toThrow('unexpected EOF');
+        });
+    });
+
+    // ─── Index values (unvalidated at parse time, but shouldn't crash) ───
+
+    describe('index values', () => {
+        test('type index at u32 max', async () => {
+            // Type section (7): count=1, type=0x70 (list), element = type index 0xFFFFFFFF
+            const wasm = componentWithSection(7, [
+                0x01,
+                0x70,       // list
+                0xFF, 0xFF, 0xFF, 0xFF, 0x0F  // type index = u32 max
+            ]);
+            // Parser doesn't validate index ranges — this should parse without error
+            const model = await parse(wasm);
+            expect(model.length).toBe(1);
+        });
+
+        test('core func index at u32 max in canon lift', async () => {
+            // Canon section (8): count=1, lift with huge core func index
+            const wasm = componentWithSection(8, [
+                0x01,
+                0x00, 0x00,  // lift, control byte
+                0xFF, 0xFF, 0xFF, 0xFF, 0x0F,  // core_func_index = u32 max
+                0x00,        // 0 options
+                0x00,        // type_index = 0
+            ]);
+            const model = await parse(wasm);
+            expect(model.length).toBe(1);
+        });
+
+        test('component func index at u32 max in canon lower', async () => {
+            // Canon section (8): count=1, lower with huge func index
+            const wasm = componentWithSection(8, [
+                0x01,
+                0x01, 0x00,  // lower, control byte
+                0xFF, 0xFF, 0xFF, 0xFF, 0x0F,  // func_index = u32 max
+                0x00,        // 0 options
+            ]);
+            const model = await parse(wasm);
+            expect(model.length).toBe(1);
+        });
+
+        test('module index at u32 max in core instance', async () => {
+            // Core instance section (2): count=1, instantiate, module index = huge
+            const wasm = componentWithSection(2, [
+                0x01,
+                0x00,       // instantiate
+                0xFF, 0xFF, 0xFF, 0xFF, 0x0F,  // module_index = u32 max
+                0x00,       // 0 args
+            ]);
+            const model = await parse(wasm);
+            expect(model.length).toBe(1);
+        });
+
+        test('component index at u32 max in component instance', async () => {
+            // Instance section (5): count=1, instantiate, component index = huge
+            const wasm = componentWithSection(5, [
+                0x01,
+                0x00,       // instantiate
+                0xFF, 0xFF, 0xFF, 0xFF, 0x0F,  // component_index = u32 max
+                0x00,       // 0 args
+            ]);
+            const model = await parse(wasm);
+            expect(model.length).toBe(1);
+        });
+
+        test('resource index at u32 max in resource.new', async () => {
+            // Canon section (8): count=1, resource.new with huge resource index
+            const wasm = componentWithSection(8, [
+                0x01,
+                0x02,       // resource.new
+                0xFF, 0xFF, 0xFF, 0xFF, 0x0F,  // resource = u32 max
+            ]);
+            const model = await parse(wasm);
+            expect(model.length).toBe(1);
+        });
+
+        test('resource index at u32 max in resource.drop', async () => {
+            const wasm = componentWithSection(8, [
+                0x01,
+                0x03,       // resource.drop
+                0xFF, 0xFF, 0xFF, 0xFF, 0x0F,  // resource = u32 max
+            ]);
+            const model = await parse(wasm);
+            expect(model.length).toBe(1);
+        });
+
+        test('resource index at u32 max in resource.rep', async () => {
+            const wasm = componentWithSection(8, [
+                0x01,
+                0x04,       // resource.rep
+                0xFF, 0xFF, 0xFF, 0xFF, 0x0F,  // resource = u32 max
+            ]);
+            const model = await parse(wasm);
+            expect(model.length).toBe(1);
+        });
+
+        test('instance index at u32 max in alias', async () => {
+            // Alias section (6): count=1, sort=0x01 (func), target=0x00 (instance export),
+            // instance index = huge, name
+            const wasm = componentWithSection(6, [
+                0x01,       // count = 1
+                0x01,       // sort b1 = func
+                0x00,       // target = instance export
+                0xFF, 0xFF, 0xFF, 0xFF, 0x0F,  // instance_index = u32 max
+                ...encodeName('x'),
+            ]);
+            const model = await parse(wasm);
+            expect(model.length).toBe(1);
+        });
+
+        test('core instance index at u32 max in core alias', async () => {
+            // Alias section (6): count=1, sort=0x00, sub=0x00 (func), target=0x01 (core instance export)
+            // core instance index = huge, name
+            const wasm = componentWithSection(6, [
+                0x01,       // count = 1
+                0x00,       // sort b1 = core
+                0x00,       // sort b2 = func (ExternalKind.Func)
+                0x01,       // target = core instance export
+                0xFF, 0xFF, 0xFF, 0xFF, 0x0F,  // core_instance_index = u32 max
+                ...encodeName('x'),
+            ]);
+            const model = await parse(wasm);
+            expect(model.length).toBe(1);
+        });
+
+        test('outer alias count and index at u32 max', async () => {
+            // Alias section (6): count=1, sort=0x03 (type), target=0x02 (outer),
+            // count = huge, index = huge
+            const wasm = componentWithSection(6, [
+                0x01,       // count = 1
+                0x03,       // sort b1 = Type outer alias kind
+                0x02,       // target = outer
+                0xFF, 0xFF, 0xFF, 0xFF, 0x0F,  // count = u32 max
+                0xFF, 0xFF, 0xFF, 0xFF, 0x0F,  // index = u32 max
+            ]);
+            const model = await parse(wasm);
+            expect(model.length).toBe(1);
+        });
+
+        test('export index at u32 max', async () => {
+            // Export section (11): count=1, name, kind=func, index=huge, no type bound
+            const wasm = componentWithSection(11, [
+                0x01,       // count = 1
+                ...externNameKebab('test'),
+                0x01,       // kind = func
+                0xFF, 0xFF, 0xFF, 0xFF, 0x0F,  // index = u32 max
+                0x00,       // no type bound
+            ]);
+            const model = await parse(wasm);
+            expect(model.length).toBe(1);
+        });
+
+        test('type ref index at u32 max in import', async () => {
+            // Import section (10): count=1, name, type ref = func, index = huge
+            const wasm = componentWithSection(10, [
+                0x01,       // count = 1
+                ...externNameKebab('test'),
+                0x01,       // type ref = Func
+                0xFF, 0xFF, 0xFF, 0xFF, 0x0F,  // func type index = u32 max
+            ]);
+            const model = await parse(wasm);
+            expect(model.length).toBe(1);
+        });
+
+        test('memory index at u32 max in canon option', async () => {
+            // Canon section (8): count=1, lift, control=0x00, core_func=0,
+            // 1 option: memory with huge index, type_index=0
+            const wasm = componentWithSection(8, [
+                0x01,
+                0x00, 0x00,  // lift, control byte
+                0x00,        // core_func_index = 0
+                0x01,        // 1 option
+                0x03,        // memory option
+                0xFF, 0xFF, 0xFF, 0xFF, 0x0F,  // memory index = u32 max
+                0x00,        // type_index = 0
+            ]);
+            const model = await parse(wasm);
+            expect(model.length).toBe(1);
+        });
+
+        test('start function indices at u32 max', async () => {
+            // Start section (9): func=huge, argCount=2, arg0=huge, arg1=huge, results=huge
+            const huge = [0xFF, 0xFF, 0xFF, 0xFF, 0x0F];
+            const wasm = componentWithSection(9, [
+                ...huge,    // func_index
+                0x02,       // 2 args
+                ...huge,    // arg[0]
+                ...huge,    // arg[1]
+                ...huge,    // results
+            ]);
+            const model = await parse(wasm);
+            expect(model.length).toBe(1);
+        });
+
+        test('borrow/own type index at u32 max', async () => {
+            // Type section (7): count=2
+            // [0]: borrow with huge index
+            // [1]: own with huge index
+            const huge = [0xFF, 0xFF, 0xFF, 0xFF, 0x0F];
+            const wasm = componentWithSection(7, [
+                0x02,       // count = 2
+                0x68,       // borrow
+                ...huge,    // type index
+                0x69,       // own
+                ...huge,    // type index
+            ]);
+            const model = await parse(wasm);
+            expect(model.length).toBe(2);
+        });
+
+        test('component type ref indices at u32 max', async () => {
+            // Import section: test various ComponentTypeRef kinds with huge indices
+            const huge = [0xFF, 0xFF, 0xFF, 0xFF, 0x0F];
+            // kind 0x00 = module, kind 0x01 = func, kind 0x04 = component, kind 0x05 = instance
+            for (const kind of [0x00, 0x01, 0x04, 0x05]) {
+                const wasm = componentWithSection(10, [
+                    0x01,       // count = 1
+                    ...externNameKebab('test'),
+                    kind,       // type ref kind
+                    ...huge,    // type index = u32 max
+                ]);
+                const model = await parse(wasm);
+                expect(model.length).toBe(1);
+            }
+        });
+    });
+
+    // ─── Buffer boundary / offset problems ───
+
+    describe('buffer boundaries', () => {
+        test('readExact with n=0 returns empty array', async () => {
+            // A zero-length name should work (length=0 means readExact(0))
+            const wasm = componentWithSection(7, [
+                0x01,       // count = 1
+                0x6e,       // flags
+                0x01,       // 1 member
+                0x00,       // member name length = 0
+            ]);
+            const model = await parse(wasm);
+            expect(model.length).toBe(1);
+        });
+
+        test('section consumes exactly all bytes', async () => {
+            // Type section (7): count=1, primitive char (0x74) — exactly 2 bytes of payload
+            const wasm = componentWithSection(7, [0x01, 0x74]);
+            const model = await parse(wasm);
+            expect(model.length).toBe(1);
+        });
+
+        test('multiple sections back to back', async () => {
+            // Two type sections, each with 1 primitive
+            const section1 = [7, ...leb128U32(2), 0x01, 0x74]; // type section: count=1, char
+            const section2 = [7, ...leb128U32(2), 0x01, 0x73]; // type section: count=1, string
+            const wasm = new Uint8Array([...PREAMBLE, ...section1, ...section2]);
+            const model = await parse(wasm);
+            expect(model.length).toBe(2);
+        });
+
+        test('section with payload at exact u8 boundary (255 bytes)', async () => {
+            // Create a type section with lots of primitives to fill ~255 bytes
+            // Each primitive type is 1 byte, plus 1 byte per count entry
+            // count (LEB128 of 254 is 2 bytes: 0xFE, 0x01) + 254 bytes of primitives = 256 bytes
+            // Let's use count=253 + 253 bytes of 0x74 (char primitive) = 254 + LEB128(253)=2 = 255
+            const count = 253;
+            const payload = [...leb128U32(count), ...Array(count).fill(0x74)];
+            expect(payload.length).toBe(255); // verify our math
+            const wasm = componentWithSection(7, payload);
+            const model = await parse(wasm);
+            expect(model.length).toBe(count);
+        });
+
+        test('data after valid component has trailing garbage', async () => {
+            // A valid section type byte followed by a valid LEB128 size, then garbage
+            // The parser reads type, then size, then dispatches
+            const wasm = new Uint8Array([...PREAMBLE, 0x20, 0x00]);
+            // 0x20 = 32, not a valid section type, size = 0
+            await expect(parse(wasm)).rejects.toThrow('unknown section: 32');
+        });
+    });
+
+    // ─── Nesting depth ───
+
+    describe('nesting depth limit', () => {
+        test('component nesting at limit is rejected', async () => {
+            // Build 101 levels of nested components
+            // Each nested component: section type 4, size = N, then preamble
+            // The deepest fails when depth >= 100
+
+            // Build from inside out
+            let inner = new Uint8Array(PREAMBLE);  // innermost empty component
+            for (let i = 0; i < 101; i++) {
+                const sizeBytes = leb128U32(inner.length);
+                const outer = new Uint8Array([
+                    ...PREAMBLE,
+                    4,  // component section
+                    ...sizeBytes,
+                    ...inner
+                ]);
+                inner = outer;
+            }
+            await expect(parse(inner)).rejects.toThrow(`component nesting depth exceeds ${100}`);
+        });
+
+        test('99 levels of nesting succeeds', async () => {
+            let inner = new Uint8Array(PREAMBLE);
+            for (let i = 0; i < 99; i++) {
+                const sizeBytes = leb128U32(inner.length);
+                const outer = new Uint8Array([
+                    ...PREAMBLE,
+                    4,
+                    ...sizeBytes,
+                    ...inner
+                ]);
+                inner = outer;
+            }
+            const model = await parse(inner);
+            expect(model.length).toBe(1); // one component section
+        });
+    });
+
+    // ─── Component-specific edge cases ───
+
+    describe('component type edge cases', () => {
+        test('result type with both ok and err absent', async () => {
+            // Type section (7): count=1, result with ok=absent, err=absent
+            const wasm = componentWithSection(7, [
+                0x01,
+                0x6a,       // result
+                0x00,       // ok absent
+                0x00,       // err absent
+            ]);
+            const model = await parse(wasm);
+            expect(model.length).toBe(1);
+        });
+
+        test('result type with both ok and err present', async () => {
+            // Type section (7): count=1, result with ok=string, err=string
+            const wasm = componentWithSection(7, [
+                0x01,
+                0x6a,       // result
+                0x01, 0x73, // ok = present, string primitive
+                0x01, 0x73, // err = present, string primitive
+            ]);
+            const model = await parse(wasm);
+            expect(model.length).toBe(1);
+        });
+
+        test('option type with type index 0', async () => {
+            const wasm = componentWithSection(7, [
+                0x01,
+                0x6b,       // option
+                0x00,       // type index 0
+            ]);
+            const model = await parse(wasm);
+            expect(model.length).toBe(1);
+        });
+
+        test('empty enum (0 members)', async () => {
+            const wasm = componentWithSection(7, [
+                0x01,
+                0x6d,       // enum
+                0x00,       // 0 members
+            ]);
+            const model = await parse(wasm);
+            expect(model.length).toBe(1);
+        });
+
+        test('empty flags (0 members)', async () => {
+            const wasm = componentWithSection(7, [
+                0x01,
+                0x6e,       // flags
+                0x00,       // 0 members
+            ]);
+            const model = await parse(wasm);
+            expect(model.length).toBe(1);
+        });
+
+        test('empty tuple (0 members)', async () => {
+            const wasm = componentWithSection(7, [
+                0x01,
+                0x6f,       // tuple
+                0x00,       // 0 members
+            ]);
+            const model = await parse(wasm);
+            expect(model.length).toBe(1);
+        });
+
+        test('empty variant (0 cases)', async () => {
+            const wasm = componentWithSection(7, [
+                0x01,
+                0x71,       // variant
+                0x00,       // 0 cases
+            ]);
+            const model = await parse(wasm);
+            expect(model.length).toBe(1);
+        });
+
+        test('empty record (0 members)', async () => {
+            const wasm = componentWithSection(7, [
+                0x01,
+                0x72,       // record
+                0x00,       // 0 members
+            ]);
+            const model = await parse(wasm);
+            expect(model.length).toBe(1);
+        });
+
+        test('func type with 0 params and unnamed result', async () => {
+            const wasm = componentWithSection(7, [
+                0x01,
+                0x40,       // func
+                0x00,       // 0 params
+                0x00,       // unnamed result
+                0x73,       // result type = string
+            ]);
+            const model = await parse(wasm);
+            expect(model.length).toBe(1);
+        });
+
+        test('func type with named results', async () => {
+            const wasm = componentWithSection(7, [
+                0x01,
+                0x40,       // func
+                0x00,       // 0 params
+                0x01,       // named results
+                0x01,       // 1 named value
+                ...encodeName('r'),
+                0x73,       // type = string
+            ]);
+            const model = await parse(wasm);
+            expect(model.length).toBe(1);
+        });
+
+        test('component type tag is accepted', async () => {
+            // 0x41 = component type (no declarations to read)
+            const wasm = componentWithSection(7, [
+                0x01,
+                0x41,       // component type
+            ]);
+            const model = await parse(wasm);
+            expect(model.length).toBe(1);
+        });
+
+        test('instance type with all declaration kinds', async () => {
+            // instance type with declarations:
+            // 0x00 = core type, 0x01 = type, 0x03 = import, 0x04 = export
+            const wasm = componentWithSection(7, [
+                0x01,
+                0x42,       // instance type
+                0x02,       // 2 declarations
+                // decl 0: type (kind=0x01) -> primitive string
+                0x01, 0x73,
+                // decl 1: export (kind=0x04) -> name + type ref
+                0x04,
+                ...externNameKebab('x'),
+                0x01,       // type ref = func
+                0x00,       // func type index = 0
+            ]);
+            const model = await parse(wasm);
+            expect(model.length).toBe(1);
+        });
+    });
+
+    // ─── Valid components with empty sections ───
+
+    describe('empty sections', () => {
+        test('empty component (just preamble)', async () => {
+            const wasm = new Uint8Array(PREAMBLE);
+            const model = await parse(wasm);
+            expect(model.length).toBe(0);
+        });
+
+        test('type section with 0 types', async () => {
+            const wasm = componentWithSection(7, [0x00]);
+            const model = await parse(wasm);
+            expect(model.length).toBe(0);
+        });
+
+        test('import section with 0 imports', async () => {
+            const wasm = componentWithSection(10, [0x00]);
+            const model = await parse(wasm);
+            expect(model.length).toBe(0);
+        });
+
+        test('export section with 0 exports', async () => {
+            const wasm = componentWithSection(11, [0x00]);
+            const model = await parse(wasm);
+            expect(model.length).toBe(0);
+        });
+
+        test('alias section with 0 aliases', async () => {
+            const wasm = componentWithSection(6, [0x00]);
+            const model = await parse(wasm);
+            expect(model.length).toBe(0);
+        });
+
+        test('canon section with 0 functions', async () => {
+            const wasm = componentWithSection(8, [0x00]);
+            const model = await parse(wasm);
+            expect(model.length).toBe(0);
+        });
+
+        test('core instance section with 0 instances', async () => {
+            const wasm = componentWithSection(2, [0x00]);
+            const model = await parse(wasm);
+            expect(model.length).toBe(0);
+        });
+
+        test('instance section with 0 instances', async () => {
+            const wasm = componentWithSection(5, [0x00]);
+            const model = await parse(wasm);
+            expect(model.length).toBe(0);
+        });
+
+        test('core type section with 0 types', async () => {
+            const wasm = componentWithSection(3, [0x00]);
+            const model = await parse(wasm);
+            expect(model.length).toBe(0);
+        });
+    });
+});

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -32,6 +32,7 @@ export type ParserContext = {
     processCustomSection?: (section: CustomSection) => CustomSection
     verbose?: Verbosity
     logger?: LogFn
+    depth: number
 }
 
 export type ParserOptions = {

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -8,7 +8,7 @@ export type CoreModule = IndexedElement & {
 }
 
 export type CustomSection = {
-    tag: ModelTag.CustomSection
+    tag: 2
     name: string
     data?: Uint8Array
 }
@@ -39,6 +39,4 @@ export type ParserOptions = {
     otherSectionData?: boolean
     compileStreaming?: typeof WebAssembly.compileStreaming
     processCustomSection?: (section: CustomSection) => CustomSection
-    verbose?: Partial<Verbosity>
-    logger?: LogFn
 }

--- a/src/parser/values.ts
+++ b/src/parser/values.ts
@@ -307,6 +307,8 @@ export function readInstanceTypeDeclarations(src: SyncSource): InstanceTypeDecla
                 };
                 break;
             }
+            default:
+                throw new Error(`unknown instance type declaration kind: 0x${type.toString(16)}`);
         }
         declarations.push(declaration);
     }
@@ -706,10 +708,13 @@ export function readComponentValType(src: SyncSource): ComponentValType {
     if (first & 0x80) {
         let shift = 7;
         let byte: number;
+        let count = 1;
         do {
             byte = src.read();
             result |= (byte & 0x7f) << shift;
             shift += 7;
+            count++;
+            if (count > 5) throw new Error('LEB128 overflow in component val type index');
         } while (byte & 0x80);
     }
     return {

--- a/src/resolver/api-types.ts
+++ b/src/resolver/api-types.ts
@@ -1,6 +1,4 @@
 
-import { PlanOp } from './binding-plan';
-
 export type JsInterface = Record<string, Function>;
 export type JsInterfaceCollection = Record<string, JsInterface>;
 
@@ -24,7 +22,5 @@ export type ResolutionStats = {
 
 export type WasmComponent<TJSExports> = {
     instantiate: WasmComponentFactory<TJSExports>
-    plan?: PlanOp[]
-    stats?: ResolutionStats
 }
 export type WasmComponentFactory<TJSExports> = (imports?: JsImports) => Promise<WasmComponentInstance<TJSExports>>

--- a/src/resolver/binding-plan.ts
+++ b/src/resolver/binding-plan.ts
@@ -4,6 +4,7 @@ import { planOpKindName } from '../utils/debug-names';
 import { JsImports, WasmComponentInstance } from './api-types';
 import { createBindingContext } from './context';
 import { BinderArgs, BindingContext, ResolvedContext, ResolverRes } from './types';
+import { EXPORTS, ABORT } from '../constants';
 
 export const enum PlanOpKind {
     CoreInstantiate,
@@ -85,7 +86,7 @@ export async function executePlan<TJSExports>(
     }));
 
     return {
-        exports,
-        abort: ctx.abort,
+        [EXPORTS]: exports,
+        [ABORT]: ctx.abort,
     } as any as WasmComponentInstance<TJSExports>;
 }

--- a/src/resolver/binding-plan.ts
+++ b/src/resolver/binding-plan.ts
@@ -1,4 +1,5 @@
-import { isDebug, LogLevel } from '../utils/assert';
+import isDebug from 'env:isDebug';
+import { LogLevel } from '../utils/assert';
 import { planOpKindName } from '../utils/debug-names';
 import { JsImports, WasmComponentInstance } from './api-types';
 import { createBindingContext } from './context';

--- a/src/resolver/binding/cache.ts
+++ b/src/resolver/binding/cache.ts
@@ -1,4 +1,5 @@
-import { isDebug, LogLevel } from '../../utils/assert';
+import isDebug from 'env:isDebug';
+import { LogLevel } from '../../utils/assert';
 import { modelTagName } from '../../utils/debug-names';
 import type { LogFn, Verbosity } from '../../utils/assert';
 

--- a/src/resolver/binding/canonical-abi.test.ts
+++ b/src/resolver/binding/canonical-abi.test.ts
@@ -10,6 +10,7 @@ import { createLowering } from './to-js';
 import { storeToMemory, loadFromMemory } from './test-helpers';
 import { WasmPointer, WasmSize, WasmValue } from './types';
 import { validateAllocResult, validatePointerAlignment, checkNotPoisoned, checkNotReentrant } from './validation';
+import { describeDebugOnly } from '../../test-utils/debug-only';
 
 /** Test-only UTF-8 validator with detailed error messages. */
 function validateUtf8(bytes: Uint8Array): void {
@@ -191,7 +192,7 @@ function _createTinyBufferContext(size: number): { ctx: BindingContext, buffer: 
 // Phase C1: Memory Alignment & Bounds Validation
 // =============================================================================
 
-describe('C1: validateAllocResult', () => {
+describeDebugOnly('C1: validateAllocResult', () => {
     test('accepts aligned pointer with sufficient bounds', () => {
         const { ctx } = createMockMemoryContext();
         // ptr=16, align=4, size=8 — valid (16 is aligned to 4, 16+8 < 4096)
@@ -245,7 +246,7 @@ describe('C1: validateAllocResult', () => {
     });
 });
 
-describe('C1: validatePointerAlignment', () => {
+describeDebugOnly('C1: validatePointerAlignment', () => {
     test('accepts aligned pointer', () => {
         expect(() => validatePointerAlignment(16, 4, 'list')).not.toThrow();
     });
@@ -265,7 +266,7 @@ describe('C1: validatePointerAlignment', () => {
     });
 });
 
-describe('C1: list pointer alignment validation', () => {
+describeDebugOnly('C1: list pointer alignment validation', () => {
     test('list<u32> at misaligned pointer traps on load', () => {
         const rctx = createMinimalRctx();
         const listModel = {
@@ -316,7 +317,7 @@ describe('C1: list pointer alignment validation', () => {
     });
 });
 
-describe('C1: list out-of-bounds validation', () => {
+describeDebugOnly('C1: list out-of-bounds validation', () => {
     test('list<u32> beyond memory traps', () => {
         const rctx = createMinimalRctx();
         const listModel = {
@@ -332,7 +333,7 @@ describe('C1: list out-of-bounds validation', () => {
     });
 });
 
-describe('C1: string out-of-bounds validation', () => {
+describeDebugOnly('C1: string out-of-bounds validation', () => {
     test('string beyond memory traps on load', () => {
         const rctx = createMinimalRctx();
         const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.String));
@@ -344,7 +345,7 @@ describe('C1: string out-of-bounds validation', () => {
     });
 });
 
-describe('C1: list lifting with misaligned realloc traps', () => {
+describeDebugOnly('C1: list lifting with misaligned realloc traps', () => {
     test('list<u32> lifting traps when realloc returns misaligned ptr', () => {
         const rctx = createMinimalRctx();
         const listModel = {
@@ -364,7 +365,7 @@ describe('C1: list lifting with misaligned realloc traps', () => {
 // Phase C2: String Encoding Validation
 // =============================================================================
 
-describe('C2: validateUtf8', () => {
+describeDebugOnly('C2: validateUtf8', () => {
     test('accepts valid ASCII', () => {
         expect(() => validateUtf8(new Uint8Array([0x48, 0x65, 0x6C, 0x6C, 0x6F]))).not.toThrow();
     });
@@ -496,7 +497,7 @@ describe('C2: validateUtf8', () => {
     });
 });
 
-describe('C2: string lowering validates UTF-8 from memory', () => {
+describeDebugOnly('C2: string lowering validates UTF-8 from memory', () => {
     test('valid UTF-8 string loads correctly', () => {
         const rctx = createMinimalRctx();
         const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.String));
@@ -585,7 +586,7 @@ describe('C2: string lowering validates UTF-8 from memory', () => {
 // Phase C3: Complex Spilling & Nested Memory Layout
 // =============================================================================
 
-describe('C3: nested compound types through memory', () => {
+describeDebugOnly('C3: nested compound types through memory', () => {
     test('option<list<u8>> round-trips through memory', () => {
         const rctx = createMinimalRctx();
         const { ctx, buffer } = createMockMemoryContext();
@@ -833,7 +834,7 @@ describe('C3: nested compound types through memory', () => {
 // Phase C4: Runtime Behavioral Guarantees
 // =============================================================================
 
-describe('C4: checkNotPoisoned', () => {
+describeDebugOnly('C4: checkNotPoisoned', () => {
     test('does not throw on healthy context', () => {
         const { ctx } = createMockMemoryContext();
         expect(() => checkNotPoisoned(ctx)).not.toThrow();
@@ -853,7 +854,7 @@ describe('C4: checkNotPoisoned', () => {
     });
 });
 
-describe('C4: checkNotReentrant', () => {
+describeDebugOnly('C4: checkNotReentrant', () => {
     test('does not throw when not in export', () => {
         const { ctx } = createMockMemoryContext();
         expect(() => checkNotReentrant(ctx)).not.toThrow();
@@ -873,7 +874,7 @@ describe('C4: checkNotReentrant', () => {
     });
 });
 
-describe('C4: instance poisoning through liftingTrampoline', () => {
+describeDebugOnly('C4: instance poisoning through liftingTrampoline', () => {
     test('export call sets inExport and clears on return', () => {
         const rctx = createMinimalRctx();
         const funcModel = {
@@ -940,7 +941,7 @@ describe('C4: instance poisoning through liftingTrampoline', () => {
     });
 });
 
-describe('C4: reentrance guard through liftingTrampoline', () => {
+describeDebugOnly('C4: reentrance guard through liftingTrampoline', () => {
     test('reentrant export call is rejected', () => {
         const rctx = createMinimalRctx();
         const funcModel = {
@@ -980,7 +981,7 @@ describe('C4: reentrance guard through liftingTrampoline', () => {
     });
 });
 
-describe('C4: post-return cleanup', () => {
+describeDebugOnly('C4: post-return cleanup', () => {
     test('post-return function is called after successful export', () => {
         const rctx = createMinimalRctx();
         const funcModel = {
@@ -1032,7 +1033,7 @@ describe('C4: post-return cleanup', () => {
 // Combined C1-C4: integration scenarios
 // =============================================================================
 
-describe('C-integration: full round-trip with validation', () => {
+describeDebugOnly('C-integration: full round-trip with validation', () => {
     test('string lift + lower round-trip with valid UTF-8', () => {
         const liftRctx = createMinimalRctx();
         const lowerRctx = createMinimalRctx();
@@ -1103,7 +1104,7 @@ describe('C-integration: full round-trip with validation', () => {
 // UTF-16 String Encoding
 // =============================================================================
 
-describe('UTF-16 string encoding', () => {
+describeDebugOnly('UTF-16 string encoding', () => {
     function createUtf16Rctx(): ResolverContext {
         return {
             resolved: {
@@ -1247,7 +1248,7 @@ describe('UTF-16 string encoding', () => {
 // Security: spilled-path boundary validation (CVE-inspired)
 // =============================================================================
 
-describe('Security: spilled-path memory loader validation', () => {
+describeDebugOnly('Security: spilled-path memory loader validation', () => {
 
     describe('string loader bounds checking', () => {
         test('traps on out-of-bounds string pointer in memory (spilled path)', () => {

--- a/src/resolver/binding/canonical-abi.test.ts
+++ b/src/resolver/binding/canonical-abi.test.ts
@@ -1,5 +1,5 @@
-import { setConfiguration } from '../../utils/assert';
-setConfiguration('Debug');
+import { initializeAsserts } from '../../utils/assert';
+initializeAsserts();
 
 import { ModelTag } from '../../model/tags';
 import { ComponentValType, PrimitiveValType } from '../../model/types';

--- a/src/resolver/binding/compound-types.test.ts
+++ b/src/resolver/binding/compound-types.test.ts
@@ -7,6 +7,7 @@ import { ResolverContext, BindingContext } from '../types';
 import { createLifting as _createLifting } from './to-abi';
 import { createLowering } from './to-js';
 import { WasmPointer, WasmSize, WasmValue } from './types';
+import { describeDebugOnly } from '../../test-utils/debug-only';
 
 // Wrap BYO-buffer lifters to return arrays for test convenience
 function createLifting(rctx: any, model: any): (ctx: BindingContext, value: any) => WasmValue[] {
@@ -93,7 +94,7 @@ function prim(value: PrimitiveValType): ComponentValType {
 
 // ─── Option lifting (JS → WASM) ───────────────────────────────────────────
 
-describe('option lifting (JS → WASM)', () => {
+describeDebugOnly('option lifting (JS → WASM)', () => {
     let rctx: ResolverContext;
     let bctx: BindingContext;
 
@@ -135,7 +136,7 @@ describe('option lifting (JS → WASM)', () => {
 
 // ─── Option lowering (WASM → JS) ──────────────────────────────────────────
 
-describe('option lowering (WASM → JS)', () => {
+describeDebugOnly('option lowering (WASM → JS)', () => {
     let rctx: ResolverContext;
     let bctx: BindingContext;
 
@@ -167,7 +168,7 @@ describe('option lowering (WASM → JS)', () => {
 
 // ─── Nested option (option<option<u32>>) ───────────────────────────────────
 
-describe('nested option<option<u32>>', () => {
+describeDebugOnly('nested option<option<u32>>', () => {
     let rctx: ResolverContext;
     let bctx: BindingContext;
 
@@ -238,7 +239,7 @@ describe('nested option<option<u32>>', () => {
 
 // ─── Result lifting (JS → WASM) ───────────────────────────────────────────
 
-describe('result lifting (JS → WASM)', () => {
+describeDebugOnly('result lifting (JS → WASM)', () => {
     let rctx: ResolverContext;
     let bctx: BindingContext;
 
@@ -271,7 +272,7 @@ describe('result lifting (JS → WASM)', () => {
 
 // ─── Result lowering (WASM → JS) ──────────────────────────────────────────
 
-describe('result lowering (WASM → JS)', () => {
+describeDebugOnly('result lowering (WASM → JS)', () => {
     let rctx: ResolverContext;
     let bctx: BindingContext;
 
@@ -309,7 +310,7 @@ describe('result lowering (WASM → JS)', () => {
 
 // ─── Result with no error type ─────────────────────────────────────────────
 
-describe('result with no error type', () => {
+describeDebugOnly('result with no error type', () => {
     let rctx: ResolverContext;
     let bctx: BindingContext;
 
@@ -351,7 +352,7 @@ describe('result with no error type', () => {
 
 // ─── Result with no ok type ────────────────────────────────────────────────
 
-describe('result with no ok type (error-only)', () => {
+describeDebugOnly('result with no ok type (error-only)', () => {
     let rctx: ResolverContext;
     let bctx: BindingContext;
 
@@ -388,7 +389,7 @@ describe('result with no ok type (error-only)', () => {
 
 // ─── List lifting (JS → WASM) ─────────────────────────────────────────────
 
-describe('list lifting (JS → WASM)', () => {
+describeDebugOnly('list lifting (JS → WASM)', () => {
     const listU32Model = {
         tag: ModelTag.ComponentTypeDefinedList as const,
         value: prim(PrimitiveValType.U32),
@@ -457,7 +458,7 @@ describe('list lifting (JS → WASM)', () => {
 
 // ─── List lowering (WASM → JS) ────────────────────────────────────────────
 
-describe('list lowering (WASM → JS)', () => {
+describeDebugOnly('list lowering (WASM → JS)', () => {
     const listU32Model = {
         tag: ModelTag.ComponentTypeDefinedList as const,
         value: prim(PrimitiveValType.U32),
@@ -512,7 +513,7 @@ describe('list lowering (WASM → JS)', () => {
 
 // ─── Compound type spill counts ────────────────────────────────────────────
 
-describe('compound type spill counts', () => {
+describeDebugOnly('compound type spill counts', () => {
     let rctx: ResolverContext;
 
     beforeEach(() => {
@@ -574,7 +575,7 @@ describe('compound type spill counts', () => {
 
 // ─── List round-trip (lift then lower) ─────────────────────────────────────
 
-describe('list round-trip', () => {
+describeDebugOnly('list round-trip', () => {
     test('list<u32> lifts then lowers back to original', () => {
         const rctx = createMinimalRctx();
         const { ctx } = createMockMemoryContext();
@@ -597,7 +598,7 @@ describe('list round-trip', () => {
 
 // ─── Variant lifting (JS → WASM) ──────────────────────────────────────────
 
-describe('variant lifting', () => {
+describeDebugOnly('variant lifting', () => {
     let rctx: ResolverContext;
     let bctx: BindingContext;
 
@@ -638,7 +639,7 @@ describe('variant lifting', () => {
 
 // ─── Variant lowering (WASM → JS) ─────────────────────────────────────────
 
-describe('variant lowering', () => {
+describeDebugOnly('variant lowering', () => {
     let rctx: ResolverContext;
     let bctx: BindingContext;
 
@@ -679,7 +680,7 @@ describe('variant lowering', () => {
 
 // ─── Enum lifting (JS → WASM) ─────────────────────────────────────────────
 
-describe('enum lifting', () => {
+describeDebugOnly('enum lifting', () => {
     let rctx: ResolverContext;
     let bctx: BindingContext;
 
@@ -716,7 +717,7 @@ describe('enum lifting', () => {
 
 // ─── Enum lowering (WASM → JS) ────────────────────────────────────────────
 
-describe('enum lowering', () => {
+describeDebugOnly('enum lowering', () => {
     let rctx: ResolverContext;
     let bctx: BindingContext;
 
@@ -753,7 +754,7 @@ describe('enum lowering', () => {
 
 // ─── Flags lifting (JS → WASM) ────────────────────────────────────────────
 
-describe('flags lifting', () => {
+describeDebugOnly('flags lifting', () => {
     let rctx: ResolverContext;
     let bctx: BindingContext;
 
@@ -804,7 +805,7 @@ describe('flags lifting', () => {
 
 // ─── Flags lowering (WASM → JS) ───────────────────────────────────────────
 
-describe('flags lowering', () => {
+describeDebugOnly('flags lowering', () => {
     let rctx: ResolverContext;
     let bctx: BindingContext;
 
@@ -855,7 +856,7 @@ describe('flags lowering', () => {
 
 // ─── Tuple lifting (JS → WASM) ────────────────────────────────────────────
 
-describe('tuple lifting', () => {
+describeDebugOnly('tuple lifting', () => {
     let rctx: ResolverContext;
     let bctx: BindingContext;
 
@@ -885,7 +886,7 @@ describe('tuple lifting', () => {
 
 // ─── Tuple lowering (WASM → JS) ───────────────────────────────────────────
 
-describe('tuple lowering', () => {
+describeDebugOnly('tuple lowering', () => {
     let rctx: ResolverContext;
     let bctx: BindingContext;
 

--- a/src/resolver/binding/compound-types.test.ts
+++ b/src/resolver/binding/compound-types.test.ts
@@ -1,5 +1,5 @@
-import { setConfiguration } from '../../utils/assert';
-setConfiguration('Debug');
+import { initializeAsserts } from '../../utils/assert';
+initializeAsserts();
 
 import { ModelTag } from '../../model/tags';
 import { ComponentValType, PrimitiveValType } from '../../model/types';

--- a/src/resolver/binding/edge-cases.test.ts
+++ b/src/resolver/binding/edge-cases.test.ts
@@ -10,6 +10,7 @@ import { createLowering, createFunctionLowering } from './to-js';
 import { storeToMemory, loadFromMemory } from './test-helpers';
 import { WasmPointer, WasmSize, WasmValue } from './types';
 import { deepResolveType } from '../calling-convention';
+import { describeDebugOnly } from '../../test-utils/debug-only';
 
 // Wrap BYO-buffer lifters to return arrays for test convenience
 function createLifting(rctx: any, model: any): (ctx: BindingContext, value: any) => WasmValue[] {
@@ -94,7 +95,7 @@ function prim(value: PrimitiveValType): ComponentValType {
 
 // ─── Primitive edge cases ──────────────────────────────────────────────────
 
-describe('primitive lifting edge cases', () => {
+describeDebugOnly('primitive lifting edge cases', () => {
     let rctx: ResolverContext;
     let bctx: BindingContext;
 
@@ -312,7 +313,7 @@ describe('primitive lifting edge cases', () => {
     });
 });
 
-describe('primitive lowering edge cases', () => {
+describeDebugOnly('primitive lowering edge cases', () => {
     let rctx: ResolverContext;
     let bctx: BindingContext;
 
@@ -450,7 +451,7 @@ describe('primitive lowering edge cases', () => {
 
 // ─── String edge cases ─────────────────────────────────────────────────────
 
-describe('string edge cases', () => {
+describeDebugOnly('string edge cases', () => {
     test('empty string lifts to [0, 0]', () => {
         const rctx = createMinimalRctx();
         const { ctx } = createMockMemoryContext();
@@ -514,7 +515,7 @@ describe('string edge cases', () => {
 
 // ─── Compound type edge cases ──────────────────────────────────────────────
 
-describe('option edge cases', () => {
+describeDebugOnly('option edge cases', () => {
     let rctx: ResolverContext;
     let bctx: BindingContext;
 
@@ -566,7 +567,7 @@ describe('option edge cases', () => {
     });
 });
 
-describe('result edge cases', () => {
+describeDebugOnly('result edge cases', () => {
     let rctx: ResolverContext;
     let bctx: BindingContext;
 
@@ -605,7 +606,7 @@ describe('result edge cases', () => {
     });
 });
 
-describe('variant edge cases', () => {
+describeDebugOnly('variant edge cases', () => {
     let rctx: ResolverContext;
     let bctx: BindingContext;
 
@@ -660,7 +661,7 @@ describe('variant edge cases', () => {
     });
 });
 
-describe('enum edge cases', () => {
+describeDebugOnly('enum edge cases', () => {
     let rctx: ResolverContext;
     let bctx: BindingContext;
 
@@ -707,7 +708,7 @@ describe('enum edge cases', () => {
     });
 });
 
-describe('flags edge cases', () => {
+describeDebugOnly('flags edge cases', () => {
     let rctx: ResolverContext;
     let bctx: BindingContext;
 
@@ -789,7 +790,7 @@ describe('flags edge cases', () => {
     });
 });
 
-describe('tuple edge cases', () => {
+describeDebugOnly('tuple edge cases', () => {
     let rctx: ResolverContext;
     let bctx: BindingContext;
 
@@ -850,7 +851,7 @@ describe('tuple edge cases', () => {
 
 // ─── Record edge cases ─────────────────────────────────────────────────────
 
-describe('record edge cases', () => {
+describeDebugOnly('record edge cases', () => {
     let rctx: ResolverContext;
     let bctx: BindingContext;
 
@@ -922,7 +923,7 @@ describe('record edge cases', () => {
 
 // ─── List edge cases ───────────────────────────────────────────────────────
 
-describe('list edge cases', () => {
+describeDebugOnly('list edge cases', () => {
     test('list with single element', () => {
         const rctx = createMinimalRctx();
         const { ctx, buffer } = createMockMemoryContext();
@@ -992,7 +993,7 @@ describe('list edge cases', () => {
 
 // ─── Resource edge cases ───────────────────────────────────────────────────
 
-describe('resource edge cases', () => {
+describeDebugOnly('resource edge cases', () => {
     test('own: lifting null/undefined still stores it', () => {
         const rctx = createMinimalRctx();
         const bctx = { resources: createResourceTable() } as any as BindingContext;
@@ -1043,7 +1044,7 @@ describe('resource edge cases', () => {
 
 // ─── Memory round-trip edge cases ──────────────────────────────────────────
 
-describe('storeToMemory/loadFromMemory round-trips', () => {
+describeDebugOnly('storeToMemory/loadFromMemory round-trips', () => {
     test('record with alignment padding round-trips', () => {
         const rctx = createMinimalRctx();
         const { ctx } = createMockMemoryContext();
@@ -1120,7 +1121,7 @@ describe('storeToMemory/loadFromMemory round-trips', () => {
 
 // ─── ComponentValTypeType (type reference) edge cases ──────────────────────
 
-describe('type reference (ComponentValTypeType) edge cases', () => {
+describeDebugOnly('type reference (ComponentValTypeType) edge cases', () => {
     test('resolves through type reference for primitives', () => {
         const rctx = createMinimalRctx();
         const bctx = createMinimalBctx();
@@ -1154,7 +1155,7 @@ describe('type reference (ComponentValTypeType) edge cases', () => {
 
 // ─── Discriminant size boundary tests ──────────────────────────────────────
 
-describe('discriminant size boundaries', () => {
+describeDebugOnly('discriminant size boundaries', () => {
     let rctx: ResolverContext;
     let bctx: BindingContext;
 
@@ -1254,7 +1255,7 @@ describe('discriminant size boundaries', () => {
 
 // ─── Nested compound type tests ────────────────────────────────────────────
 
-describe('nested compound types', () => {
+describeDebugOnly('nested compound types', () => {
     let rctx: ResolverContext;
     let bctx: BindingContext;
 
@@ -1520,7 +1521,7 @@ describe('nested compound types', () => {
 
 // ─── Char boundary value tests ─────────────────────────────────────────────
 
-describe('char boundary values (spec-exact)', () => {
+describeDebugOnly('char boundary values (spec-exact)', () => {
     let rctx: ResolverContext;
     let bctx: BindingContext;
 
@@ -1619,7 +1620,7 @@ describe('char boundary values (spec-exact)', () => {
 
 // ─── Multi-word flags tests ────────────────────────────────────────────────
 
-describe('multi-word flags (>32 members)', () => {
+describeDebugOnly('multi-word flags (>32 members)', () => {
     let rctx: ResolverContext;
     let bctx: BindingContext;
 
@@ -1718,7 +1719,7 @@ describe('multi-word flags (>32 members)', () => {
 
 // ─── Bool from memory tests ────────────────────────────────────────────────
 
-describe('bool from memory (non-0/1 values)', () => {
+describeDebugOnly('bool from memory (non-0/1 values)', () => {
     test('loadFromMemory: value 2 reads as true', () => {
         const rctx = createMinimalRctx();
         const { ctx, buffer } = createMockMemoryContext();
@@ -1773,7 +1774,7 @@ describe('bool from memory (non-0/1 values)', () => {
 
 // ─── Discriminant memory round-trip tests ──────────────────────────────────
 
-describe('discriminant in memory round-trips', () => {
+describeDebugOnly('discriminant in memory round-trips', () => {
     test('variant 256 cases via storeToMemory/loadFromMemory', () => {
         const rctx = createMinimalRctx();
         const { ctx } = createMockMemoryContext();
@@ -1984,7 +1985,7 @@ describe('discriminant in memory round-trips', () => {
 
 // ─── Resource handle edge cases (additional) ───────────────────────────────
 
-describe('resource handle additional edge cases', () => {
+describeDebugOnly('resource handle additional edge cases', () => {
     test('own via memory round-trip', () => {
         const rctx = createMinimalRctx();
         const { ctx } = createMockMemoryContext();
@@ -2070,7 +2071,7 @@ describe('resource handle additional edge cases', () => {
 
 // ─── Nested memory round-trips (complex) ──────────────────────────────────
 
-describe('nested types via memory round-trips', () => {
+describeDebugOnly('nested types via memory round-trips', () => {
     test('list<record{a: u8, b: u32}> via memory', () => {
         const rctx = createMinimalRctx();
         const { ctx } = createMockMemoryContext();
@@ -2140,7 +2141,7 @@ describe('nested types via memory round-trips', () => {
 
 // ─── Function trampoline edge cases ────────────────────────────────────────
 
-describe('function trampoline edge cases', () => {
+describeDebugOnly('function trampoline edge cases', () => {
     function createFuncRctx(): ResolverContext {
         return {
             resolved: {
@@ -2312,7 +2313,7 @@ describe('function trampoline edge cases', () => {
 
 // ─── Variant lowering edge cases ───────────────────────────────────────────
 
-describe('variant lowering validation', () => {
+describeDebugOnly('variant lowering validation', () => {
     let rctx: ResolverContext;
     let bctx: BindingContext;
 
@@ -2365,7 +2366,7 @@ describe('variant lowering validation', () => {
 
 // ─── CompactUTF-16 encoding error ──────────────────────────────────────────
 
-describe('CompactUTF-16 encoding', () => {
+describeDebugOnly('CompactUTF-16 encoding', () => {
     test('lifting with CompactUTF-16 throws not-supported', () => {
         const rctx = {
             resolved: {
@@ -2395,7 +2396,7 @@ describe('CompactUTF-16 encoding', () => {
 
 // ─── UTF-16 string out-of-bounds ───────────────────────────────────────────
 
-describe('UTF-16 string bounds checking', () => {
+describeDebugOnly('UTF-16 string bounds checking', () => {
     test('UTF-16 lowering out-of-bounds traps', () => {
         const rctx = {
             resolved: {

--- a/src/resolver/binding/edge-cases.test.ts
+++ b/src/resolver/binding/edge-cases.test.ts
@@ -1,5 +1,5 @@
-import { setConfiguration } from '../../utils/assert';
-setConfiguration('Debug');
+import { initializeAsserts } from '../../utils/assert';
+initializeAsserts();
 
 import { ModelTag } from '../../model/tags';
 import { ComponentValType, PrimitiveValType } from '../../model/types';

--- a/src/resolver/binding/function-imports.test.ts
+++ b/src/resolver/binding/function-imports.test.ts
@@ -1,5 +1,5 @@
-import { setConfiguration } from '../../utils/assert';
-setConfiguration('Debug');
+import { initializeAsserts } from '../../utils/assert';
+initializeAsserts();
 
 import { ModelTag } from '../../model/tags';
 import { resolveComponentImport } from '../component-imports';

--- a/src/resolver/binding/memoization.test.ts
+++ b/src/resolver/binding/memoization.test.ts
@@ -4,6 +4,7 @@ import { ResolvedContext, BindingContext, StringEncoding } from '../types';
 import { createLifting as _createLifting, createFunctionLifting } from './to-abi';
 import { createLowering, createFunctionLowering } from './to-js';
 import type { WasmValue } from './types';
+import { describeDebugOnly } from '../../test-utils/debug-only';
 
 // Wrap BYO-buffer lifters to return arrays for test convenience
 function createLifting(rctx: any, model: any): (ctx: BindingContext, value: any) => WasmValue[] {
@@ -34,7 +35,7 @@ function prim(value: PrimitiveValType): ComponentValType {
 
 // ─── Memoization key identity tests ──────────────────────────────────────
 
-describe('memoization keys', () => {
+describeDebugOnly('memoization keys', () => {
 
     describe('cache hit by object identity', () => {
         test('createLifting returns same result for same object reference', () => {

--- a/src/resolver/binding/primitives.test.ts
+++ b/src/resolver/binding/primitives.test.ts
@@ -154,6 +154,30 @@ describeDebugOnly('primitive lifting (JS → WASM)', () => {
         });
     });
 
+    describe('s64 (Number mode)', () => {
+        test('0n lifts to [0]', () => {
+            const nrctx = createMinimalRctx(true);
+            const lifter = createLifting(nrctx.resolved, prim(PrimitiveValType.S64));
+            const result = lifter(bctx, 0n);
+            expect(result).toEqual([0]);
+            expect(typeof result[0]).toBe('number');
+        });
+        test('-1n lifts to [-1]', () => {
+            const nrctx = createMinimalRctx(true);
+            const lifter = createLifting(nrctx.resolved, prim(PrimitiveValType.S64));
+            const result = lifter(bctx, -1n);
+            expect(result).toEqual([-1]);
+            expect(typeof result[0]).toBe('number');
+        });
+        test('42n lifts to [42]', () => {
+            const nrctx = createMinimalRctx(true);
+            const lifter = createLifting(nrctx.resolved, prim(PrimitiveValType.S64));
+            const result = lifter(bctx, 42n);
+            expect(result).toEqual([42]);
+            expect(typeof result[0]).toBe('number');
+        });
+    });
+
     describe('u64 (BigInt mode)', () => {
         test('0n lifts to [0n]', () => {
             const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.U64));
@@ -163,6 +187,23 @@ describeDebugOnly('primitive lifting (JS → WASM)', () => {
             const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.U64));
             const maxU64 = BigInt(2) ** BigInt(64) - 1n;
             expect(lifter(bctx, maxU64)).toEqual([18446744073709551615n]);
+        });
+    });
+
+    describe('u64 (Number mode)', () => {
+        test('0n lifts to [0]', () => {
+            const nrctx = createMinimalRctx(true);
+            const lifter = createLifting(nrctx.resolved, prim(PrimitiveValType.U64));
+            const result = lifter(bctx, 0n);
+            expect(result).toEqual([0]);
+            expect(typeof result[0]).toBe('number');
+        });
+        test('100n lifts to [100]', () => {
+            const nrctx = createMinimalRctx(true);
+            const lifter = createLifting(nrctx.resolved, prim(PrimitiveValType.U64));
+            const result = lifter(bctx, 100n);
+            expect(result).toEqual([100]);
+            expect(typeof result[0]).toBe('number');
         });
     });
 
@@ -293,10 +334,51 @@ describeDebugOnly('primitive lowering (WASM → JS)', () => {
         });
     });
 
+    describe('s64 (Number mode)', () => {
+        test('0n lowers to 0', () => {
+            const nrctx = createMinimalRctx(true);
+            const lowerer = createLowering(nrctx.resolved, prim(PrimitiveValType.S64));
+            const result = lowerer(bctx, 0n);
+            expect(result).toBe(0);
+            expect(typeof result).toBe('number');
+        });
+        test('-1n lowers to -1', () => {
+            const nrctx = createMinimalRctx(true);
+            const lowerer = createLowering(nrctx.resolved, prim(PrimitiveValType.S64));
+            const result = lowerer(bctx, -1n);
+            expect(result).toBe(-1);
+            expect(typeof result).toBe('number');
+        });
+        test('42n lowers to 42', () => {
+            const nrctx = createMinimalRctx(true);
+            const lowerer = createLowering(nrctx.resolved, prim(PrimitiveValType.S64));
+            const result = lowerer(bctx, 42n);
+            expect(result).toBe(42);
+            expect(typeof result).toBe('number');
+        });
+    });
+
     describe('u64 (BigInt mode)', () => {
         test('0n lowers to 0n', () => {
             const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.U64));
             expect(lowerer(bctx, 0n)).toBe(0n);
+        });
+    });
+
+    describe('u64 (Number mode)', () => {
+        test('0n lowers to 0', () => {
+            const nrctx = createMinimalRctx(true);
+            const lowerer = createLowering(nrctx.resolved, prim(PrimitiveValType.U64));
+            const result = lowerer(bctx, 0n);
+            expect(result).toBe(0);
+            expect(typeof result).toBe('number');
+        });
+        test('100n lowers to 100', () => {
+            const nrctx = createMinimalRctx(true);
+            const lowerer = createLowering(nrctx.resolved, prim(PrimitiveValType.U64));
+            const result = lowerer(bctx, 100n);
+            expect(result).toBe(100);
+            expect(typeof result).toBe('number');
         });
     });
 
@@ -361,5 +443,76 @@ describeDebugOnly('lowerer spill counts', () => {
     test('string has spill=2', () => {
         const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.String));
         expect((lowerer as any).spill).toBe(2);
+    });
+});
+
+describeDebugOnly('useNumberForInt64 option handling', () => {
+    test('default (undefined) → usesNumberForInt64 = false', () => {
+        const rctx = createMinimalRctx();
+        expect(rctx.resolved.usesNumberForInt64).toBe(false);
+    });
+
+    test('false → usesNumberForInt64 = false', () => {
+        const rctx = createMinimalRctx(false);
+        expect(rctx.resolved.usesNumberForInt64).toBe(false);
+    });
+
+    test('true → usesNumberForInt64 = true, lifters produce Number', () => {
+        const rctx = createMinimalRctx(true);
+        const bctx = createMinimalBctx();
+        expect(rctx.resolved.usesNumberForInt64).toBe(true);
+
+        const s64Lifter = createLifting(rctx.resolved, prim(PrimitiveValType.S64));
+        const s64Result = s64Lifter(bctx, 42n);
+        expect(typeof s64Result[0]).toBe('number');
+        expect(s64Result[0]).toBe(42);
+
+        const u64Lifter = createLifting(rctx.resolved, prim(PrimitiveValType.U64));
+        const u64Result = u64Lifter(bctx, 100n);
+        expect(typeof u64Result[0]).toBe('number');
+        expect(u64Result[0]).toBe(100);
+    });
+
+    test('true → lowerers produce Number', () => {
+        const rctx = createMinimalRctx(true);
+        const bctx = createMinimalBctx();
+
+        const s64Lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.S64));
+        const s64Result = s64Lowerer(bctx, 42n);
+        expect(typeof s64Result).toBe('number');
+        expect(s64Result).toBe(42);
+
+        const u64Lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.U64));
+        const u64Result = u64Lowerer(bctx, 100n);
+        expect(typeof u64Result).toBe('number');
+        expect(u64Result).toBe(100);
+    });
+
+    test('false → lifters and lowerers produce BigInt', () => {
+        const rctx = createMinimalRctx(false);
+        const bctx = createMinimalBctx();
+
+        const lifter = createLifting(rctx.resolved, prim(PrimitiveValType.S64));
+        const liftResult = lifter(bctx, 42n);
+        expect(typeof liftResult[0]).toBe('bigint');
+
+        const lowerer = createLowering(rctx.resolved, prim(PrimitiveValType.S64));
+        const lowerResult = lowerer(bctx, 42n);
+        expect(typeof lowerResult).toBe('bigint');
+    });
+
+    test('BigInt and Number caches are independent', () => {
+        const bigintRctx = createMinimalRctx(false);
+        const numberRctx = createMinimalRctx(true);
+        const bctx = createMinimalBctx();
+
+        // Same primitive type, but different resolvedContexts
+        const bigintLifter = createLifting(bigintRctx.resolved, prim(PrimitiveValType.S64));
+        const numberLifter = createLifting(numberRctx.resolved, prim(PrimitiveValType.S64));
+
+        // Different caches, different lifters
+        expect(bigintLifter).not.toBe(numberLifter);
+        expect(typeof bigintLifter(bctx, 1n)[0]).toBe('bigint');
+        expect(typeof numberLifter(bctx, 1n)[0]).toBe('number');
     });
 });

--- a/src/resolver/binding/primitives.test.ts
+++ b/src/resolver/binding/primitives.test.ts
@@ -7,6 +7,7 @@ import { ResolverContext, BindingContext } from '../types';
 import { createLifting as _createLifting } from './to-abi';
 import { createLowering } from './to-js';
 import type { WasmValue } from './types';
+import { describeDebugOnly } from '../../test-utils/debug-only';
 
 // Wrap BYO-buffer lifters to return arrays for test convenience
 function createLifting(rctx: any, model: any): (ctx: BindingContext, value: any) => WasmValue[] {
@@ -36,7 +37,7 @@ function prim(value: PrimitiveValType): ComponentValType {
     return { tag: ModelTag.ComponentValTypePrimitive, value };
 }
 
-describe('primitive lifting (JS → WASM)', () => {
+describeDebugOnly('primitive lifting (JS → WASM)', () => {
     let rctx: ResolverContext;
     let bctx: BindingContext;
 
@@ -203,7 +204,7 @@ describe('primitive lifting (JS → WASM)', () => {
     });
 });
 
-describe('primitive lowering (WASM → JS)', () => {
+describeDebugOnly('primitive lowering (WASM → JS)', () => {
     let rctx: ResolverContext;
     let bctx: BindingContext;
 
@@ -329,7 +330,7 @@ describe('primitive lowering (WASM → JS)', () => {
     });
 });
 
-describe('lowerer spill counts', () => {
+describeDebugOnly('lowerer spill counts', () => {
     let rctx: ResolverContext;
 
     beforeEach(() => {

--- a/src/resolver/binding/primitives.test.ts
+++ b/src/resolver/binding/primitives.test.ts
@@ -1,5 +1,5 @@
-import { setConfiguration } from '../../utils/assert';
-setConfiguration('Debug');
+import { initializeAsserts } from '../../utils/assert';
+initializeAsserts();
 
 import { ModelTag } from '../../model/tags';
 import { ComponentValType, PrimitiveValType } from '../../model/types';

--- a/src/resolver/binding/resources.test.ts
+++ b/src/resolver/binding/resources.test.ts
@@ -1,5 +1,5 @@
-import { setConfiguration } from '../../utils/assert';
-setConfiguration('Debug');
+import { initializeAsserts } from '../../utils/assert';
+initializeAsserts();
 
 import { ModelTag } from '../../model/tags';
 import { ResolverContext, BindingContext } from '../types';

--- a/src/resolver/binding/resources.test.ts
+++ b/src/resolver/binding/resources.test.ts
@@ -8,6 +8,7 @@ import { resolveCanonicalResourceType } from '../type-resolution';
 import { createLifting as _createLifting } from './to-abi';
 import { createLowering } from './to-js';
 import type { WasmValue } from './types';
+import { describeDebugOnly } from '../../test-utils/debug-only';
 
 // Wrap BYO-buffer lifters to return arrays for test convenience
 function createLifting(rctx: any, model: any): (ctx: BindingContext, value: any) => WasmValue[] {
@@ -38,7 +39,7 @@ function createMockCtxWithResources(): BindingContext {
     } as any as BindingContext;
 }
 
-describe('ResourceTable', () => {
+describeDebugOnly('ResourceTable', () => {
     test('add returns handle >= 1', () => {
         const resources = createResourceTable();
         const h = resources.add(0, { name: 'a' });
@@ -106,7 +107,7 @@ describe('ResourceTable', () => {
     });
 });
 
-describe('canonical resource identity resolution', () => {
+describeDebugOnly('canonical resource identity resolution', () => {
     test('resolves own<T> to ComponentTypeResource via unified type index', () => {
         const rctx = {
             indexes: {
@@ -179,7 +180,7 @@ describe('canonical resource identity resolution', () => {
     });
 });
 
-describe('own<T> lifting', () => {
+describeDebugOnly('own<T> lifting', () => {
     let rctx: ResolverContext;
     let bctx: BindingContext;
 
@@ -214,7 +215,7 @@ describe('own<T> lifting', () => {
     });
 });
 
-describe('own<T> lowering', () => {
+describeDebugOnly('own<T> lowering', () => {
     let rctx: ResolverContext;
     let bctx: BindingContext;
 
@@ -256,7 +257,7 @@ describe('own<T> lowering', () => {
     });
 });
 
-describe('borrow<T> lifting', () => {
+describeDebugOnly('borrow<T> lifting', () => {
     let rctx: ResolverContext;
     let bctx: BindingContext;
 
@@ -283,7 +284,7 @@ describe('borrow<T> lifting', () => {
     });
 });
 
-describe('borrow<T> lowering', () => {
+describeDebugOnly('borrow<T> lowering', () => {
     let rctx: ResolverContext;
     let bctx: BindingContext;
 
@@ -327,7 +328,7 @@ describe('borrow<T> lowering', () => {
     });
 });
 
-describe('own vs borrow semantics', () => {
+describeDebugOnly('own vs borrow semantics', () => {
     let rctx: ResolverContext;
     let bctx: BindingContext;
 
@@ -376,7 +377,7 @@ describe('own vs borrow semantics', () => {
     });
 });
 
-describe('borrow accounting (lend/unlend)', () => {
+describeDebugOnly('borrow accounting (lend/unlend)', () => {
     test('new handle starts with zero lends', () => {
         const resources = createResourceTable();
         const h = resources.add(0, 'obj');
@@ -471,7 +472,7 @@ describe('borrow accounting (lend/unlend)', () => {
     });
 });
 
-describe('resource handle isolation', () => {
+describeDebugOnly('resource handle isolation', () => {
     test('handles across types are globally unique', () => {
         const resources = createResourceTable();
         const h1 = resources.add(0, 'type0-a');
@@ -524,7 +525,7 @@ describe('resource handle isolation', () => {
     });
 });
 
-describe('resource handle cleanup and ref counting', () => {
+describeDebugOnly('resource handle cleanup and ref counting', () => {
     test('remove all handles leaves table empty', () => {
         const resources = createResourceTable();
         const handles = [

--- a/src/resolver/binding/shared.ts
+++ b/src/resolver/binding/shared.ts
@@ -1,0 +1,15 @@
+// Shared typed-array buffers for float↔int bit reinterpretation (used by coerceFlatLift/Lower and NaN canonicalization)
+export const _f32 = new Float32Array(1);
+export const _i32 = new Int32Array(_f32.buffer);
+export const _f64 = new Float64Array(1);
+export const _i64 = new BigInt64Array(_f64.buffer);
+
+// Canonical NaN values per spec (CANONICAL_FLOAT32_NAN = 0x7fc00000, CANONICAL_FLOAT64_NAN = 0x7ff8000000000000)
+_i32[0] = 0x7fc00000;
+export const canonicalNaN32: number = _f32[0];
+_i64[0] = 0x7ff8000000000000n;
+export const canonicalNaN64: number = _f64[0];
+
+export function bigIntReplacer(_key: string, value: unknown): unknown {
+    return typeof value === 'bigint' ? value.toString() + 'n' : value;
+}

--- a/src/resolver/binding/spilling.test.ts
+++ b/src/resolver/binding/spilling.test.ts
@@ -7,6 +7,7 @@ import { ResolverContext, BindingContext } from '../types';
 import { createFunctionLifting } from './to-abi';
 import { createFunctionLowering } from './to-js';
 import { WasmPointer, WasmSize } from './types';
+import { describeDebugOnly } from '../../test-utils/debug-only';
 
 // ─── Mock helpers ──────────────────────────────────────────────────────────
 
@@ -109,7 +110,7 @@ function makeFunc(paramCount: number, resultType?: ComponentValType): ComponentT
 
 // ─── Tests ─────────────────────────────────────────────────────────────────
 
-describe('function trampolines', () => {
+describeDebugOnly('function trampolines', () => {
 
     // ── Flat params (within MAX_FLAT_PARAMS) ────────────────────────────
 

--- a/src/resolver/binding/spilling.test.ts
+++ b/src/resolver/binding/spilling.test.ts
@@ -1,5 +1,5 @@
-import { setConfiguration } from '../../utils/assert';
-setConfiguration('Debug');
+import { initializeAsserts } from '../../utils/assert';
+initializeAsserts();
 
 import { ModelTag } from '../../model/tags';
 import { ComponentTypeFunc, ComponentValType, PrimitiveValType, ComponentTypeDefinedRecord } from '../../model/types';

--- a/src/resolver/binding/to-abi.ts
+++ b/src/resolver/binding/to-abi.ts
@@ -44,7 +44,6 @@ export function createFunctionLifting(rctx: ResolvedContext, importModel: Compon
         }
 
         // Pre-resolve param types for spilled path — deep-resolve ensures
-        // storeToMemory/loadFromMemory can work without rctx.resolvedTypes lookups
         const paramResolvedTypes = importModel.params.map(p => deepResolveType(rctx, resolveValType(rctx, p.type)));
 
         // Pre-capture rctx properties needed at call time — after this, rctx is not captured

--- a/src/resolver/binding/to-abi.ts
+++ b/src/resolver/binding/to-abi.ts
@@ -7,27 +7,14 @@ import { jsco_assert, LogLevel } from '../../utils/assert';
 import { callingConventionName } from '../../utils/debug-names';
 import type { ResolvedType } from '../type-resolution';
 import { getCanonicalResourceId } from '../context';
-import { CallingConvention, determineFunctionCallingConvention, sizeOf, alignOf, flatCount, alignOfValType, resolveValType, resolveValTypePure, deepResolveType, discriminantSize, FlatType, flattenType, flattenValType, flattenVariant } from '../calling-convention';
+import { CallingConvention, determineFunctionCallingConvention, sizeOf, alignOf, alignUp, flatCount, alignOfValType, resolveValType, resolveValTypePure, deepResolveType, discriminantSize, FlatType, flattenType, flattenValType, flattenVariant } from '../calling-convention';
 import { memoize } from './cache';
 import { createLowering, createMemoryLoader } from './to-js';
 import { LiftingFromJs, WasmPointer, FnLiftingCallFromJs, JsFunction, WasmSize, WasmValue, WasmFunction, JsValue } from './types';
 import { validateAllocResult, checkNotPoisoned, checkNotReentrant } from './validation';
+import { _f32, _i32, _f64, _i64, canonicalNaN32, canonicalNaN64, bigIntReplacer } from './shared';
 import camelCase from 'just-camel-case';
 import { TAG, VAL, OK } from '../../constants';
-
-// Canonical NaN values per spec (CANONICAL_FLOAT32_NAN = 0x7fc00000, CANONICAL_FLOAT64_NAN = 0x7ff8000000000000)
-const _f32 = new Float32Array(1);
-const _i32 = new Int32Array(_f32.buffer);
-_i32[0] = 0x7fc00000;
-const canonicalNaN32: number = _f32[0];
-const _f64 = new Float64Array(1);
-const _i64 = new BigInt64Array(_f64.buffer);
-_i64[0] = 0x7ff8000000000000n;
-const canonicalNaN64: number = _f64[0];
-
-function bigIntReplacer(_key: string, value: unknown): unknown {
-    return typeof value === 'bigint' ? value.toString() + 'n' : value;
-}
 
 
 export function createFunctionLifting(rctx: ResolvedContext, importModel: ComponentTypeFunc): FnLiftingCallFromJs {
@@ -451,10 +438,6 @@ function createStringLiftingUtf16(): LiftingFromJs {
 }
 
 // --- Memory store helpers (for list element storage) ---
-
-function alignUp(offset: number, align: number): number {
-    return (offset + align - 1) & ~(align - 1);
-}
 
 export type MemoryStorer = (ctx: BindingContext, ptr: number, jsValue: JsValue) => void;
 

--- a/src/resolver/binding/to-abi.ts
+++ b/src/resolver/binding/to-abi.ts
@@ -13,6 +13,7 @@ import { createLowering, createMemoryLoader } from './to-js';
 import { LiftingFromJs, WasmPointer, FnLiftingCallFromJs, JsFunction, WasmSize, WasmValue, WasmFunction, JsValue } from './types';
 import { validateAllocResult, checkNotPoisoned, checkNotReentrant } from './validation';
 import camelCase from 'just-camel-case';
+import { TAG, VAL, OK } from '../../constants';
 
 // Canonical NaN values per spec (CANONICAL_FLOAT32_NAN = 0x7fc00000, CANONICAL_FLOAT64_NAN = 0x7ff8000000000000)
 const _f32 = new Float32Array(1);
@@ -566,9 +567,9 @@ export function createMemoryStorer(type: ResolvedType, stringEncoding: StringEnc
             const errStorer = type.err !== undefined ? createMemoryStorer(resolveValTypePure(type.err), stringEncoding, canonicalResourceIds, ownInstanceResources) : undefined;
             return (ctx, ptr, jsValue) => {
                 const dv = ctx.memory.getView(ptr as WasmPointer, 1 as WasmSize);
-                const { tag, val } = jsValue as { tag: string, val?: any };
+                const tag = (jsValue as any)[TAG], val = (jsValue as any)[VAL];
                 if (typeof tag !== 'string') throw new TypeError(`Expected result value with 'tag' field, got ${typeof jsValue === 'object' ? JSON.stringify(jsValue) : typeof jsValue}`);
-                if (tag === 'ok') {
+                if (tag === OK) {
                     dv.setUint8(0, 0);
                     if (okStorer && val !== undefined) {
                         okStorer(ctx, ptr + payloadOffset, val);
@@ -595,7 +596,7 @@ export function createMemoryStorer(type: ResolvedType, stringEncoding: StringEnc
             );
             const nameToIndex = new Map(type.variants.map((c, i) => [c.name, i]));
             return (ctx, ptr, jsValue) => {
-                const { tag, val } = jsValue as { tag: string, val?: any };
+                const tag = (jsValue as any)[TAG], val = (jsValue as any)[VAL];
                 if (typeof tag !== 'string') throw new TypeError(`Expected variant value with 'tag' field, got ${typeof jsValue === 'object' ? JSON.stringify(jsValue) : typeof jsValue}`);
                 const caseIndex = nameToIndex.get(tag)!;
                 const dv = ctx.memory.getView(ptr as WasmPointer, discSize as WasmSize);
@@ -746,10 +747,10 @@ function createResultLifting(rctx: ResolvedContext, resultModel: ComponentTypeDe
     const errNeedsCoercion = errFlatTypes.some((ct, i) => ct !== payloadJoined[i]);
 
     return (ctx, srcJsValue, out, offset) => {
-        const { tag, val } = srcJsValue as { tag: string, val?: any };
+        const tag = (srcJsValue as any)[TAG], val = (srcJsValue as any)[VAL];
         if (typeof tag !== 'string') throw new TypeError(`Expected result value with 'tag' field, got ${typeof srcJsValue === 'object' ? JSON.stringify(srcJsValue) : typeof srcJsValue}`);
         for (let i = 0; i < totalSize; i++) out[offset + i] = zeroValues[i];
-        if (tag === 'ok') {
+        if (tag === OK) {
             if (okLifter) okLifter(ctx, val, out, offset + 1);
             if (okNeedsCoercion) {
                 for (let i = 0; i < okFlatTypes.length; i++) {
@@ -800,7 +801,7 @@ function createVariantLifting(rctx: ResolvedContext, variantModel: ComponentType
     const nameToCase = new Map(cases.map(c => [c.name, c]));
 
     return (ctx, srcJsValue, out, offset) => {
-        const { tag, val } = srcJsValue as { tag: string, val?: any };
+        const tag = (srcJsValue as any)[TAG], val = (srcJsValue as any)[VAL];
         if (typeof tag !== 'string') throw new TypeError(`Expected variant value with 'tag' field, got ${typeof srcJsValue === 'object' ? JSON.stringify(srcJsValue) : typeof srcJsValue}`);
         const c = nameToCase.get(tag);
         if (!c) throw new Error(`Unknown variant case: ${tag}`);

--- a/src/resolver/binding/to-abi.ts
+++ b/src/resolver/binding/to-abi.ts
@@ -1,8 +1,9 @@
+import isDebug from 'env:isDebug';
 import { ComponentTypeIndex } from '../../model/indices';
 import { ModelTag } from '../../model/tags';
 import { ComponentTypeDefinedRecord, ComponentTypeDefinedList, ComponentTypeDefinedOption, ComponentTypeDefinedResult, ComponentTypeDefinedVariant, ComponentTypeDefinedEnum, ComponentTypeDefinedFlags, ComponentTypeDefinedTuple, ComponentTypeFunc, ComponentValType, PrimitiveValType, ComponentTypeDefinedOwn, ComponentTypeDefinedBorrow } from '../../model/types';
 import { BindingContext, ResolvedContext, StringEncoding } from '../types';
-import { jsco_assert, isDebug, LogLevel } from '../../utils/assert';
+import { jsco_assert, LogLevel } from '../../utils/assert';
 import { callingConventionName } from '../../utils/debug-names';
 import type { ResolvedType } from '../type-resolution';
 import { getCanonicalResourceId } from '../context';

--- a/src/resolver/binding/to-js.ts
+++ b/src/resolver/binding/to-js.ts
@@ -21,7 +21,6 @@ export function createFunctionLowering(rctx: ResolvedContext, exportModel: Compo
     return memoize(rctx.loweringCache, exportModel, () => {
         const callingConvention = determineFunctionCallingConvention(deepResolveType(rctx, exportModel) as ComponentTypeFunc);
         // Pre-resolve param/result types for spilled path — deep-resolve ensures
-        // storeToMemory/loadFromMemory can work without rctx.resolvedTypes lookups
         const paramResolvedTypes = exportModel.params.map(p => deepResolveType(rctx, resolveValType(rctx, p.type)));
         let resultType: ResolvedType | undefined;
         if (exportModel.results.tag === ModelTag.ComponentFuncResultUnnamed) {

--- a/src/resolver/binding/to-js.ts
+++ b/src/resolver/binding/to-js.ts
@@ -1,8 +1,9 @@
+import isDebug from 'env:isDebug';
 import { ComponentTypeIndex } from '../../model/indices';
 import { ModelTag } from '../../model/tags';
 import { ComponentTypeDefinedRecord, ComponentTypeDefinedList, ComponentTypeDefinedOption, ComponentTypeDefinedResult, ComponentTypeDefinedVariant, ComponentTypeDefinedEnum, ComponentTypeDefinedFlags, ComponentTypeDefinedTuple, ComponentTypeFunc, ComponentValType, PrimitiveValType, ComponentTypeDefinedOwn, ComponentTypeDefinedBorrow } from '../../model/types';
 import { BindingContext, ResolvedContext, StringEncoding } from '../types';
-import { jsco_assert, isDebug, LogLevel } from '../../utils/assert';
+import { jsco_assert, LogLevel } from '../../utils/assert';
 import { callingConventionName } from '../../utils/debug-names';
 import type { ResolvedType } from '../type-resolution';
 import { getCanonicalResourceId } from '../context';

--- a/src/resolver/binding/to-js.ts
+++ b/src/resolver/binding/to-js.ts
@@ -13,6 +13,7 @@ import { createLifting, createMemoryStorer } from './to-abi';
 import { LoweringToJs, FnLoweringCallToJs, WasmFunction, WasmPointer, JsFunction, WasmSize, WasmValue } from './types';
 import { validatePointerAlignment, validateUtf16 } from './validation';
 import camelCase from 'just-camel-case';
+import { TAG, VAL, OK, ERR } from '../../constants';
 
 // Canonical NaN values per spec (CANONICAL_FLOAT32_NAN = 0x7fc00000, CANONICAL_FLOAT64_NAN = 0x7ff8000000000000)
 const _f32 = new Float32Array(1);
@@ -579,10 +580,10 @@ export function createMemoryLoader(type: ResolvedType, stringEncoding: StringEnc
                 if (disc > 1) throw new Error(`Invalid result discriminant: ${disc}`);
                 if (disc === 0) {
                     const val = okLoader ? okLoader(ctx, ptr + payloadOffset) : undefined;
-                    return { tag: 'ok', val };
+                    return { [TAG]: OK, [VAL]: val };
                 } else {
                     const val = errLoader ? errLoader(ctx, ptr + payloadOffset) : undefined;
-                    return { tag: 'err', val };
+                    return { [TAG]: ERR, [VAL]: val };
                 }
             };
         }
@@ -607,9 +608,9 @@ export function createMemoryLoader(type: ResolvedType, stringEncoding: StringEnc
                 if (disc >= numCases) throw new Error(`Invalid variant discriminant: ${disc} >= ${numCases}`);
                 const loader = caseLoaders[disc];
                 if (loader) {
-                    return { tag: caseNames[disc], val: loader(ctx, ptr + payloadOffset) };
+                    return { [TAG]: caseNames[disc], [VAL]: loader(ctx, ptr + payloadOffset) };
                 }
-                return { tag: caseNames[disc] };
+                return { [TAG]: caseNames[disc] };
             };
         }
         case ModelTag.ComponentTypeDefinedEnum: {
@@ -761,7 +762,7 @@ function createResultLowering(rctx: ResolvedContext, resultModel: ComponentTypeD
                 }
             }
             const val = okLowerer ? okLowerer(ctx, ...payload.slice(0, okFlatTypes.length)) : undefined;
-            return { tag: 'ok', val };
+            return { [TAG]: OK, [VAL]: val };
         } else {
             if (errNeedsCoercion) {
                 for (let i = 0; i < errFlatTypes.length; i++) {
@@ -771,7 +772,7 @@ function createResultLowering(rctx: ResolvedContext, resultModel: ComponentTypeD
                 }
             }
             const val = errLowerer ? errLowerer(ctx, ...payload.slice(0, errFlatTypes.length)) : undefined;
-            return { tag: 'err', val };
+            return { [TAG]: ERR, [VAL]: val };
         }
     };
     fn.spill = totalSpill;
@@ -814,9 +815,9 @@ function createVariantLowering(rctx: ResolvedContext, variantModel: ComponentTyp
                     }
                 }
             }
-            return { tag: c.name, val: c.lowerer(ctx, ...payload) };
+            return { [TAG]: c.name, [VAL]: c.lowerer(ctx, ...payload) };
         }
-        return { tag: c.name };
+        return { [TAG]: c.name };
     };
     fn.spill = totalSpill;
     return fn;

--- a/src/resolver/binding/to-js.ts
+++ b/src/resolver/binding/to-js.ts
@@ -7,27 +7,14 @@ import { jsco_assert, LogLevel } from '../../utils/assert';
 import { callingConventionName } from '../../utils/debug-names';
 import type { ResolvedType } from '../type-resolution';
 import { getCanonicalResourceId } from '../context';
-import { CallingConvention, determineFunctionCallingConvention, sizeOf, alignOf, alignOfValType, resolveValType, resolveValTypePure, deepResolveType, discriminantSize, FlatType, flattenType, flattenValType, flattenVariant } from '../calling-convention';
+import { CallingConvention, determineFunctionCallingConvention, sizeOf, alignOf, alignUp, alignOfValType, resolveValType, resolveValTypePure, deepResolveType, discriminantSize, FlatType, flattenType, flattenValType, flattenVariant } from '../calling-convention';
 import { memoize } from './cache';
 import { createLifting, createMemoryStorer } from './to-abi';
 import { LoweringToJs, FnLoweringCallToJs, WasmFunction, WasmPointer, JsFunction, WasmSize, WasmValue } from './types';
 import { validatePointerAlignment, validateUtf16 } from './validation';
+import { _f32, _i32, _f64, _i64, canonicalNaN32, canonicalNaN64, bigIntReplacer } from './shared';
 import camelCase from 'just-camel-case';
 import { TAG, VAL, OK, ERR } from '../../constants';
-
-// Canonical NaN values per spec (CANONICAL_FLOAT32_NAN = 0x7fc00000, CANONICAL_FLOAT64_NAN = 0x7ff8000000000000)
-const _f32 = new Float32Array(1);
-const _i32 = new Int32Array(_f32.buffer);
-_i32[0] = 0x7fc00000;
-const canonicalNaN32: number = _f32[0];
-const _f64 = new Float64Array(1);
-const _i64 = new BigInt64Array(_f64.buffer);
-_i64[0] = 0x7ff8000000000000n;
-const canonicalNaN64: number = _f64[0];
-
-function bigIntReplacer(_key: string, value: unknown): unknown {
-    return typeof value === 'bigint' ? value.toString() + 'n' : value;
-}
 
 
 export function createFunctionLowering(rctx: ResolvedContext, exportModel: ComponentTypeFunc): FnLoweringCallToJs {
@@ -423,10 +410,6 @@ function createStringLoweringUtf16(): LoweringToJs {
 }
 
 // --- Memory load helpers (for list element loading) ---
-
-function alignUp(offset: number, align: number): number {
-    return (offset + align - 1) & ~(align - 1);
-}
 
 export type MemoryLoader = (ctx: BindingContext, ptr: number) => any;
 

--- a/src/resolver/calling-convention.ts
+++ b/src/resolver/calling-convention.ts
@@ -1,6 +1,6 @@
 import { ComponentTypeIndex } from '../model/indices';
 import { ModelTag } from '../model/tags';
-import { ComponentTypeDefinedResult, ComponentTypeDefinedVariant, ComponentTypeFunc, ComponentValType, PrimitiveValType } from '../model/types';
+import { ComponentTypeDefinedResult, ComponentTypeDefinedVariant, ComponentTypeFunc, ComponentValType, PrimitiveValType_Count } from '../model/types';
 import type { ResolvedType } from './type-resolution';
 import type { ResolvedContext } from './types';
 
@@ -37,66 +37,28 @@ export type FunctionCallingConvention = {
     resultFlatCount: number;
 }
 
-// --- Primitive size/alignment tables ---
+// --- Primitive size/alignment/flat tables (indexed by PrimitiveValType) ---
+// PrimitiveValType: Bool=0, S8=1, U8=2, S16=3, U16=4, S32=5, U32=6, S64=7, U64=8, Float32=9, Float64=10, Char=11, String=12
 
-function primitiveSizeOf(prim: PrimitiveValType): number {
-    switch (prim) {
-        case PrimitiveValType.Bool:
-        case PrimitiveValType.S8:
-        case PrimitiveValType.U8:
-            return 1;
-        case PrimitiveValType.S16:
-        case PrimitiveValType.U16:
-            return 2;
-        case PrimitiveValType.S32:
-        case PrimitiveValType.U32:
-        case PrimitiveValType.Float32:
-        case PrimitiveValType.Char:
-            return 4;
-        case PrimitiveValType.S64:
-        case PrimitiveValType.U64:
-        case PrimitiveValType.Float64:
-            return 8;
-        case PrimitiveValType.String:
-            return 8; // pointer + length
-    }
-}
+// Bool=0, S8=1, U8=2, S16=3, U16=4, S32=5, U32=6, S64=7, U64=8, Float32=9, Float64=10, Char=11, String=12
+const _primSize: number[] = [1, 1, 1, 2, 2, 4, 4, 8, 8, 4, 8, 4, 8];
+const _primAlign: number[] = [1, 1, 1, 2, 2, 4, 4, 8, 8, 4, 8, 4, 4];
+const _primFC: number[] = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2];
+const _I32: FlatType[] = [FlatType.I32];
+const _I64: FlatType[] = [FlatType.I64];
+const _F32: FlatType[] = [FlatType.F32];
+const _F64: FlatType[] = [FlatType.F64];
+const _I32I32: FlatType[] = [FlatType.I32, FlatType.I32];
+const _primFT: FlatType[][] = [_I32, _I32, _I32, _I32, _I32, _I32, _I32, _I64, _I64, _F32, _F64, _I32, _I32I32];
 
-function primitiveAlignOf(prim: PrimitiveValType): number {
-    switch (prim) {
-        case PrimitiveValType.Bool:
-        case PrimitiveValType.S8:
-        case PrimitiveValType.U8:
-            return 1;
-        case PrimitiveValType.S16:
-        case PrimitiveValType.U16:
-            return 2;
-        case PrimitiveValType.S32:
-        case PrimitiveValType.U32:
-        case PrimitiveValType.Float32:
-        case PrimitiveValType.Char:
-            return 4;
-        case PrimitiveValType.S64:
-        case PrimitiveValType.U64:
-        case PrimitiveValType.Float64:
-            return 8;
-        case PrimitiveValType.String:
-            return 4; // pointer alignment
-    }
-}
-
-function primitiveFlatCount(prim: PrimitiveValType): number {
-    switch (prim) {
-        case PrimitiveValType.String:
-            return 2; // pointer + length
-        default:
-            return 1;
-    }
+function primIdx(v: number): number {
+    if (v < 0 || v >= PrimitiveValType_Count) throw new Error(`PrimitiveValType out of range: ${v}`);
+    return v;
 }
 
 // --- Composite type calculations ---
 
-function alignUp(offset: number, align: number): number {
+export function alignUp(offset: number, align: number): number {
     return (offset + align - 1) & ~(align - 1);
 }
 
@@ -104,7 +66,7 @@ export function sizeOf(type: ResolvedType): number {
     switch (type.tag) {
         case ModelTag.ComponentValTypePrimitive:
         case ModelTag.ComponentTypeDefinedPrimitive:
-            return primitiveSizeOf(type.value);
+            return _primSize[primIdx(type.value)];
 
         case ModelTag.ComponentTypeDefinedRecord: {
             let size = 0;
@@ -189,7 +151,7 @@ export function alignOf(type: ResolvedType): number {
     switch (type.tag) {
         case ModelTag.ComponentValTypePrimitive:
         case ModelTag.ComponentTypeDefinedPrimitive:
-            return primitiveAlignOf(type.value);
+            return _primAlign[primIdx(type.value)];
 
         case ModelTag.ComponentTypeDefinedRecord: {
             let maxAlign = 1;
@@ -250,7 +212,7 @@ export function flatCount(type: ResolvedType): number {
     switch (type.tag) {
         case ModelTag.ComponentValTypePrimitive:
         case ModelTag.ComponentTypeDefinedPrimitive:
-            return primitiveFlatCount(type.value);
+            return _primFC[primIdx(type.value)];
 
         case ModelTag.ComponentTypeDefinedRecord: {
             let count = 0;
@@ -493,29 +455,6 @@ export function discriminantSize(caseCount: number): number {
 
 // --- Flat type representation per canonical ABI ---
 
-function primitiveFlatType(prim: PrimitiveValType): FlatType[] {
-    switch (prim) {
-        case PrimitiveValType.Bool:
-        case PrimitiveValType.S8:
-        case PrimitiveValType.U8:
-        case PrimitiveValType.S16:
-        case PrimitiveValType.U16:
-        case PrimitiveValType.S32:
-        case PrimitiveValType.U32:
-        case PrimitiveValType.Char:
-            return [FlatType.I32];
-        case PrimitiveValType.S64:
-        case PrimitiveValType.U64:
-            return [FlatType.I64];
-        case PrimitiveValType.Float32:
-            return [FlatType.F32];
-        case PrimitiveValType.Float64:
-            return [FlatType.F64];
-        case PrimitiveValType.String:
-            return [FlatType.I32, FlatType.I32]; // pointer + length
-    }
-}
-
 /** Spec: join(a, b) — find the common flat type for two slots */
 export function joinFlatType(a: FlatType, b: FlatType): FlatType {
     if (a === b) return a;
@@ -528,7 +467,7 @@ export function flattenType(type: ResolvedType): FlatType[] {
     switch (type.tag) {
         case ModelTag.ComponentValTypePrimitive:
         case ModelTag.ComponentTypeDefinedPrimitive:
-            return primitiveFlatType(type.value);
+            return _primFT[primIdx(type.value)];
 
         case ModelTag.ComponentTypeDefinedRecord: {
             const flat: FlatType[] = [];

--- a/src/resolver/component-exports.ts
+++ b/src/resolver/component-exports.ts
@@ -51,7 +51,7 @@ export const resolveComponentExport: Resolver<ComponentExport> = (rctx, rargs) =
                 element: componentExport,
                 binder: withDebugTrace(async (bctx, bargs) => {
                     const args = {
-                        arguments: bargs.arguments,
+                        arguments: [componentExport.name.name],
                         imports: bargs.imports,
                         callerArgs: bargs,
                         debugStack: bargs.debugStack,

--- a/src/resolver/component-functions.ts
+++ b/src/resolver/component-functions.ts
@@ -66,7 +66,7 @@ export const resolveCanonicalFunctionLift: Resolver<CanonicalFunctionLift> = (rc
 
     rctx.resolved.stringEncoding = savedEncoding;
 
-    const useJspi = rctx.resolved.jspi;
+    const noJspi = rctx.resolved.noJspi;
 
     return {
         callerElement: rargs.callerElement,
@@ -93,8 +93,13 @@ export const resolveCanonicalFunctionLift: Resolver<CanonicalFunctionLift> = (rc
             // JSPI: wrap the core function with promising() so that the WASM stack
             // can suspend when an async (Suspending-wrapped) import is called.
             // Only the component export entry point needs this — NOT all core exports.
+            // noJspi can be true (disable all), an array of export names to exclude, or false/undefined (enable all).
             let coreFn = functionResult.result as WasmFunction;
-            if (useJspi) {
+            const exportName = bargs.arguments?.[0] as string | undefined;
+            const shouldWrapJspi = noJspi === true ? false
+                : Array.isArray(noJspi) ? (exportName !== undefined && !noJspi.includes(exportName))
+                    : true;
+            if (shouldWrapJspi) {
                 coreFn = (WebAssembly as any)[PROMISING](coreFn);
             }
 

--- a/src/resolver/component-functions.ts
+++ b/src/resolver/component-functions.ts
@@ -1,7 +1,7 @@
 import isDebug from 'env:isDebug';
 import { ComponentAliasInstanceExport, ComponentFunction } from '../model/aliases';
 import { CanonicalFunctionLift } from '../model/canonicals';
-import { ComponentExternalKind } from '../model/exports';
+import { ComponentExport, ComponentExternalKind } from '../model/exports';
 import { CoreFuncIndex } from '../model/indices';
 import { ModelTag } from '../model/tags';
 import { withDebugTrace, jsco_assert, LogLevel } from '../utils/assert';
@@ -62,8 +62,34 @@ export const resolveCanonicalFunctionLift: Resolver<CanonicalFunctionLift> = (rc
         postReturnResolution = resolveCoreFunction(rctx, { element: postReturnFunc, callerElement: canonicalFunctionLift });
     }
 
+    // When useNumberForInt64 is string[], check if this function's export name
+    // matches and temporarily switch to Number-mode with separate caches.
+    const numberForMethods = rctx.resolved.useNumberForInt64Methods;
+    let savedUsesNumber: boolean | undefined;
+    let savedLiftingCache: Map<unknown, unknown> | undefined;
+    let savedLoweringCache: Map<unknown, unknown> | undefined;
+    if (numberForMethods) {
+        const callerExport = rargs.callerElement;
+        const exportName = callerExport && callerExport.tag === ModelTag.ComponentExport
+            ? (callerExport as ComponentExport).name.name : undefined;
+        const useNumber = exportName !== undefined && numberForMethods.includes(exportName);
+        if (useNumber) {
+            savedUsesNumber = rctx.resolved.usesNumberForInt64;
+            savedLiftingCache = rctx.resolved.liftingCache;
+            savedLoweringCache = rctx.resolved.loweringCache;
+            rctx.resolved.usesNumberForInt64 = true;
+            rctx.resolved.liftingCache = rctx.resolved.numberModeLiftingCache!;
+            rctx.resolved.loweringCache = rctx.resolved.numberModeLoweringCache!;
+        }
+    }
+
     const liftingBinder = createFunctionLifting(rctx.resolved, sectionFunType);
 
+    if (savedUsesNumber !== undefined) {
+        rctx.resolved.usesNumberForInt64 = savedUsesNumber;
+        rctx.resolved.liftingCache = savedLiftingCache!;
+        rctx.resolved.loweringCache = savedLoweringCache!;
+    }
     rctx.resolved.stringEncoding = savedEncoding;
 
     const noJspi = rctx.resolved.noJspi;

--- a/src/resolver/component-functions.ts
+++ b/src/resolver/component-functions.ts
@@ -1,9 +1,10 @@
+import isDebug from 'env:isDebug';
 import { ComponentAliasInstanceExport, ComponentFunction } from '../model/aliases';
 import { CanonicalFunctionLift } from '../model/canonicals';
 import { ComponentExternalKind } from '../model/exports';
 import { CoreFuncIndex } from '../model/indices';
 import { ModelTag } from '../model/tags';
-import { withDebugTrace, jsco_assert, isDebug, LogLevel } from '../utils/assert';
+import { withDebugTrace, jsco_assert, LogLevel } from '../utils/assert';
 import { createFunctionLifting } from './binding';
 import { WasmFunction } from './binding/types';
 import { resolveComponentInstance } from './component-instances';

--- a/src/resolver/component-functions.ts
+++ b/src/resolver/component-functions.ts
@@ -13,6 +13,7 @@ import { resolveCoreFunction } from './core-functions';
 import { getCoreFunction, getComponentType, getComponentInstance } from './indices';
 import { Resolver, ResolverRes, resolveCanonicalOptions } from './types';
 import camelCase from 'just-camel-case';
+import { PROMISING } from '../constants';
 
 export const resolveComponentFunction: Resolver<ComponentFunction> = (rctx, rargs) => {
     const cached = rctx.componentFunctionCache.get(rargs.element);
@@ -94,7 +95,7 @@ export const resolveCanonicalFunctionLift: Resolver<CanonicalFunctionLift> = (rc
             // Only the component export entry point needs this — NOT all core exports.
             let coreFn = functionResult.result as WasmFunction;
             if (useJspi) {
-                coreFn = (WebAssembly as any).promising(coreFn);
+                coreFn = (WebAssembly as any)[PROMISING](coreFn);
             }
 
             const jsFunction = liftingBinder(bctx, coreFn);

--- a/src/resolver/component-instances.ts
+++ b/src/resolver/component-instances.ts
@@ -1,3 +1,4 @@
+import isDebug from 'env:isDebug';
 import camelCase from 'just-camel-case';
 import { ComponentExport, ComponentExternalKind } from '../model/exports';
 import { ComponentFuncIndex, ComponentInstanceIndex } from '../model/indices';
@@ -5,7 +6,7 @@ import { ComponentInstance, ComponentInstanceFromExports, ComponentInstanceInsta
 import { ComponentAliasInstanceExport } from '../model/aliases';
 import { ModelTag, TaggedElement } from '../model/tags';
 import { ComponentTypeInstance } from '../model/types';
-import { debugStack, withDebugTrace, jsco_assert, isDebug } from '../utils/assert';
+import { debugStack, withDebugTrace, jsco_assert } from '../utils/assert';
 import { JsImports } from './api-types';
 import { resolveComponentFunction } from './component-functions';
 import { resolveComponentType } from './component-types';

--- a/src/resolver/component-types.ts
+++ b/src/resolver/component-types.ts
@@ -1,8 +1,9 @@
+import isDebug from 'env:isDebug';
 import { ComponentExport, ComponentExternalKind } from '../model/exports';
 import { ModelTag } from '../model/tags';
 import { ComponentType } from '../model/types';
 import { ComponentSection } from '../parser/types';
-import { debugStack, withDebugTrace, jsco_assert, isDebug, LogLevel } from '../utils/assert';
+import { debugStack, withDebugTrace, jsco_assert, LogLevel } from '../utils/assert';
 import { resolveComponentExport } from './component-exports';
 import { resolveComponentAliasInstanceExport } from './component-functions';
 import { resolveComponentImport } from './component-imports';

--- a/src/resolver/context.ts
+++ b/src/resolver/context.ts
@@ -1,9 +1,10 @@
+import isDebug from 'env:isDebug';
 import { WITModel } from '../parser';
 import { IndexedElement, ModelTag, TaggedElement } from '../model/tags';
 import { ComponentAliasInstanceExport, ComponentOuterAliasKind } from '../model/aliases';
 import { ExternalKind } from '../model/core';
 import { ComponentExport, ComponentExternalKind } from '../model/exports';
-import { configuration, defaultVerbosity, isDebug, LogLevel } from '../utils/assert';
+import { defaultVerbosity, LogLevel } from '../utils/assert';
 import type { LogFn, Verbosity } from '../utils/assert';
 import { BindingContext, ComponentFactoryOptions, MemoryView, Allocator, InstanceTable, ResolvedContext, ResolverContext, ResourceTable, StringEncoding } from './types';
 import { TCabiRealloc, WasmPointer, WasmSize } from './binding/types';
@@ -461,7 +462,7 @@ export function createBindingContext(componentImports: JsImports, resolved: Reso
             ctx.poisoned = true;
         },
     };
-    if (configuration === 'Debug') {
+    if (isDebug) {
         ctx.debugStack = [];
     }
     return ctx;

--- a/src/resolver/context.ts
+++ b/src/resolver/context.ts
@@ -17,12 +17,15 @@ import { NO_JSPI, USE_NUMBER_FOR_INT64, VALIDATE_TYPES, WASM_INSTANTIATE, VERBOS
 export function createResolverContext(sections: WITModel, options: ComponentFactoryOptions): ResolverContext {
     // eslint-disable-next-line no-console
     const defaultLogger: LogFn = (phase, _level, ...args) => console.log(`[${phase}]`, ...args);
-    const verbose = { ...defaultVerbosity, ...options[VERBOSE] };
-    const logger = options[LOGGER] ?? defaultLogger;
+    const verbose = { ...defaultVerbosity, ...(options as any)[VERBOSE] };
+    const logger = (options as any)[LOGGER] ?? defaultLogger;
     const rctx: ResolverContext = {
         resolved: {
             noJspi: options[NO_JSPI],
-            usesNumberForInt64: (options[USE_NUMBER_FOR_INT64] === true) ? true : false,
+            usesNumberForInt64: options[USE_NUMBER_FOR_INT64] === true,
+            useNumberForInt64Methods: Array.isArray(options[USE_NUMBER_FOR_INT64]) ? options[USE_NUMBER_FOR_INT64] : undefined,
+            numberModeLiftingCache: Array.isArray(options[USE_NUMBER_FOR_INT64]) ? new Map() : undefined,
+            numberModeLoweringCache: Array.isArray(options[USE_NUMBER_FOR_INT64]) ? new Map() : undefined,
             stringEncoding: StringEncoding.Utf8,
             liftingCache: new Map(),
             loweringCache: new Map(),

--- a/src/resolver/context.ts
+++ b/src/resolver/context.ts
@@ -21,7 +21,7 @@ export function createResolverContext(sections: WITModel, options: ComponentFact
     const logger = options[LOGGER] ?? defaultLogger;
     const rctx: ResolverContext = {
         resolved: {
-            jspi: options[NO_JSPI] !== true,
+            noJspi: options[NO_JSPI],
             usesNumberForInt64: (options[USE_NUMBER_FOR_INT64] === true) ? true : false,
             stringEncoding: StringEncoding.Utf8,
             liftingCache: new Map(),

--- a/src/resolver/context.ts
+++ b/src/resolver/context.ts
@@ -12,16 +12,17 @@ import { JsImports } from './api-types';
 import { buildResolvedTypeMap } from './type-resolution';
 import type { ComponentImport } from '../model/imports';
 import type { ComponentTypeInstance } from '../model/types';
+import { NO_JSPI, USE_NUMBER_FOR_INT64, VALIDATE_TYPES, WASM_INSTANTIATE, VERBOSE, LOGGER } from '../constants';
 
 export function createResolverContext(sections: WITModel, options: ComponentFactoryOptions): ResolverContext {
     // eslint-disable-next-line no-console
     const defaultLogger: LogFn = (phase, _level, ...args) => console.log(`[${phase}]`, ...args);
-    const verbose = { ...defaultVerbosity, ...options.verbose };
-    const logger = options.logger ?? defaultLogger;
+    const verbose = { ...defaultVerbosity, ...options[VERBOSE] };
+    const logger = options[LOGGER] ?? defaultLogger;
     const rctx: ResolverContext = {
         resolved: {
-            jspi: options.jspi === true,
-            usesNumberForInt64: (options.useNumberForInt64 === true) ? true : false,
+            jspi: options[NO_JSPI] !== true,
+            usesNumberForInt64: (options[USE_NUMBER_FOR_INT64] === true) ? true : false,
             stringEncoding: StringEncoding.Utf8,
             liftingCache: new Map(),
             loweringCache: new Map(),
@@ -33,8 +34,8 @@ export function createResolverContext(sections: WITModel, options: ComponentFact
             verbose,
             logger,
         },
-        validateTypes: (options.validateTypes === false) ? false : true,
-        wasmInstantiate: options.wasmInstantiate ?? ((module, importObject) => WebAssembly.instantiate(module, importObject)),
+        validateTypes: (options[VALIDATE_TYPES] === false) ? false : true,
+        wasmInstantiate: options[WASM_INSTANTIATE] ?? ((module, importObject) => WebAssembly.instantiate(module, importObject)),
         importToInstanceIndex: new Map(),
         resourceAliasGroups: new Map(),
         componentInstanceCache: new Map(),

--- a/src/resolver/core-functions.ts
+++ b/src/resolver/core-functions.ts
@@ -1,3 +1,4 @@
+import isDebug from 'env:isDebug';
 import { ComponentFunction, CoreFunction, ComponentAliasInstanceExport as ComponentAliasInstanceExportType } from '../model/aliases';
 import { CanonicalFunctionLower, CanonicalFunctionResourceDrop, CanonicalFunctionResourceNew, CanonicalFunctionResourceRep } from '../model/canonicals';
 import { ComponentExternalKind } from '../model/exports';
@@ -5,7 +6,7 @@ import { ComponentImport } from '../model/imports';
 import { ComponentTypeIndex } from '../model/indices';
 import { ModelTag } from '../model/tags';
 import { ComponentType, ComponentTypeFunc, ComponentTypeInstance, InstanceTypeDeclaration, ComponentTypeDefinedOwn, ComponentTypeDefinedBorrow } from '../model/types';
-import { debugStack, withDebugTrace, jsco_assert, isDebug, LogLevel } from '../utils/assert';
+import { debugStack, withDebugTrace, jsco_assert, LogLevel } from '../utils/assert';
 import { createFunctionLowering } from './binding';
 import { JsFunction } from './binding/types';
 import { resolveComponentFunction } from './component-functions';

--- a/src/resolver/core-instance.ts
+++ b/src/resolver/core-instance.ts
@@ -1,8 +1,9 @@
+import isDebug from 'env:isDebug';
 import { Export, ExternalKind } from '../model/core';
 import { CoreInstanceIndex } from '../model/indices';
 import { CoreInstance, CoreInstanceFromExports, CoreInstanceInstantiate, InstantiationArg, InstantiationArgKind } from '../model/instances';
 import { ModelTag, TaggedElement } from '../model/tags';
-import { debugStack, withDebugTrace, jsco_assert, isDebug } from '../utils/assert';
+import { debugStack, withDebugTrace, jsco_assert } from '../utils/assert';
 import { TCabiRealloc } from './binding/types';
 import { resolveCoreFunction } from './core-functions';
 import { resolveCoreModule } from './core-module';

--- a/src/resolver/import-index.test.ts
+++ b/src/resolver/import-index.test.ts
@@ -211,3 +211,42 @@ describe('import index mapping', () => {
         expect(rctx.indexes.componentSections.length).toBe(1);
     });
 });
+
+describe('useNumberForInt64 option initialization', () => {
+    test('undefined → usesNumberForInt64 = false, no method filter', () => {
+        const rctx = createResolverContext([], {});
+        expect(rctx.resolved.usesNumberForInt64).toBe(false);
+        expect(rctx.resolved.useNumberForInt64Methods).toBeUndefined();
+        expect(rctx.resolved.numberModeLiftingCache).toBeUndefined();
+        expect(rctx.resolved.numberModeLoweringCache).toBeUndefined();
+    });
+
+    test('false → usesNumberForInt64 = false, no method filter', () => {
+        const rctx = createResolverContext([], { useNumberForInt64: false });
+        expect(rctx.resolved.usesNumberForInt64).toBe(false);
+        expect(rctx.resolved.useNumberForInt64Methods).toBeUndefined();
+    });
+
+    test('true → usesNumberForInt64 = true, no method filter', () => {
+        const rctx = createResolverContext([], { useNumberForInt64: true });
+        expect(rctx.resolved.usesNumberForInt64).toBe(true);
+        expect(rctx.resolved.useNumberForInt64Methods).toBeUndefined();
+        expect(rctx.resolved.numberModeLiftingCache).toBeUndefined();
+    });
+
+    test('string[] → usesNumberForInt64 = false, method filter set', () => {
+        const methods = ['my-func', 'other-func'];
+        const rctx = createResolverContext([], { useNumberForInt64: methods });
+        expect(rctx.resolved.usesNumberForInt64).toBe(false);
+        expect(rctx.resolved.useNumberForInt64Methods).toBe(methods);
+        expect(rctx.resolved.numberModeLiftingCache).toBeInstanceOf(Map);
+        expect(rctx.resolved.numberModeLoweringCache).toBeInstanceOf(Map);
+    });
+
+    test('empty string[] → usesNumberForInt64 = false, empty method filter', () => {
+        const rctx = createResolverContext([], { useNumberForInt64: [] });
+        expect(rctx.resolved.usesNumberForInt64).toBe(false);
+        expect(rctx.resolved.useNumberForInt64Methods).toEqual([]);
+        expect(rctx.resolved.numberModeLiftingCache).toBeInstanceOf(Map);
+    });
+});

--- a/src/resolver/import-index.test.ts
+++ b/src/resolver/import-index.test.ts
@@ -1,5 +1,5 @@
-import { setConfiguration } from '../utils/assert';
-setConfiguration('Debug');
+import { initializeAsserts } from '../utils/assert';
+initializeAsserts();
 
 import { ModelTag, WITSection } from '../model/tags';
 import { PrimitiveValType, ComponentTypeInstance, ComponentTypeFunc } from '../model/types';

--- a/src/resolver/index.ts
+++ b/src/resolver/index.ts
@@ -10,6 +10,7 @@ import { resolveComponentImport } from './component-imports';
 import { createResolverContext } from './context';
 import { resolveCoreInstance } from './core-instance';
 import { ComponentFactoryInput, ComponentFactoryOptions, ResolverContext } from './types';
+import { INSTANTIATE } from '../constants';
 
 export async function instantiateComponent<TJSExports>(
     modelOrComponentOrUrl: ComponentFactoryInput,
@@ -21,7 +22,7 @@ export async function instantiateComponent<TJSExports>(
         input = await parse(input, options ?? {});
     }
     const component = await createComponent<TJSExports>(input, options);
-    return component.instantiate(imports);
+    return component[INSTANTIATE](imports);
 }
 
 export async function createComponent<TJSExports>(modelOrComponentOrUrl: ComponentFactoryInput, options?: ComponentFactoryOptions & ParserOptions): Promise<WasmComponent<TJSExports>> {
@@ -116,8 +117,8 @@ export async function createComponent<TJSExports>(modelOrComponentOrUrl: Compone
 
     const resolved = rctx.resolved;
     let firstInstantiation = true;
-    const component: WasmComponent<TJSExports> = {
-        instantiate: async (imports) => {
+    const component = {
+        [INSTANTIATE]: async (imports?: JsImports) => {
             const result = await executePlan<TJSExports>(sortedPlan, resolved, imports);
             if (firstInstantiation) {
                 firstInstantiation = false;
@@ -131,7 +132,7 @@ export async function createComponent<TJSExports>(modelOrComponentOrUrl: Compone
         plan: sortedPlan,
         stats: isDebug ? { ...rctx.resolved.stats! } : undefined,
     };
-    return component;
+    return component as WasmComponent<TJSExports>;
 }
 
 const executionOrder: Record<PlanOpKind, number> = {

--- a/src/resolver/index.ts
+++ b/src/resolver/index.ts
@@ -1,6 +1,7 @@
+import isDebug from 'env:isDebug';
 import { parse } from '../parser';
 import { ParserOptions } from '../parser/types';
-import { isDebug, LogLevel } from '../utils/assert';
+import { LogLevel } from '../utils/assert';
 import { planOpKindName, modelTagName } from '../utils/debug-names';
 import { JsImports, WasmComponentInstance, WasmComponent } from './api-types';
 import { PlanOp, PlanOpKind, executePlan } from './binding-plan';

--- a/src/resolver/index.ts
+++ b/src/resolver/index.ts
@@ -13,11 +13,11 @@ import { ComponentFactoryInput, ComponentFactoryOptions, ResolverContext } from 
 import { INSTANTIATE } from '../constants';
 
 export async function instantiateComponent<TJSExports>(
-    modelOrComponentOrUrl: ComponentFactoryInput,
+    componentBytesOrUrl: ComponentFactoryInput,
     imports?: JsImports,
     options?: ComponentFactoryOptions & ParserOptions,
 ): Promise<WasmComponentInstance<TJSExports>> {
-    let input = modelOrComponentOrUrl as any;
+    let input = componentBytesOrUrl as any;
     if (typeof input !== 'object' || (Array.isArray(input) && input.length != 0 && typeof input[0] !== 'object')) {
         input = await parse(input, options ?? {});
     }
@@ -25,8 +25,8 @@ export async function instantiateComponent<TJSExports>(
     return component[INSTANTIATE](imports);
 }
 
-export async function createComponent<TJSExports>(modelOrComponentOrUrl: ComponentFactoryInput, options?: ComponentFactoryOptions & ParserOptions): Promise<WasmComponent<TJSExports>> {
-    let input = modelOrComponentOrUrl as any;
+export async function createComponent<TJSExports>(componentBytesOrUrl: ComponentFactoryInput, options?: ComponentFactoryOptions & ParserOptions): Promise<WasmComponent<TJSExports>> {
+    let input = componentBytesOrUrl as any;
     if (typeof input !== 'object' || (Array.isArray(input) && input.length != 0 && typeof input[0] !== 'object')) {
         input = await parse(input, options ?? {});
     }

--- a/src/resolver/indices.ts
+++ b/src/resolver/indices.ts
@@ -1,9 +1,10 @@
+import isDebug from 'env:isDebug';
 import { ComponentFunction, CoreFunction } from '../model/aliases';
 import { CoreFuncIndex, CoreInstanceIndex, CoreModuleIndex, ComponentFuncIndex, ComponentInstanceIndex, ComponentTypeIndex } from '../model/indices';
 import { CoreInstance, ComponentInstance } from '../model/instances';
 import { ComponentType } from '../model/types';
 import { CoreModule } from '../parser/types';
-import { isDebug, jsco_assert } from '../utils/assert';
+import { jsco_assert } from '../utils/assert';
 import { modelTagName } from '../utils/debug-names';
 import { ResolverContext } from './types';
 

--- a/src/resolver/type-isolation.test.ts
+++ b/src/resolver/type-isolation.test.ts
@@ -1,5 +1,5 @@
-import { setConfiguration } from '../utils/assert';
-setConfiguration('Debug');
+import { initializeAsserts } from '../utils/assert';
+initializeAsserts();
 
 import { ModelTag } from '../model/tags';
 import { ComponentTypeIndex } from '../model/indices';

--- a/src/resolver/type-isolation.test.ts
+++ b/src/resolver/type-isolation.test.ts
@@ -8,6 +8,7 @@ import { ResolverContext, StringEncoding } from './types';
 import { createLifting } from './binding/to-abi';
 import { deepResolveType, resolveValType } from './calling-convention';
 import type { ResolvedType } from './type-resolution';
+import { describeDebugOnly } from '../test-utils/debug-only';
 
 /**
  * Tests for instance-local type isolation.
@@ -55,7 +56,7 @@ function createRctxWithGlobalTypes(globalTypes: [number, ResolvedType][]): Resol
     } as any as ResolverContext;
 }
 
-describe('instance-local type isolation', () => {
+describeDebugOnly('instance-local type isolation', () => {
     test('outer alias lookup uses snapshot, not live map', () => {
         // Scenario: instance has local type 0 = new Enum, local type 1 = outer alias to global 0
         // Without fix: local type 1 would get the Enum (from local 0) instead of the global Record

--- a/src/resolver/types.ts
+++ b/src/resolver/types.ts
@@ -63,7 +63,7 @@ export function resolveCanonicalOptions(options: CanonicalOption[]): ResolvedCan
 export type ComponentFactoryOptions = {
     useNumberForInt64?: boolean
     validateTypes?: boolean
-    noJspi?: boolean
+    noJspi?: boolean | string[]
     wasmInstantiate?: (moduleObject: WebAssembly.Module, importObject?: WebAssembly.Imports) => Promise<WebAssembly.Instance>
     verbose?: Partial<Verbosity>
     logger?: LogFn
@@ -97,7 +97,7 @@ export type IndexedModel = {
 /** Subset of ResolverContext retained for binding/call time. Separate object so
  *  binder closures don't keep the heavy IndexedModel alive. */
 export type ResolvedContext = {
-    jspi?: boolean
+    noJspi?: boolean | string[]
     liftingCache: Map<unknown, unknown>
     loweringCache: Map<unknown, unknown>
     resolvedTypes: Map<ComponentTypeIndex, ResolvedType>

--- a/src/resolver/types.ts
+++ b/src/resolver/types.ts
@@ -63,7 +63,7 @@ export function resolveCanonicalOptions(options: CanonicalOption[]): ResolvedCan
 export type ComponentFactoryOptions = {
     useNumberForInt64?: boolean
     validateTypes?: boolean
-    jspi?: boolean
+    noJspi?: boolean
     wasmInstantiate?: (moduleObject: WebAssembly.Module, importObject?: WebAssembly.Imports) => Promise<WebAssembly.Instance>
     verbose?: Partial<Verbosity>
     logger?: LogFn

--- a/src/resolver/types.ts
+++ b/src/resolver/types.ts
@@ -4,7 +4,6 @@ import { ComponentExport } from '../model/exports';
 import { ComponentImport } from '../model/imports';
 import { CoreInstance, ComponentInstance } from '../model/instances';
 import { ComponentTypeResource, ComponentType } from '../model/types';
-import { WITModel } from '../parser';
 import { CoreModule, ComponentSection } from '../parser/types';
 import { TaggedElement } from '../model/tags';
 import { JsImports } from './api-types';
@@ -61,16 +60,13 @@ export function resolveCanonicalOptions(options: CanonicalOption[]): ResolvedCan
 }
 
 export type ComponentFactoryOptions = {
-    useNumberForInt64?: boolean
-    validateTypes?: boolean
+    useNumberForInt64?: boolean | string[]
     noJspi?: boolean | string[]
+    validateTypes?: boolean
     wasmInstantiate?: (moduleObject: WebAssembly.Module, importObject?: WebAssembly.Imports) => Promise<WebAssembly.Instance>
-    verbose?: Partial<Verbosity>
-    logger?: LogFn
 }
 
-export type ComponentFactoryInput = WITModel
-    | string
+export type ComponentFactoryInput = string
     | ArrayLike<number>
     | ReadableStream<Uint8Array>
     | Response
@@ -115,6 +111,12 @@ export type ResolvedContext = {
     /** Current string encoding for the canonical function being resolved. Set per lift/lower. */
     stringEncoding: StringEncoding
     usesNumberForInt64: boolean
+    /** When useNumberForInt64 is string[], stores the method name filter. */
+    useNumberForInt64Methods?: string[]
+    /** Separate cache for Number-mode lifters when per-method filtering is active. */
+    numberModeLiftingCache?: Map<unknown, unknown>
+    /** Separate cache for Number-mode lowerers when per-method filtering is active. */
+    numberModeLoweringCache?: Map<unknown, unknown>
     verbose?: Verbosity
     logger?: LogFn
 }

--- a/src/test-utils/debug-only.ts
+++ b/src/test-utils/debug-only.ts
@@ -1,0 +1,8 @@
+import isDebug from 'env:isDebug';
+
+/**
+ * Use in place of `describe()` for test suites that exercise debug-only
+ * internal APIs (e.g. createLifting, createLowering, printWAT).
+ * Skips the entire suite when Configuration=Release.
+ */
+export const describeDebugOnly: typeof describe = isDebug ? describe : describe.skip;

--- a/src/test-utils/verbose-logger.ts
+++ b/src/test-utils/verbose-logger.ts
@@ -53,7 +53,7 @@ export function verboseOptions(capture: VerboseCapture, levels?: Partial<Verbosi
             executor: levels?.executor ?? LogLevel.Off,
         } as Verbosity,
         logger: capture.logger,
-    };
+    } as any;
 }
 
 /**

--- a/src/utils/assert.ts
+++ b/src/utils/assert.ts
@@ -1,3 +1,5 @@
+import isDebug from 'env:isDebug';
+
 // TODO inline rollup macro
 export function jsco_assert(condition: unknown, messageFactory: string | (() => string)): asserts condition {
     if (condition) return;
@@ -38,12 +40,7 @@ export function jsco_log(phase: string, level: LogLevel, ...args: unknown[]): vo
     _logger(phase, level, ...args);
 }
 
-// TODO figure out how to get jest to use virtual modules
-export let configuration = 'Debug';
-export let isDebug = false;
-export function setConfiguration(value: string) {
-    configuration = value;
-    isDebug = value === 'Debug';
+export function initializeAsserts() {
     if (isDebug) {
         initDebugNames();
     }

--- a/src/utils/fetch-like.ts
+++ b/src/utils/fetch-like.ts
@@ -1,11 +1,11 @@
-const isNode = typeof process == 'object' && typeof process.versions == 'object' && typeof process.versions.node == 'string';
+const isNode = typeof process == 'object' && typeof process['versions'] == 'object' && typeof process['versions']['node'] == 'string';
 
 export function fetchLike(url: string) {
     const isFileUrl = url.startsWith('file://');
     const isHttpUrl = url.startsWith('https://') || url.startsWith('http://');
     if (isNode && (isFileUrl || !isHttpUrl)) {
         return import('fs/promises').then((fs) => {
-            return fs.readFile(url);
+            return fs['readFile'](url);
         });
     }
     if (typeof globalThis.fetch !== 'function') {
@@ -25,7 +25,7 @@ export async function getBodyIfResponse(
         return input;
     }
     if ('body' in input) {
-        return getBodyIfResponse(input.body!);
+        return getBodyIfResponse((input as Response)['body']!);
     }
     if ('then' in input) {
         return getBodyIfResponse(await input);

--- a/src/utils/streaming.ts
+++ b/src/utils/streaming.ts
@@ -326,7 +326,7 @@ class SyncArraySource implements SyncSource {
     read(eof?: true): number | null {
         if (this.items.length - this._pos < 1) {
             if (eof) {
-                null;
+                return null;
             } else {
                 throw new Error('unexpected EOF.');
             }

--- a/tests/browser/index.html
+++ b/tests/browser/index.html
@@ -15,8 +15,8 @@
             const instance = await component.instantiate({});
             const ns = instance.exports['jsco:test/echo-primitives@0.1.0'];
 
-            const boolResult = ns.echoBool(true);
-            const u8Result = ns.echoU8(42);
+            const boolResult = await ns.echoBool(true);
+            const u8Result = await ns.echoU8(42);
 
             window.__testResults = {
                 success: true,


### PR DESCRIPTION
## Summary

Enables production minification with terser, adds parser hardening against malicious inputs, and cleans up the public API surface to survive property mangling.

## Bundle size

Release builds now go through terser with property mangling (`keep_quoted: 'strict'`). CI enforces a **90 KB** ceiling on `dist/index.js`. Debug builds remain unminified and un-tree-shaken for development.

## Build-time constants

`isDebug`, `configuration`, and `gitHash` are injected via rollup `@rollup/plugin-virtual` as `env:isDebug`, `env:configuration`, and `env:gitHash` virtual modules. In Release builds `isDebug === false`, which lets terser tree-shake all debug-only code paths (assertion messages, verbose logging, WAT printer, debug names).

Jest gets equivalent modules through `moduleNameMapper` → `src/__mocks__/env-*.ts`, so tests run in Debug mode by default and can be switched to Release with `Configuration=Release`.

## Property-mangle safety (constants.ts)

All property names that cross the public API boundary (option keys, `tag`/`val`/`ok`/`err` on variants/results, `exports`/`abort`/`instantiate` on component instances, WebAssembly JSPI names) are declared as string constants in `src/constants.ts` and accessed via bracket notation (`obj[EXPORTS]`). Terser cannot resolve computed property accesses, so these survive mangling. Internal-only properties are mangled consistently within the bundle.

## Parser hardening

- **Nesting depth limit** — `MAX_NESTING_DEPTH = 100` for nested component sections, preventing stack overflow from deeply recursive inputs.
- **Bounds checking** in LEB128 readers and section parsers.
- **1,172 lines of new security tests** (`src/parser/security.test.ts`) covering preamble validation, truncated inputs, oversized counts, unknown section IDs, nested component depth bombs, and edge cases.

## Public API changes

### `useNumberForInt64` now accepts `string[]`
- `false` (default) — all exports use `bigint`
- `true` — all exports use `number`
- `string[]` — only the listed export interface names use `number`; others stay `bigint`

Per-method mode uses separate lifting/lowering caches so that `bigint` and `number` codepaths don't interfere.

### `noJspi` now accepts `string[]`
- `false`/`undefined` (default) — all exports are wrapped with `WebAssembly.promising()`
- `true` — no exports are wrapped
- `string[]` — only the listed export names are synchronous; all others remain async

### Renamed parameter
`modelOrComponentOrUrl` → `componentBytesOrUrl` in `instantiateComponent` / `createComponent` for clarity.

### Removed re-export
`api-types.ts` types that were previously re-exported from `index.ts` as a value export are now `export type` only. `ResolutionStats` is internal.

## Internal refactoring

- **Numeric `ModelTag` enum** replaces string-based tag comparisons throughout the resolver and host, saving minified size and enabling integer-comparison fast paths.
- **`CallingConvention` / `FlatType` / `StringEncoding`** converted to numeric `const enum` with lookup tables (`_primSize`, `_primAlign`, `_primFC`, flat-type arrays) replacing switch statements.
- **Shared float↔int reinterpretation buffers** extracted to `src/resolver/binding/shared.ts` (canonical NaN constants, `bigIntReplacer`).
- **`describeDebugOnly`** helper (`src/test-utils/debug-only.ts`) for test suites that exercise debug-only internal APIs — auto-skips under `Configuration=Release`.
- `jspi: true` option replaced by `noJspi` (inverted, supports `string[]`).

## CI changes

- **Jest matrix** now runs both `Debug` and `Release` configurations.
- **New `release-bundle-size` job** — builds with `Configuration=Release`, asserts `dist/index.js` ≤ 90 KB.
- Integration tests workflow updated with `--experimental-wasm-jspi` flag.
