### PR TITLE
Reactor start-shim JSPI wrapping, VFS size limits & quota, and host hardening

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -35,6 +35,7 @@
 - update `Demo scope` in readme
 
 # Other
+- "use components"
 - pass CLI args to wasi:cli
 - OCI download
 - explore webidl2wit

--- a/src/host/_shared/enabled-interfaces.ts
+++ b/src/host/_shared/enabled-interfaces.ts
@@ -1,0 +1,50 @@
+// Copyright (c) 2023 Pavel Savara. Licensed under the Apache-2.0 license with LLVM exception. See LICENSE for details.
+
+/**
+ * `enabledInterfaces` whitelist enforcement for assembled WASI import tables.
+ *
+ * Kept dependency-free so it can be imported into the lightweight auto-detect
+ * entry (`wasi-auto.ts`) without pulling the heavier host modules.
+ */
+
+/**
+ * Build a trapping replacement for a disabled WASI interface.
+ *
+ * Preserves the interface's member keys so the resolver can still bind the
+ * import (the component instantiates), but every member is a function that
+ * throws when the guest actually invokes it.
+ */
+function makeTrappingInterface(key: string, original: unknown): unknown {
+    const trap = (): never => {
+        throw new Error(`WASI interface "${key}" is disabled (not listed in enabledInterfaces)`);
+    };
+    if (original && typeof original === 'object') {
+        const stub: Record<string, unknown> = {};
+        for (const member of Object.keys(original as Record<string, unknown>)) {
+            stub[member] = trap;
+        }
+        return stub;
+    }
+    return trap;
+}
+
+/**
+ * Enforce the `enabledInterfaces` whitelist on an assembled imports map.
+ *
+ * When `enabledInterfaces` is set, any key that does not start with one of the
+ * listed prefixes (e.g. `'wasi:cli'` matches `'wasi:cli/environment'` and the
+ * versioned `'wasi:cli/environment@0.3.0-...'`) is replaced in place by a
+ * trapping stub. Idempotent — re-running on an already-filtered map is safe.
+ */
+export function applyEnabledInterfaces(
+    map: Record<string, unknown>,
+    enabledInterfaces: string[] | undefined,
+): void {
+    if (!enabledInterfaces) return;
+    for (const key of Object.keys(map)) {
+        const enabled = enabledInterfaces.some(prefix => key.startsWith(prefix));
+        if (!enabled) {
+            map[key] = makeTrappingInterface(key, map[key]);
+        }
+    }
+}

--- a/src/host/wasip2-via-wasip3/node/index.ts
+++ b/src/host/wasip2-via-wasip3/node/index.ts
@@ -20,6 +20,7 @@ import type { IncomingHandlerFn, NetworkConfig, WasiHttpServer, HttpServerConfig
 import { createWasiP3Host } from '../../wasip3/node/wasip3';
 import { createWasiP2ViaP3Adapter } from '../index';
 import { createHttpServer as createLocalHttpServer } from './http-server';
+import { applyEnabledInterfaces } from '../../_shared/enabled-interfaces';
 
 // Re-export the browser adapter
 export { createWasiP2ViaP3Adapter } from '../index';
@@ -49,7 +50,9 @@ export function createWasiP2ViaP3NodeHost(
     },
 ): WasiP2Imports & JsImports {
     const p3 = createWasiP3Host(config);
-    return createWasiP2ViaP3Adapter(p3, { limits: config?.limits });
+    const p2 = createWasiP2ViaP3Adapter(p3, { limits: config?.limits });
+    applyEnabledInterfaces(p2 as Record<string, unknown>, config?.enabledInterfaces);
+    return p2;
 }
 
 /**

--- a/src/host/wasip3/filesystem.ts
+++ b/src/host/wasip3/filesystem.ts
@@ -584,7 +584,11 @@ export interface FilesystemState {
  * Initialize the filesystem from config, returning shared state.
  */
 export function initFilesystem(config?: HostConfig): FilesystemState {
-    const backend = new MemoryVfsBackend({ limits: config?.limits });
+    const backend = new MemoryVfsBackend({
+        limits: config?.limits,
+        maxTotalSize: config?.vfsLimits?.maxTotalSize,
+        maxFileSize: config?.vfsLimits?.maxFileSize,
+    });
     const maxPathLength = config?.limits?.maxPathLength ?? LIMIT_DEFAULTS.maxPathLength;
 
     // Populate from config.fs

--- a/src/host/wasip3/index.ts
+++ b/src/host/wasip3/index.ts
@@ -59,6 +59,7 @@ import { createHttpTypes, createHttpClient, createHttpHandler } from './http';
 import { createSocketsTypes, createIpNameLookup } from './sockets';
 import { JsImports } from '../../resolver/api-types';
 import { makeRegister } from '../_shared/resource-table';
+import { applyEnabledInterfaces } from '../_shared/enabled-interfaces';
 
 const P3_VERSIONS = ['0.3.0-rc-2026-03-15'] as const;
 export { WasiExit } from './cli';
@@ -140,6 +141,8 @@ export function createWasiP3Host(config?: HostConfig): WasiP3Imports & JsImports
     register('random/random', createRandom(config?.limits));
     register('sockets/ip-name-lookup', createIpNameLookup());
     register('sockets/types', createSocketsTypes());
+
+    applyEnabledInterfaces(result, config?.enabledInterfaces);
 
     return result as unknown as WasiP3Imports & JsImports;
 }

--- a/src/host/wasip3/node/filesystem-node.ts
+++ b/src/host/wasip3/node/filesystem-node.ts
@@ -30,10 +30,18 @@ import type {
     VfsDescriptorFlags,
 } from '../vfs';
 import { VfsNodeType, VfsError, resolvePathComponents, createFileNode, createDirectoryNode } from '../vfs';
-import type { AllocationLimits, MountConfig } from '../types';
+import type { AllocationLimits, MountConfig, VfsLimits } from '../types';
 import { LIMIT_DEFAULTS } from '../types';
 import { _FsDescriptor as FsDescriptor } from '../filesystem';
 import type { FilesystemState } from '../filesystem';
+
+/**
+ * Reserved file name placed at the root of a Node.js mount to persist the
+ * tracked aggregate size when `vfsLimits.maxTotalSize` is enforced. It is
+ * excluded from quota accounting, hidden from `readDirectory` at the mount
+ * root, and rejected for any guest access so the guest cannot tamper with it.
+ */
+const QUOTA_FILENAME = '.jsco-quota.json';
 
 // ──────────────────── Error mapping ────────────────────
 
@@ -155,20 +163,134 @@ export class NodeFsBackend implements IVfsBackend {
     readonly readOnly: boolean;
     private readonly maxPathLength: number;
     private readonly maxAllocationSize: number;
+    private readonly maxFileSize: number | undefined;
+    private readonly maxTotalSize: number | undefined;
+    /** Real (symlink-resolved) mount root, set only when maxTotalSize is enforced. */
+    private readonly realRoot: string | undefined;
+    /** Absolute host path of the quota file, set only when maxTotalSize is enforced. */
+    private readonly quotaFilePath: string | undefined;
+    /** Running aggregate of all file bytes under the mount (quota file excluded). */
+    private totalSize = 0;
 
-    constructor(hostRoot: string, readOnly: boolean, limits?: AllocationLimits) {
+    constructor(hostRoot: string, readOnly: boolean, limits?: AllocationLimits, vfsLimits?: VfsLimits) {
         this.hostRoot = nodePath.resolve(hostRoot);
         this.readOnly = readOnly;
         this.maxPathLength = limits?.maxPathLength ?? LIMIT_DEFAULTS.maxPathLength;
         this.maxAllocationSize = limits?.maxAllocationSize ?? LIMIT_DEFAULTS.maxAllocationSize;
+        this.maxFileSize = vfsLimits?.maxFileSize;
+        this.maxTotalSize = vfsLimits?.maxTotalSize;
+        if (this.maxTotalSize !== undefined) {
+            this.realRoot = fs.realpathSync(this.hostRoot);
+            this.quotaFilePath = nodePath.join(this.realRoot, QUOTA_FILENAME);
+            this.totalSize = this.loadQuota();
+        } else {
+            this.realRoot = undefined;
+            this.quotaFilePath = undefined;
+        }
     }
 
     private resolve(parts: string[]): string {
-        return safeResolve(this.hostRoot, parts);
+        const hostPath = safeResolve(this.hostRoot, parts);
+        this.guardQuotaFile(hostPath);
+        return hostPath;
     }
 
     private ensureWrite(): void {
         if (this.readOnly) throw new VfsError('read-only');
+    }
+
+    // ──── Quota tracking (only active when maxTotalSize is set) ────
+
+    /** Load the persisted total from the quota file, or compute it by walking the mount. */
+    private loadQuota(): number {
+        if (this.quotaFilePath === undefined) return 0;
+        try {
+            const raw = fs.readFileSync(this.quotaFilePath, 'utf8');
+            const parsed = JSON.parse(raw) as { totalSize?: unknown };
+            if (typeof parsed.totalSize === 'number' && Number.isFinite(parsed.totalSize) && parsed.totalSize >= 0) {
+                return parsed.totalSize;
+            }
+        } catch {
+            // Missing or corrupt quota file — recompute below.
+        }
+        const total = this.computeTotalSize(this.realRoot ?? this.hostRoot);
+        this.persistQuota(total);
+        return total;
+    }
+
+    /** Recursively sum regular-file sizes under `dir`, excluding the quota file. */
+    private computeTotalSize(dir: string): number {
+        let sum = 0;
+        let entries: fs.Dirent[];
+        try {
+            entries = fs.readdirSync(dir, { withFileTypes: true });
+        } catch {
+            return 0;
+        }
+        for (const entry of entries) {
+            const full = nodePath.join(dir, entry.name);
+            if (entry.isDirectory()) {
+                sum += this.computeTotalSize(full);
+            } else if (entry.isFile()) {
+                if (full === this.quotaFilePath) continue;
+                try { sum += fs.statSync(full).size; } catch { /* race: ignore */ }
+            }
+            // Symlinks and special files are not counted.
+        }
+        return sum;
+    }
+
+    /** Best-effort write of the current total to the quota file. */
+    private persistQuota(total: number): void {
+        if (this.quotaFilePath === undefined) return;
+        try {
+            fs.writeFileSync(this.quotaFilePath, JSON.stringify({ totalSize: total }));
+        } catch { /* best-effort persistence */ }
+    }
+
+    /** Size of `hostPath` if it is a regular file, else 0. */
+    private fileSizeOrZero(hostPath: string): number {
+        try {
+            const st = fs.statSync(hostPath);
+            return st.isFile() ? st.size : 0;
+        } catch {
+            return 0;
+        }
+    }
+
+    /**
+     * Reject any guest operation that targets the reserved quota file.
+     * Throws `VfsError('access')`, which the descriptor layer surfaces to the
+     * guest as a graceful `access` error code (not a trap). Combined with the
+     * `readDirectory` filter, this keeps the quota file invisible and immutable.
+     */
+    private guardQuotaFile(hostPath: string): void {
+        if (this.quotaFilePath !== undefined && hostPath === this.quotaFilePath) {
+            throw new VfsError('access', 'reserved quota file');
+        }
+    }
+
+    /** Enforce the per-file size cap. */
+    private checkFileSize(newSize: number): void {
+        if (this.maxFileSize !== undefined && newSize > this.maxFileSize) {
+            throw new VfsError('insufficient-space', 'file size exceeds max file size');
+        }
+    }
+
+    /** Enforce the aggregate size cap for a positive growth `delta` (before the write). */
+    private reserveTotal(delta: number): void {
+        if (this.maxTotalSize === undefined) return;
+        if (delta > 0 && this.totalSize + delta > this.maxTotalSize) {
+            throw new VfsError('insufficient-space', 'VFS total size exceeded');
+        }
+    }
+
+    /** Apply a committed size `delta` and persist the new total. */
+    private commitTotal(delta: number): void {
+        if (this.maxTotalSize === undefined || delta === 0) return;
+        this.totalSize += delta;
+        if (this.totalSize < 0) this.totalSize = 0;
+        this.persistQuota(this.totalSize);
     }
 
     // ──── IVfsBackend ────
@@ -198,12 +320,17 @@ export class NodeFsBackend implements IVfsBackend {
         this.ensureWrite();
         try {
             const hostPath = this.resolve(path);
+            const oldSize = this.fileSizeOrZero(hostPath);
+            const newSize = Math.max(oldSize, Number(offset) + data.length);
+            this.checkFileSize(newSize);
+            this.reserveTotal(newSize - oldSize);
             const fd = fs.openSync(hostPath, 'r+');
             try {
                 fs.writeSync(fd, data, 0, data.length, Number(offset));
             } finally {
                 fs.closeSync(fd);
             }
+            this.commitTotal(newSize - oldSize);
         } catch (e) { mapNodeError(e); }
     }
 
@@ -211,7 +338,12 @@ export class NodeFsBackend implements IVfsBackend {
         this.ensureWrite();
         try {
             const hostPath = this.resolve(path);
+            const oldSize = this.fileSizeOrZero(hostPath);
+            const newSize = oldSize + data.length;
+            this.checkFileSize(newSize);
+            this.reserveTotal(data.length);
             fs.appendFileSync(hostPath, data);
+            this.commitTotal(data.length);
         } catch (e) { mapNodeError(e); }
     }
 
@@ -219,7 +351,12 @@ export class NodeFsBackend implements IVfsBackend {
         this.ensureWrite();
         try {
             const hostPath = this.resolve(path);
-            fs.truncateSync(hostPath, Number(size));
+            const oldSize = this.fileSizeOrZero(hostPath);
+            const newSize = Number(size);
+            this.checkFileSize(newSize);
+            this.reserveTotal(newSize - oldSize);
+            fs.truncateSync(hostPath, newSize);
+            this.commitTotal(newSize - oldSize);
         } catch (e) { mapNodeError(e); }
     }
 
@@ -251,6 +388,7 @@ export class NodeFsBackend implements IVfsBackend {
         const fullParts = resolvePathComponents(dirPath, relativePath);
         try {
             const hostPath = safeResolve(this.hostRoot, fullParts);
+            this.guardQuotaFile(hostPath);
 
             let stats: fs.Stats | null = null;
             try {
@@ -264,7 +402,9 @@ export class NodeFsBackend implements IVfsBackend {
                 if (openFlags.directory && !stats.isDirectory()) throw new VfsError('not-directory');
                 if (openFlags.truncate && stats.isFile()) {
                     this.ensureWrite();
+                    const oldSize = stats.size;
                     fs.truncateSync(hostPath, 0);
+                    this.commitTotal(-oldSize);
                 }
             } else {
                 if (!openFlags.create) throw new VfsError('no-entry');
@@ -288,10 +428,13 @@ export class NodeFsBackend implements IVfsBackend {
         try {
             const hostPath = this.resolve(path);
             const entries = fs.readdirSync(hostPath, { withFileTypes: true });
-            return entries.map(e => ({
-                type: direntType(e),
-                name: e.name,
-            }));
+            const atRoot = this.realRoot !== undefined && hostPath === this.realRoot;
+            return entries
+                .filter(e => !(atRoot && e.name === QUOTA_FILENAME))
+                .map(e => ({
+                    type: direntType(e),
+                    name: e.name,
+                }));
         } catch (e) { mapNodeError(e); }
     }
 
@@ -300,6 +443,7 @@ export class NodeFsBackend implements IVfsBackend {
         try {
             const parentHost = this.resolve(dirPath);
             const targetPath = nodePath.join(parentHost, name);
+            this.guardQuotaFile(targetPath);
             // Re-verify containment after join
             safeResolve(this.hostRoot, [...dirPath, name]);
             fs.mkdirSync(targetPath);
@@ -320,7 +464,9 @@ export class NodeFsBackend implements IVfsBackend {
             const hostPath = this.resolve([...dirPath, name]);
             const stats = fs.statSync(hostPath);
             if (stats.isDirectory()) throw new VfsError('is-directory');
+            const size = stats.isFile() ? stats.size : 0;
             fs.unlinkSync(hostPath);
+            this.commitTotal(-size);
         } catch (e) { mapNodeError(e); }
     }
 
@@ -329,7 +475,11 @@ export class NodeFsBackend implements IVfsBackend {
         try {
             const oldPath = this.resolve([...oldDirPath, oldName]);
             const newPath = this.resolve([...newDirPath, newName]);
+            // A rename within the mount preserves the source bytes; only an
+            // overwritten destination file frees its bytes from the total.
+            const destFreed = this.fileSizeOrZero(newPath);
             fs.renameSync(oldPath, newPath);
+            if (destFreed) this.commitTotal(-destFreed);
         } catch (e) { mapNodeError(e); }
     }
 
@@ -349,6 +499,7 @@ export class NodeFsBackend implements IVfsBackend {
         try {
             const hostDir = this.resolve(dirPath);
             const linkPath = nodePath.join(hostDir, linkName);
+            this.guardQuotaFile(linkPath);
             // Verify the link path stays in bounds
             safeResolve(this.hostRoot, [...dirPath, linkName]);
             fs.symlinkSync(target, linkPath);
@@ -362,6 +513,7 @@ export class NodeFsBackend implements IVfsBackend {
             // would resolve to the target and cause EINVAL when readlinkSync is called.
             const hostDir = this.resolve(dirPath);
             const hostPath = nodePath.join(hostDir, name);
+            this.guardQuotaFile(hostPath);
             // Verify containment lexically
             const normalizedRoot = nodePath.resolve(this.hostRoot);
             if (!hostPath.startsWith(normalizedRoot + nodePath.sep) && hostPath !== normalizedRoot) {
@@ -391,7 +543,9 @@ export class NodeFsBackend implements IVfsBackend {
                 lower: BigInt(stats.dev),
                 upper: BigInt(stats.ino),
             };
-        } catch {
+        } catch (e) {
+            // Never mask a guard/containment rejection with the path-hash fallback.
+            if (e instanceof VfsError) throw e;
             // Fallback: hash the path string
             let h = 0n;
             const str = path.join('/');
@@ -414,11 +568,13 @@ export class NodeFsBackend implements IVfsBackend {
  * @param state The filesystem state from `initFilesystem()`.
  * @param mounts Mount configurations.
  * @param limits Allocation limits.
+ * @param vfsLimits Aggregate/per-file size limits (maxTotalSize, maxFileSize).
  */
 export function addNodeMounts(
     state: FilesystemState,
     mounts: MountConfig[],
     limits?: AllocationLimits,
+    vfsLimits?: VfsLimits,
 ): void {
     const maxPathLength = limits?.maxPathLength ?? LIMIT_DEFAULTS.maxPathLength;
 
@@ -433,7 +589,7 @@ export function addNodeMounts(
         }
 
         const readOnly = mount.readOnly ?? false;
-        const backend = new NodeFsBackend(hostAbsolute, readOnly, limits);
+        const backend = new NodeFsBackend(hostAbsolute, readOnly, limits, vfsLimits);
         const guestPath = mount.guestPath.endsWith('/')
             ? mount.guestPath.slice(0, -1) || '/'
             : mount.guestPath;

--- a/src/host/wasip3/node/wasip3.ts
+++ b/src/host/wasip3/node/wasip3.ts
@@ -58,7 +58,7 @@ export function createWasiP3Host(config?: HostConfig): WasiP3Imports & JsImports
     // Wire real filesystem mounts
     if (config?.mounts && config.mounts.length > 0) {
         const fsState = initFilesystem(config);
-        addNodeMounts(fsState, config.mounts, config.limits);
+        addNodeMounts(fsState, config.mounts, config.limits, config.vfsLimits);
         override('filesystem/preopens', createPreopens(fsState));
         override('filesystem/types', createFilesystemTypes(fsState));
     }

--- a/src/host/wasip3/node/wasip3.ts
+++ b/src/host/wasip3/node/wasip3.ts
@@ -16,6 +16,7 @@ import { serve as serveImpl, linkHandler as linkHandlerImpl } from './http-serve
 import type { WasiHttpHandlerExport, ServeConfig, ServeHandle } from './http-server';
 import { JsImports } from '../../../resolver/api-types';
 import { makeRegister } from '../../_shared/resource-table';
+import { applyEnabledInterfaces } from '../../_shared/enabled-interfaces';
 
 const P3_VERSIONS = ['0.3.0-rc-2026-03-15'] as const;
 
@@ -61,6 +62,11 @@ export function createWasiP3Host(config?: HostConfig): WasiP3Imports & JsImports
         override('filesystem/preopens', createPreopens(fsState));
         override('filesystem/types', createFilesystemTypes(fsState));
     }
+
+    // Re-apply the enabledInterfaces whitelist: the browser host already
+    // filtered, but the Node overrides above replace some interfaces with real
+    // implementations, which must be re-trapped if they are disabled.
+    applyEnabledInterfaces(host, config?.enabledInterfaces);
 
     return host as unknown as WasiP3Imports & JsImports;
 }

--- a/src/host/wasip3/types.ts
+++ b/src/host/wasip3/types.ts
@@ -4,5 +4,5 @@
  * WASIp3 Host — Configuration types re-exported from runtime.
  */
 
-export type { MountConfig, NetworkConfig, AllocationLimits, HostConfig } from '../../runtime/model/types';
+export type { MountConfig, NetworkConfig, AllocationLimits, VfsLimits, HostConfig } from '../../runtime/model/types';
 export { NETWORK_DEFAULTS, LIMIT_DEFAULTS } from '../../runtime/model/types';

--- a/src/host/wasip3/vfs.ts
+++ b/src/host/wasip3/vfs.ts
@@ -235,6 +235,8 @@ export interface MemoryVfsConfig {
     limits?: AllocationLimits;
     /** Maximum total VFS size in bytes. Default: 256MB */
     maxTotalSize?: number;
+    /** Maximum single file size in bytes. Default: undefined (no extra cap beyond maxAllocationSize). */
+    maxFileSize?: number;
 }
 
 const DEFAULT_MAX_TOTAL_SIZE = 268_435_456; // 256MB
@@ -247,6 +249,7 @@ export class MemoryVfsBackend implements IVfsBackend {
     private readonly maxPathLength: number;
     private readonly maxAllocationSize: number;
     private readonly maxTotalSize: number;
+    private readonly maxFileSize: number | undefined;
     private totalSize: number;
 
     constructor(config?: MemoryVfsConfig) {
@@ -254,6 +257,7 @@ export class MemoryVfsBackend implements IVfsBackend {
         this.maxPathLength = config?.limits?.maxPathLength ?? LIMIT_DEFAULTS.maxPathLength;
         this.maxAllocationSize = config?.limits?.maxAllocationSize ?? LIMIT_DEFAULTS.maxAllocationSize;
         this.maxTotalSize = config?.maxTotalSize ?? DEFAULT_MAX_TOTAL_SIZE;
+        this.maxFileSize = config?.maxFileSize;
         this.totalSize = 0;
     }
 
@@ -405,6 +409,7 @@ export class MemoryVfsBackend implements IVfsBackend {
         const off = Number(offset);
         const needed = off + data.length;
         if (needed > this.maxAllocationSize) throw new VfsError('insufficient-space', 'file size exceeds allocation limit');
+        if (this.maxFileSize !== undefined && needed > this.maxFileSize) throw new VfsError('insufficient-space', 'file size exceeds max file size');
         const oldLen = node.content?.length ?? 0;
         const newLen = Math.max(oldLen, needed);
         const sizeDelta = newLen - oldLen;
@@ -429,6 +434,7 @@ export class MemoryVfsBackend implements IVfsBackend {
         const oldLen = node.content?.length ?? 0;
         const newLen = oldLen + data.length;
         if (newLen > this.maxAllocationSize) throw new VfsError('insufficient-space', 'file size exceeds allocation limit');
+        if (this.maxFileSize !== undefined && newLen > this.maxFileSize) throw new VfsError('insufficient-space', 'file size exceeds max file size');
         if (this.totalSize + data.length > this.maxTotalSize) throw new VfsError('insufficient-space', 'VFS total size exceeded');
 
         const newContent = new Uint8Array(newLen);
@@ -447,6 +453,7 @@ export class MemoryVfsBackend implements IVfsBackend {
         if (node.type !== VfsNodeType.File) throw new VfsError('invalid');
         const newSize = Number(size);
         if (newSize > this.maxAllocationSize) throw new VfsError('insufficient-space');
+        if (this.maxFileSize !== undefined && newSize > this.maxFileSize) throw new VfsError('insufficient-space', 'file size exceeds max file size');
         const oldLen = node.content?.length ?? 0;
         const sizeDelta = newSize - oldLen;
         if (sizeDelta > 0 && this.totalSize + sizeDelta > this.maxTotalSize) throw new VfsError('insufficient-space');

--- a/src/resolver/core-instance.ts
+++ b/src/resolver/core-instance.ts
@@ -7,10 +7,87 @@ import { CoreInstance, CoreInstanceFromExports, CoreInstanceInstantiate, Instant
 import { ModelTag, TaggedElement } from '../parser/model/tags';
 import { debugStack, withDebugTrace, jsco_assert } from '../utils/assert';
 import { TCabiRealloc } from '../marshal/model/types';
+import { hasJspi } from '../utils/jspi';
 import { resolveCoreFunction } from './core-functions';
 import { resolveCoreModule } from './core-module';
 import { getCoreInstance, getCoreModule } from './indices';
 import { Resolver, ResolverRes, BinderRes, BinderArgs } from './types';
+
+interface StartShimWrap {
+    imports: Record<string, WebAssembly.ModuleImports>;
+    /** Flip out of instantiate mode and await any suspended `_initialize`. */
+    settle(): Promise<void>;
+}
+
+/**
+ * A wit-component reactor "start-shim" is a synthetic module whose `(start)`
+ * calls the main module's exported `_initialize`. The start runs synchronously
+ * inside `WebAssembly.instantiate` (not a JSPI `promising` frame), so touching a
+ * `Suspending`-wrapped host import would throw "trying to suspend without
+ * WebAssembly.promising". We wrap the shim's single function import with
+ * `WebAssembly.promising` for the duration of instantiation, capture the
+ * promise(s) start produces, and await them before any export runs.
+ *
+ * Detection requires ZERO exports AND EXACTLY ONE function import: a zero-export
+ * module can still be invoked at runtime via a shared function table (componentize-js
+ * helpers), and wrapping a runtime-invoked import leaves a JS frame that breaks JSPI
+ * suspension. The shim's lone import is only ever called during its own start.
+ */
+function wrapStartShimImports(module: WebAssembly.Module, wasmImports: Record<string, WebAssembly.ModuleImports>): StartShimWrap {
+    const promising = (WebAssembly as unknown as { promising?: (fn: Function) => (...a: unknown[]) => Promise<unknown> }).promising;
+    const moduleExports = WebAssembly.Module.exports(module);
+    const functionImports = WebAssembly.Module.imports(module).filter((i) => i.kind === 'function');
+    const looksLikeStartShim = moduleExports.length === 0 && functionImports.length === 1;
+    if (!hasJspi() || typeof promising !== 'function' || !looksLikeStartShim) {
+        return { imports: wasmImports, settle: async (): Promise<void> => { } };
+    }
+
+    const initPromises: Promise<unknown>[] = [];
+    let duringInstantiate = true;
+    const wrapped: Record<string, WebAssembly.ModuleImports> = {};
+    for (const [ns, group] of Object.entries(wasmImports)) {
+        if (group && typeof group === 'object') {
+            const wrappedGroup: Record<string, unknown> = {};
+            for (const [name, value] of Object.entries(group)) {
+                if (typeof value === 'function') {
+                    // `promising` only accepts genuine WebAssembly-exported functions; the only
+                    // plain-function import a `(start)` invokes is a reactor `_initialize` (a real
+                    // wasm export). Wrap lazily and fall back to a direct call if `promising` refuses.
+                    let promisingFn: ((...a: unknown[]) => Promise<unknown>) | undefined;
+                    wrappedGroup[name] = (...callArgs: unknown[]): unknown => {
+                        // After settle the start has run; `_initialize` is `[] -> []`, so
+                        // returning undefined from the suspend path is ABI-correct.
+                        if (duringInstantiate) {
+                            if (promisingFn === undefined) {
+                                try {
+                                    promisingFn = promising(value as Function);
+                                } catch {
+                                    return (value as Function)(...callArgs);
+                                }
+                            }
+                            initPromises.push(promisingFn(...callArgs));
+                            return undefined;
+                        }
+                        return (value as Function)(...callArgs);
+                    };
+                } else {
+                    wrappedGroup[name] = value;
+                }
+            }
+            wrapped[ns] = wrappedGroup as WebAssembly.ModuleImports;
+        } else {
+            wrapped[ns] = group;
+        }
+    }
+
+    return {
+        imports: wrapped,
+        settle: async (): Promise<void> => {
+            duringInstantiate = false;
+            if (initPromises.length) await Promise.all(initPromises);
+        },
+    };
+}
 
 export const resolveCoreInstance: Resolver<CoreInstance> = (rctx, rargs) => {
     const cached = rctx.coreInstanceCache.get(rargs.element);
@@ -178,7 +255,10 @@ export const resolveCoreInstanceInstantiate: Resolver<CoreInstanceInstantiate> =
             };
             const moduleResult = await coreModuleResolution.binder(mctx, args);
             const module = moduleResult.result as WebAssembly.Module;
-            const instance = await rctx.wasmInstantiate(module, wasmImports);
+
+            const startShim = wrapStartShimImports(module, wasmImports);
+            const instance = await rctx.wasmInstantiate(module, startShim.imports);
+            await startShim.settle();
             // console.log('rctx.wasmInstantiate ' + coreInstanceIndex, Object.keys(instance.exports));
             const exports = instance.exports;
 

--- a/src/resolver/index.ts
+++ b/src/resolver/index.ts
@@ -14,24 +14,37 @@ import { resolveCoreInstance } from './core-instance';
 import { ComponentFactoryInput, ComponentFactoryOptions, ResolverContext } from './types';
 import type { RuntimeConfig } from '../runtime/model/types';
 
+/**
+ * True only when `input` is ALREADY a parsed WIT model — i.e. an array of
+ * section objects (each carrying a `tag`). Raw component sources (a Uint8Array,
+ * ArrayBuffer, string/URL, Response, or numeric byte array) are NOT parsed
+ * models and must go through `parse`. The previous `typeof input === 'object'`
+ * check wrongly treated a `Uint8Array` (an object, not an array) as parsed and
+ * skipped parsing, so the resolver then iterated the raw bytes as sections.
+ */
+function isParsedModel(input: unknown): boolean {
+    return Array.isArray(input)
+        && (input.length === 0
+            || (typeof input[0] === 'object' && input[0] !== null && 'tag' in input[0]));
+}
+
+/** Return `input` as a parsed WIT model, parsing raw component sources on demand. */
+async function ensureParsed(input: ComponentFactoryInput, options?: ParserOptions): Promise<any> {
+    return isParsedModel(input) ? input : await parse(input as any, options ?? {});
+}
+
 export async function instantiateComponent<TJSExports>(
     componentBytesOrUrl: ComponentFactoryInput,
     imports?: JsImports,
     options?: ComponentFactoryOptions & ParserOptions,
 ): Promise<WasmComponentInstance<TJSExports>> {
-    let input = componentBytesOrUrl as any;
-    if (typeof input !== 'object' || (Array.isArray(input) && input.length != 0 && typeof input[0] !== 'object')) {
-        input = await parse(input, options ?? {});
-    }
+    const input = await ensureParsed(componentBytesOrUrl, options);
     const component = await createComponent<TJSExports>(input, options);
     return component.instantiate(imports);
 }
 
 export async function createComponent<TJSExports>(componentBytesOrUrl: ComponentFactoryInput, options?: ComponentFactoryOptions & ParserOptions): Promise<WasmComponent<TJSExports>> {
-    let input = componentBytesOrUrl as any;
-    if (typeof input !== 'object' || (Array.isArray(input) && input.length != 0 && typeof input[0] !== 'object')) {
-        input = await parse(input, options ?? {});
-    }
+    const input = await ensureParsed(componentBytesOrUrl, options);
 
     const rctx: ResolverContext = createResolverContext(input, options ?? {});
 

--- a/src/runtime/model/types.ts
+++ b/src/runtime/model/types.ts
@@ -317,6 +317,23 @@ export const LIMIT_DEFAULTS = {
     maxConcurrentSubtasks: 100,
 } as const;
 
+/** In-memory virtual filesystem size limits. */
+export interface VfsLimits {
+    /**
+     * Maximum total size in bytes of all files in the in-memory VFS.
+     * Enforced on write/append/truncate and on initial population.
+     * Default: 268_435_456 (256 MB).
+     */
+    maxTotalSize?: number;
+    /**
+     * Maximum size in bytes of any single file in the in-memory VFS.
+     * Enforced on write/append/truncate, in addition to
+     * `limits.maxAllocationSize`. Default: undefined (no extra per-file cap
+     * beyond `maxAllocationSize`).
+     */
+    maxFileSize?: number;
+}
+
 /** WASI-specific host configuration. */
 export interface HostConfig {
     /** Environment variables as [key, value] pairs */
@@ -339,9 +356,14 @@ export interface HostConfig {
     network?: NetworkConfig;
     /** Allocation and size limits */
     limits?: AllocationLimits;
+    /** In-memory VFS size limits (maxTotalSize, maxFileSize). */
+    vfsLimits?: VfsLimits;
     /**
      * WASI interface prefixes to enable (e.g. ['wasi:cli', 'wasi:http']).
-     * Default: all interfaces enabled. When set, only matching prefixes are registered.
+     * Default: all interfaces enabled. When set, any imported interface whose
+     * key does not start with one of these prefixes is replaced by a trapping
+     * stub: the component still instantiates, but calling a disabled interface
+     * throws at runtime.
      */
     enabledInterfaces?: string[];
     /** When true, the VFS root preopen is read-only (writes/creates/renames/removes fail). */

--- a/src/runtime/model/types.ts
+++ b/src/runtime/model/types.ts
@@ -317,19 +317,22 @@ export const LIMIT_DEFAULTS = {
     maxConcurrentSubtasks: 100,
 } as const;
 
-/** In-memory virtual filesystem size limits. */
+/** Virtual filesystem size limits (in-memory VFS and Node.js mounts). */
 export interface VfsLimits {
     /**
-     * Maximum total size in bytes of all files in the in-memory VFS.
-     * Enforced on write/append/truncate and on initial population.
-     * Default: 268_435_456 (256 MB).
+     * Maximum total size in bytes of all files.
+     * Enforced on write/append/truncate and on initial population. For the
+     * in-memory VFS the default is 268_435_456 (256 MB); for Node.js mounts
+     * the aggregate is tracked in a `.jsco-quota.json` file at the mount root
+     * and only enforced when this value is set.
      */
     maxTotalSize?: number;
     /**
-     * Maximum size in bytes of any single file in the in-memory VFS.
+     * Maximum size in bytes of any single file.
      * Enforced on write/append/truncate, in addition to
      * `limits.maxAllocationSize`. Default: undefined (no extra per-file cap
-     * beyond `maxAllocationSize`).
+     * beyond `maxAllocationSize`). Applies to both the in-memory VFS and
+     * Node.js mounts.
      */
     maxFileSize?: number;
 }

--- a/src/wasi-auto.ts
+++ b/src/wasi-auto.ts
@@ -3,6 +3,7 @@
 import type { HostConfig } from './host/wasip3';
 import type { JsImports } from './resolver/api-types';
 import { loadWasiP3Host, loadWasiP2ViaP3Adapter } from './dynamic';
+import { applyEnabledInterfaces } from './host/_shared/enabled-interfaces';
 
 export const enum WasiType {
     None = 0,
@@ -57,9 +58,13 @@ export async function createWasiImports(wasiType: WasiType, config?: HostConfig)
     const { createWasiP3Host } = await loadWasiP3Host();
     const p3 = createWasiP3Host(config);
     if (wasiType === WasiType.P2) {
-        return (await loadWasiP2ViaP3Adapter()).createWasiP2ViaP3Adapter(p3, { limits: config?.limits });
+        const p2 = (await loadWasiP2ViaP3Adapter()).createWasiP2ViaP3Adapter(p3, { limits: config?.limits });
+        applyEnabledInterfaces(p2 as Record<string, unknown>, config?.enabledInterfaces);
+        return p2;
     }
     // P3: merge with P2 adapter so reactor-adapted components still resolve their wasi:cli/etc 0.2 imports.
     const p2 = (await loadWasiP2ViaP3Adapter()).createWasiP2ViaP3Adapter(p3, { limits: config?.limits });
-    return { ...p2, ...p3 } as JsImports;
+    const merged = { ...p2, ...p3 } as Record<string, unknown>;
+    applyEnabledInterfaces(merged, config?.enabledInterfaces);
+    return merged as JsImports;
 }

--- a/tests/host/wasip3/enabled-interfaces.test.ts
+++ b/tests/host/wasip3/enabled-interfaces.test.ts
@@ -1,0 +1,100 @@
+// Copyright (c) 2023 Pavel Savara. Licensed under the Apache-2.0 license with LLVM exception. See LICENSE for details.
+
+import { applyEnabledInterfaces } from '../../../src/host/_shared/enabled-interfaces';
+import { createWasiP3Host as createHost } from '../../../src/host/wasip3/index';
+
+const VERSION = '0.3.0-rc-2026-03-15';
+
+describe('applyEnabledInterfaces', () => {
+    test('undefined whitelist is a no-op (all interfaces kept)', () => {
+        const real = (): string => 'ok';
+        const map: Record<string, unknown> = { 'wasi:cli/environment': { getEnvironment: real } };
+        applyEnabledInterfaces(map, undefined);
+        expect((map['wasi:cli/environment'] as { getEnvironment: () => string }).getEnvironment()).toBe('ok');
+    });
+
+    test('keeps interfaces matching a prefix', () => {
+        const real = (): string => 'ok';
+        const map: Record<string, unknown> = {
+            'wasi:cli/environment': { getEnvironment: real },
+            'wasi:cli/exit': { exit: real },
+        };
+        applyEnabledInterfaces(map, ['wasi:cli']);
+        expect((map['wasi:cli/environment'] as { getEnvironment: () => string }).getEnvironment()).toBe('ok');
+        expect((map['wasi:cli/exit'] as { exit: () => string }).exit()).toBe('ok');
+    });
+
+    test('replaces non-matching interfaces with a trapping stub', () => {
+        const real = (): string => 'ok';
+        const map: Record<string, unknown> = {
+            'wasi:cli/environment': { getEnvironment: real },
+            'wasi:sockets/types': { foo: real, bar: real },
+        };
+        applyEnabledInterfaces(map, ['wasi:cli']);
+        // Enabled interface still works.
+        expect((map['wasi:cli/environment'] as { getEnvironment: () => string }).getEnvironment()).toBe('ok');
+        // Disabled interface keeps its member keys, but they trap on call.
+        const sockets = map['wasi:sockets/types'] as Record<string, () => unknown>;
+        expect(Object.keys(sockets).sort()).toEqual(['bar', 'foo']);
+        expect(() => sockets.foo!()).toThrow(/disabled/);
+        expect(() => sockets.bar!()).toThrow(/wasi:sockets\/types/);
+    });
+
+    test('prefix matches versioned interface keys', () => {
+        const real = (): string => 'ok';
+        const map: Record<string, unknown> = {
+            [`wasi:cli/environment@${VERSION}`]: { getEnvironment: real },
+            [`wasi:sockets/types@${VERSION}`]: { foo: real },
+        };
+        applyEnabledInterfaces(map, ['wasi:cli']);
+        expect((map[`wasi:cli/environment@${VERSION}`] as { getEnvironment: () => string }).getEnvironment()).toBe('ok');
+        expect(() => (map[`wasi:sockets/types@${VERSION}`] as { foo: () => unknown }).foo()).toThrow(/disabled/);
+    });
+
+    test('a non-object interface value becomes a trapping function', () => {
+        const map: Record<string, unknown> = { 'wasi:cli/run': (): string => 'ok' };
+        applyEnabledInterfaces(map, ['wasi:http']);
+        expect(typeof map['wasi:cli/run']).toBe('function');
+        expect(() => (map['wasi:cli/run'] as () => unknown)()).toThrow(/disabled/);
+    });
+
+    test('is idempotent (re-running keeps disabled interfaces trapping)', () => {
+        const real = (): string => 'ok';
+        const map: Record<string, unknown> = { 'wasi:sockets/types': { foo: real } };
+        applyEnabledInterfaces(map, ['wasi:cli']);
+        applyEnabledInterfaces(map, ['wasi:cli']);
+        expect(() => (map['wasi:sockets/types'] as { foo: () => unknown }).foo()).toThrow(/disabled/);
+    });
+});
+
+describe('createWasiP3Host with enabledInterfaces', () => {
+    test('without enabledInterfaces every interface is callable', () => {
+        const host = createHost() as unknown as Record<string, Record<string, unknown>>;
+        expect(typeof (host['wasi:clocks/monotonic-clock']!.now as () => bigint)()).toBe('bigint');
+    });
+
+    test('disabled interface members trap on call, enabled ones work', () => {
+        const host = createHost({ enabledInterfaces: ['wasi:cli'] }) as unknown as Record<string, Record<string, unknown>>;
+
+        // Enabled: wasi:cli/environment.getEnvironment works.
+        const env = host['wasi:cli/environment']!.getEnvironment as () => [string, string][];
+        expect(Array.isArray(env())).toBe(true);
+
+        // Disabled: wasi:clocks/monotonic-clock.now traps.
+        const now = host['wasi:clocks/monotonic-clock']!.now as () => bigint;
+        expect(() => now()).toThrow(/disabled/);
+    });
+
+    test('disabled versioned aliases also trap', () => {
+        const host = createHost({ enabledInterfaces: ['wasi:cli'] }) as unknown as Record<string, Record<string, unknown>>;
+        const now = host[`wasi:clocks/monotonic-clock@${VERSION}`]!.now as () => bigint;
+        expect(() => now()).toThrow(/disabled/);
+    });
+
+    test('the disabled interface still exists with its member keys (so the resolver can bind it)', () => {
+        const host = createHost({ enabledInterfaces: ['wasi:cli'] }) as unknown as Record<string, Record<string, unknown>>;
+        const clock = host['wasi:clocks/monotonic-clock']!;
+        expect(clock).toBeDefined();
+        expect(Object.keys(clock)).toContain('now');
+    });
+});

--- a/tests/host/wasip3/filesystem.test.ts
+++ b/tests/host/wasip3/filesystem.test.ts
@@ -46,6 +46,21 @@ describe('filesystem — preopens', () => {
     });
 });
 
+describe('filesystem — vfsLimits wiring', () => {
+    test('config.vfsLimits.maxFileSize is enforced by the backend', () => {
+        const state = initFilesystem({ vfsLimits: { maxFileSize: 100 }, fs: new Map([['f.txt', '']]) });
+        expect(() => state.backend.write(['f.txt'], new Uint8Array(200), 0n)).toThrow();
+        // Under the limit succeeds.
+        state.backend.write(['f.txt'], new Uint8Array(100), 0n);
+        expect(state.backend.stat(['f.txt']).size).toBe(100n);
+    });
+
+    test('config.vfsLimits.maxTotalSize is enforced by the backend', () => {
+        const state = initFilesystem({ vfsLimits: { maxTotalSize: 50 }, fs: new Map([['f.txt', '']]) });
+        expect(() => state.backend.write(['f.txt'], new Uint8Array(100), 0n)).toThrow();
+    });
+});
+
 describe('filesystem — Descriptor', () => {
     function getRoot(config?: Parameters<typeof initFilesystem>[0]) {
         const state = initFilesystem(config);

--- a/tests/host/wasip3/node/filesystem-node.test.ts
+++ b/tests/host/wasip3/node/filesystem-node.test.ts
@@ -756,3 +756,319 @@ describe('FsDescriptor with NodeFsBackend', () => {
             .toBe('deep content');
     });
 });
+
+// ──────────────────── vfsLimits quota enforcement ────────────────────
+
+const QUOTA_FILE = '.jsco-quota.json';
+
+function readQuota(dir: string): number {
+    const raw = fs.readFileSync(path.join(dir, QUOTA_FILE), 'utf-8');
+    return (JSON.parse(raw) as { totalSize: number }).totalSize;
+}
+
+describe('NodeFsBackend — maxFileSize enforcement', () => {
+    let tempDir: string;
+    let backend: NodeFsBackend;
+
+    beforeEach(() => {
+        tempDir = createTempDir();
+        backend = new NodeFsBackend(tempDir, false, undefined, { maxFileSize: 10 });
+        fs.writeFileSync(path.join(tempDir, 'f.txt'), '');
+    });
+
+    afterEach(() => cleanupTempDir(tempDir));
+
+    test('write within the cap succeeds', () => {
+        backend.write(['f.txt'], enc.encode('0123456789'), 0n);
+        expect(fs.statSync(path.join(tempDir, 'f.txt')).size).toBe(10);
+    });
+
+    test('write exceeding the cap throws insufficient-space and does not write', () => {
+        try {
+            backend.write(['f.txt'], enc.encode('01234567890'), 0n);
+            throw new Error('expected throw');
+        } catch (e) {
+            expect((e as VfsError).code).toBe('insufficient-space');
+        }
+        expect(fs.statSync(path.join(tempDir, 'f.txt')).size).toBe(0);
+    });
+
+    test('write at an offset beyond the cap throws', () => {
+        expect(() => backend.write(['f.txt'], enc.encode('ab'), 9n))
+            .toThrow(VfsError);
+    });
+
+    test('append exceeding the cap throws', () => {
+        backend.append(['f.txt'], enc.encode('12345'));
+        expect(() => backend.append(['f.txt'], enc.encode('678901')))
+            .toThrow(VfsError);
+        expect(fs.statSync(path.join(tempDir, 'f.txt')).size).toBe(5);
+    });
+
+    test('setSize exceeding the cap throws', () => {
+        expect(() => backend.setSize(['f.txt'], 11n)).toThrow(VfsError);
+        backend.setSize(['f.txt'], 10n);
+        expect(fs.statSync(path.join(tempDir, 'f.txt')).size).toBe(10);
+    });
+});
+
+describe('NodeFsBackend — maxTotalSize quota', () => {
+    let tempDir: string;
+
+    beforeEach(() => { tempDir = createTempDir(); });
+    afterEach(() => cleanupTempDir(tempDir));
+
+    test('a quota file is created at the mount root on construction', () => {
+        new NodeFsBackend(tempDir, false, undefined, { maxTotalSize: 100 });
+        expect(fs.existsSync(path.join(tempDir, QUOTA_FILE))).toBe(true);
+        expect(readQuota(tempDir)).toBe(0);
+    });
+
+    test('the aggregate total is enforced across multiple files', () => {
+        const backend = new NodeFsBackend(tempDir, false, undefined, { maxTotalSize: 20 });
+        fs.writeFileSync(path.join(tempDir, 'a.txt'), '');
+        fs.writeFileSync(path.join(tempDir, 'b.txt'), '');
+        backend.write(['a.txt'], enc.encode('0123456789'), 0n); // 10
+        backend.write(['b.txt'], enc.encode('0123456789'), 0n); // 20 total
+        expect(readQuota(tempDir)).toBe(20);
+        expect(() => backend.append(['b.txt'], enc.encode('x'))).toThrow(VfsError);
+    });
+
+    test('the total decreases when a file is truncated', () => {
+        const backend = new NodeFsBackend(tempDir, false, undefined, { maxTotalSize: 100 });
+        fs.writeFileSync(path.join(tempDir, 'a.txt'), '');
+        backend.write(['a.txt'], enc.encode('0123456789'), 0n);
+        expect(readQuota(tempDir)).toBe(10);
+        backend.setSize(['a.txt'], 4n);
+        expect(readQuota(tempDir)).toBe(4);
+    });
+
+    test('the total decreases when a file is deleted', () => {
+        const backend = new NodeFsBackend(tempDir, false, undefined, { maxTotalSize: 100 });
+        fs.writeFileSync(path.join(tempDir, 'a.txt'), '');
+        backend.write(['a.txt'], enc.encode('0123456789'), 0n);
+        expect(readQuota(tempDir)).toBe(10);
+        backend.unlinkFile([], 'a.txt');
+        expect(readQuota(tempDir)).toBe(0);
+    });
+
+    test('a truncate-on-open frees the previous file bytes', () => {
+        const backend = new NodeFsBackend(tempDir, false, undefined, { maxTotalSize: 100 });
+        fs.writeFileSync(path.join(tempDir, 'a.txt'), '');
+        backend.write(['a.txt'], enc.encode('0123456789'), 0n);
+        backend.openAt([], 'a.txt', { truncate: true }, { read: true, write: true }, false);
+        expect(readQuota(tempDir)).toBe(0);
+    });
+
+    test('the persisted total is reloaded without rescanning', () => {
+        const first = new NodeFsBackend(tempDir, false, undefined, { maxTotalSize: 100 });
+        fs.writeFileSync(path.join(tempDir, 'a.txt'), '');
+        first.write(['a.txt'], enc.encode('01234'), 0n); // 5
+        // Add a file on the host AFTER the quota was persisted; a reload that
+        // trusts the quota file must NOT re-count it.
+        fs.writeFileSync(path.join(tempDir, 'sneaky.txt'), 'this is 17 bytes!');
+        const second = new NodeFsBackend(tempDir, false, undefined, { maxTotalSize: 100 });
+        // Reserve enough headroom so only the trusted (5-byte) total fits.
+        second.write(['a.txt'], enc.encode('x'.repeat(95)), 0n);
+        expect(fs.statSync(path.join(tempDir, 'a.txt')).size).toBe(95);
+    });
+
+    test('an existing tree is counted when no quota file is present', () => {
+        fs.writeFileSync(path.join(tempDir, 'a.txt'), '12345'); // 5
+        fs.mkdirSync(path.join(tempDir, 'sub'));
+        fs.writeFileSync(path.join(tempDir, 'sub', 'b.txt'), '123'); // 3
+        new NodeFsBackend(tempDir, false, undefined, { maxTotalSize: 100 });
+        expect(readQuota(tempDir)).toBe(8);
+    });
+
+    test('a corrupt quota file is rebuilt from a directory scan', () => {
+        fs.writeFileSync(path.join(tempDir, 'a.txt'), '12345');
+        fs.writeFileSync(path.join(tempDir, QUOTA_FILE), 'not json {');
+        new NodeFsBackend(tempDir, false, undefined, { maxTotalSize: 100 });
+        expect(readQuota(tempDir)).toBe(5);
+    });
+});
+
+describe('NodeFsBackend — quota file is protected', () => {
+    let tempDir: string;
+    let backend: NodeFsBackend;
+
+    beforeEach(() => {
+        tempDir = createTempDir();
+        backend = new NodeFsBackend(tempDir, false, undefined, { maxTotalSize: 100 });
+    });
+
+    afterEach(() => cleanupTempDir(tempDir));
+
+    /** Assert `fn` rejects the quota file with a graceful `access` error code (no trap). */
+    function expectAccess(fn: () => unknown): void {
+        try {
+            fn();
+            throw new Error('expected an access VfsError');
+        } catch (e) {
+            expect(e).toBeInstanceOf(VfsError);
+            expect((e as VfsError).code).toBe('access');
+        }
+    }
+
+    test('the quota file is hidden from readDirectory at the root', () => {
+        fs.writeFileSync(path.join(tempDir, 'visible.txt'), 'x');
+        const names = backend.readDirectory([]).map(e => e.name);
+        expect(names).toContain('visible.txt');
+        expect(names).not.toContain(QUOTA_FILE);
+    });
+
+    test('the guest cannot stat the quota file', () => {
+        expectAccess(() => backend.stat([QUOTA_FILE]));
+    });
+
+    test('the guest cannot read the quota file', () => {
+        expectAccess(() => backend.read([QUOTA_FILE], 0n, 64));
+    });
+
+    test('the guest cannot open the quota file', () => {
+        expectAccess(() => backend.openAt([], QUOTA_FILE, {}, { read: true }, false));
+    });
+
+    test('the guest cannot create (open with create) the quota file', () => {
+        expectAccess(() => backend.openAt([], QUOTA_FILE, { create: true }, { read: true, write: true }, false));
+    });
+
+    test('the guest cannot write the quota file', () => {
+        expectAccess(() => backend.write([QUOTA_FILE], enc.encode('hack'), 0n));
+    });
+
+    test('the guest cannot append to the quota file', () => {
+        expectAccess(() => backend.append([QUOTA_FILE], enc.encode('hack')));
+    });
+
+    test('the guest cannot truncate (setSize) the quota file', () => {
+        expectAccess(() => backend.setSize([QUOTA_FILE], 0n));
+    });
+
+    test('the guest cannot setTimes on the quota file', () => {
+        expectAccess(() => backend.setTimes([QUOTA_FILE], 0n, 0n));
+    });
+
+    test('the guest cannot unlink the quota file', () => {
+        expectAccess(() => backend.unlinkFile([], QUOTA_FILE));
+        expect(fs.existsSync(path.join(tempDir, QUOTA_FILE))).toBe(true);
+    });
+
+    test('the guest cannot rename the quota file away', () => {
+        expectAccess(() => backend.rename([], QUOTA_FILE, [], 'stolen.json'));
+        expect(fs.existsSync(path.join(tempDir, QUOTA_FILE))).toBe(true);
+    });
+
+    test('the guest cannot rename another file onto the quota file', () => {
+        fs.writeFileSync(path.join(tempDir, 'src.txt'), 'x');
+        expectAccess(() => backend.rename([], 'src.txt', [], QUOTA_FILE));
+    });
+
+    test('the guest cannot hard-link onto the quota file name', () => {
+        fs.writeFileSync(path.join(tempDir, 'src.txt'), 'x');
+        expectAccess(() => backend.linkAt(['src.txt'], [], QUOTA_FILE));
+    });
+
+    test('the guest cannot create a directory named like the quota file', () => {
+        expectAccess(() => backend.createDirectory([], QUOTA_FILE));
+    });
+
+    test('the guest cannot metadataHash the quota file (no path-hash leak)', () => {
+        expectAccess(() => backend.metadataHash([QUOTA_FILE]));
+    });
+
+    test('isSameNode never matches the quota file', () => {
+        fs.writeFileSync(path.join(tempDir, 'other.txt'), 'x');
+        expect(backend.isSameNode([QUOTA_FILE], [QUOTA_FILE])).toBe(false);
+        expect(backend.isSameNode([QUOTA_FILE], ['other.txt'])).toBe(false);
+    });
+});
+
+// ──────────────────── vfsLimits via addNodeMounts + descriptor ────────────────────
+
+describe('vfsLimits via addNodeMounts (descriptor integration)', () => {
+    let tempDir: string;
+
+    beforeEach(() => { tempDir = createTempDir(); });
+    afterEach(() => cleanupTempDir(tempDir));
+
+    function getMountRoot(vfsLimits: { maxTotalSize?: number; maxFileSize?: number }): any {
+        const state = initFilesystem();
+        addNodeMounts(state, [{ hostPath: tempDir, guestPath: '/' }], undefined, vfsLimits);
+        return state.preopens[state.preopens.length - 1]![0];
+    }
+
+    test('maxFileSize is enforced through the descriptor write path', async () => {
+        const root = getMountRoot({ maxFileSize: 8 });
+        const file = await root.openAt(
+            { symlinkFollow: false }, 'big.txt',
+            { create: true }, { read: true, write: true, mutateDirectory: true },
+        );
+        await expect(file.writeViaStream(readableFrom(enc.encode('123456789')), 0n))
+            .rejects.toMatchObject({ tag: 'insufficient-space' });
+    });
+
+    test('maxTotalSize is enforced through the descriptor and persisted', async () => {
+        const root = getMountRoot({ maxTotalSize: 12 });
+        const a = await root.openAt(
+            { symlinkFollow: false }, 'a.txt',
+            { create: true }, { read: true, write: true, mutateDirectory: true },
+        );
+        await a.writeViaStream(readableFrom(enc.encode('0123456789')), 0n); // 10
+        expect(readQuota(tempDir)).toBe(10);
+
+        const b = await root.openAt(
+            { symlinkFollow: false }, 'b.txt',
+            { create: true }, { read: true, write: true, mutateDirectory: true },
+        );
+        await expect(b.writeViaStream(readableFrom(enc.encode('xyz')), 0n))
+            .rejects.toMatchObject({ tag: 'insufficient-space' });
+    });
+
+    test('the quota file is not listed through the descriptor readDirectory', async () => {
+        fs.writeFileSync(path.join(tempDir, 'keep.txt'), 'x');
+        const root = getMountRoot({ maxTotalSize: 100 });
+        const [stream, future] = root.readDirectory();
+        const names: string[] = [];
+        for await (const entry of stream) names.push(entry.name);
+        await future;
+        expect(names).toContain('keep.txt');
+        expect(names).not.toContain(QUOTA_FILE);
+    });
+
+    test('statAt on the quota file returns a graceful access error code', async () => {
+        const root = getMountRoot({ maxTotalSize: 100 });
+        await expect(root.statAt({ symlinkFollow: true }, QUOTA_FILE))
+            .rejects.toMatchObject({ tag: 'access' });
+    });
+
+    test('openAt on the quota file returns a graceful access error code', async () => {
+        const root = getMountRoot({ maxTotalSize: 100 });
+        await expect(root.openAt(
+            { symlinkFollow: false }, QUOTA_FILE,
+            {}, { read: true },
+        )).rejects.toMatchObject({ tag: 'access' });
+    });
+
+    test('creating the quota file via openAt returns a graceful access error code', async () => {
+        const root = getMountRoot({ maxTotalSize: 100 });
+        await expect(root.openAt(
+            { symlinkFollow: false }, QUOTA_FILE,
+            { create: true }, { read: true, write: true, mutateDirectory: true },
+        )).rejects.toMatchObject({ tag: 'access' });
+    });
+
+    test('unlinkFileAt on the quota file returns a graceful access error code', async () => {
+        const root = getMountRoot({ maxTotalSize: 100 });
+        await expect(root.unlinkFileAt(QUOTA_FILE))
+            .rejects.toMatchObject({ tag: 'access' });
+        expect(fs.existsSync(path.join(tempDir, QUOTA_FILE))).toBe(true);
+    });
+
+    test('metadataHashAt on the quota file returns a graceful access error code', async () => {
+        const root = getMountRoot({ maxTotalSize: 100 });
+        await expect(root.metadataHashAt({ symlinkFollow: true }, QUOTA_FILE))
+            .rejects.toMatchObject({ tag: 'access' });
+    });
+});

--- a/tests/host/wasip3/vfs.test.ts
+++ b/tests/host/wasip3/vfs.test.ts
@@ -505,5 +505,43 @@ describe('MemoryVfsBackend', () => {
             try { tinyVfs.write(['f.txt'], new Uint8Array(100), 0n); fail(); }
             catch (e) { expect((e as VfsError).code).toBe('insufficient-space'); }
         });
+
+        test('rejects write exceeding maxFileSize', () => {
+            const vfs = new MemoryVfsBackend({ maxFileSize: 100 });
+            vfs.populateFromMap(new Map([['f.txt', '']]));
+            try { vfs.write(['f.txt'], new Uint8Array(200), 0n); fail(); }
+            catch (e) { expect((e as VfsError).code).toBe('insufficient-space'); }
+        });
+
+        test('allows write up to maxFileSize', () => {
+            const vfs = new MemoryVfsBackend({ maxFileSize: 100 });
+            vfs.populateFromMap(new Map([['f.txt', '']]));
+            vfs.write(['f.txt'], new Uint8Array(100), 0n);
+            expect(vfs.stat(['f.txt']).size).toBe(100n);
+        });
+
+        test('rejects append exceeding maxFileSize', () => {
+            const vfs = new MemoryVfsBackend({ maxFileSize: 100 });
+            vfs.populateFromMap(new Map([['f.txt', 'x'.repeat(80)]]));
+            try { vfs.append(['f.txt'], new Uint8Array(40)); fail(); }
+            catch (e) { expect((e as VfsError).code).toBe('insufficient-space'); }
+        });
+
+        test('rejects setSize exceeding maxFileSize', () => {
+            const vfs = new MemoryVfsBackend({ maxFileSize: 100 });
+            vfs.populateFromMap(new Map([['f.txt', '']]));
+            try { vfs.setSize(['f.txt'], 200n); fail(); }
+            catch (e) { expect((e as VfsError).code).toBe('insufficient-space'); }
+        });
+
+        test('maxFileSize is independent of maxTotalSize', () => {
+            // Per-file cap of 100, but plenty of total room.
+            const vfs = new MemoryVfsBackend({ maxFileSize: 100, maxTotalSize: 1_000_000 });
+            vfs.populateFromMap(new Map([['a.txt', ''], ['b.txt', '']]));
+            vfs.write(['a.txt'], new Uint8Array(100), 0n);
+            vfs.write(['b.txt'], new Uint8Array(100), 0n);
+            try { vfs.write(['a.txt'], new Uint8Array(101), 0n); fail(); }
+            catch (e) { expect((e as VfsError).code).toBe('insufficient-space'); }
+        });
     });
 });

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2023 Pavel Savara. Licensed under the Apache-2.0 license with LLVM exception. See LICENSE for details.
 
-import { getBuildInfo, createComponent, instantiateWasiComponent, LogLevel } from '../src/index';
+import * as fs from 'node:fs';
+import { getBuildInfo, createComponent, instantiateComponent, instantiateWasiComponent, LogLevel } from '../src/index';
 import { createWasiP3Host, WasiExit } from '../src/host/wasip3/wasip3';
 import { createWasiP2ViaP3Adapter } from '../src/host/wasip2-via-wasip3';
 import { detectWasiType, WasiType, isCoreModule } from '../src/wasi-auto';
@@ -97,6 +98,42 @@ describe('public API', () => {
                 expect(typeof ns.echoBool).toBe('function');
                 expect(typeof ns.echoU8).toBe('function');
                 expect(typeof ns.echoString).toBe('function');
+            } finally {
+                instance.dispose();
+            }
+        }));
+    });
+
+    describe('input detection', () => {
+        test('createComponent accepts raw Uint8Array bytes (regression: was treated as parsed model)', () => runWithVerbose(verbose, async () => {
+            const bytes = new Uint8Array(fs.readFileSync(echoReactorWatWasm));
+            const component = await createComponent(bytes, verboseOptions(verbose));
+            const instance = await component.instantiate();
+            try {
+                expect(Object.keys(instance.exports)).toContain('jsco:test/echo-primitives@0.1.0');
+            } finally {
+                instance.dispose();
+            }
+        }));
+
+        test('createComponent accepts a plain number[] byte array', () => runWithVerbose(verbose, async () => {
+            const bytes = [...new Uint8Array(fs.readFileSync(echoReactorWatWasm))];
+            const component = await createComponent(bytes, verboseOptions(verbose));
+            expect(typeof component.instantiate).toBe('function');
+        }));
+
+        test('createComponent accepts an already-parsed model (array of tagged sections)', () => runWithVerbose(verbose, async () => {
+            const model = await parse(echoReactorWatWasm, {});
+            const component = await createComponent(model as never, verboseOptions(verbose));
+            expect(typeof component.instantiate).toBe('function');
+        }));
+
+        test('instantiateComponent works end-to-end from raw bytes', () => runWithVerbose(verbose, async () => {
+            const bytes = new Uint8Array(fs.readFileSync(echoReactorWatWasm));
+            const instance = await instantiateComponent(bytes, undefined, verboseOptions(verbose));
+            try {
+                expect(instance.exports).toBeDefined();
+                expect(Object.keys(instance.exports)).toContain('jsco:test/echo-primitives@0.1.0');
             } finally {
                 instance.dispose();
             }

--- a/tests/resolver/error-paths.test.ts
+++ b/tests/resolver/error-paths.test.ts
@@ -39,10 +39,11 @@ describe('error paths', () => {
             await expect(parse(corrupt)).rejects.toThrow();
         });
 
-        test('createComponent with truncated binary rejects', async () => {
-            const truncated = new Uint8Array([...WIT_MAGIC, ...WIT_VERSION, ...WIT_LAYER]);
-            // Preamble only with no sections — resolver rejects with section error
-            await expect(createComponent(truncated)).rejects.toThrow();
+        test('createComponent with corrupt binary rejects', async () => {
+            // Valid preamble + invalid section id 0xFF — createComponent must
+            // route raw bytes through the parser, which rejects the bad section.
+            const corrupt = new Uint8Array([...WIT_MAGIC, ...WIT_VERSION, ...WIT_LAYER, 0xFF, 0x00]);
+            await expect(createComponent(corrupt)).rejects.toThrow();
         });
     });
 


### PR DESCRIPTION
## Summary

This branch adds three independent improvements plus two correctness fixes:

1. **JSPI start-shim wrapping** so wit-component "reactor" components whose `_initialize` touches suspending host imports instantiate correctly.
2. **VFS size limits** (`maxFileSize`, `maxTotalSize`) for both the in-memory VFS and Node.js mounts, with **persistent quota tracking** for Node mounts.
3. **Trapping enforcement of `enabledInterfaces`** so disabled WASI interfaces still let a component instantiate but throw when actually invoked.

Plus:
- Fix to component-source detection in the resolver (a `Uint8Array` was wrongly treated as an already-parsed model).
- Quota-file guarding so a reserved bookkeeping file can't be read, written, listed, or otherwise tampered with by the guest.

## Changes

### 1. Reactor start-shim JSPI wrapping
`src/resolver/core-instance.ts`

A wit-component reactor "start-shim" is a synthetic core module whose `(start)` calls the main module's exported `_initialize`. Because start runs synchronously inside `WebAssembly.instantiate` (not inside a JSPI `promising` frame), invoking a `Suspending`-wrapped host import throws *"trying to suspend without WebAssembly.promising"*.

The new `wrapStartShimImports` helper:
- Detects a start-shim by structure: **zero exports AND exactly one function import** (avoids wrapping runtime-invoked imports that would break JSPI suspension).
- Wraps the shim's single function import with `WebAssembly.promising` for the duration of instantiation, captures the produced promise(s), and awaits them via `settle()` before any export runs.
- Falls back gracefully when JSPI / `WebAssembly.promising` is unavailable, or if `promising` rejects the function (direct call).

`resolveCoreInstanceInstantiate` now wraps imports before `wasmInstantiate` and awaits `startShim.settle()` afterward.

### 2. VFS size limits + Node quota persistence
`src/runtime/model/types.ts`, `src/host/wasip3/vfs.ts`, `src/host/wasip3/node/filesystem-node.ts`, `src/host/wasip3/filesystem.ts`, `src/host/wasip3/node/wasip3.ts`, `src/host/wasip3/types.ts`

New `VfsLimits` interface on `HostConfig.vfsLimits`:
- `maxFileSize` — per-file cap, enforced on write/append/truncate (in addition to `limits.maxAllocationSize`).
- `maxTotalSize` — aggregate cap across all files.

**In-memory VFS** (`MemoryVfsBackend`): adds `maxFileSize` enforcement alongside the existing `maxTotalSize`.

**Node.js mounts** (`NodeFsBackend`): tracks a running aggregate of file bytes, only when `maxTotalSize` is set. The total is persisted to a reserved `.jsco-quota.json` file at the (symlink-resolved) mount root, recomputed by walking the tree if the file is missing/corrupt. Reserve/commit accounting is applied around write, append, truncate, open-with-truncate, unlink, and rename (overwritten destination).

### 3. `enabledInterfaces` now traps instead of silently dropping
`src/host/_shared/enabled-interfaces.ts` (new), `src/host/wasip3/index.ts`, `src/host/wasip3/node/wasip3.ts`, `src/host/wasip2-via-wasip3/node/index.ts`, `src/wasi-auto.ts`

New dependency-free `applyEnabledInterfaces` helper replaces any import whose key doesn't match an enabled prefix with a **trapping stub** that preserves member keys (so the component still binds and instantiates) but throws on invocation. Applied across all host assembly paths (P3, P2-via-P3, Node hosts, and the auto-detect entry). The Node host re-applies the whitelist after installing real filesystem overrides.

### 4. Resolver component-source detection fix
`src/resolver/index.ts`

Extracted `isParsedModel` / `ensureParsed`. The previous `typeof input === 'object'` check wrongly treated a `Uint8Array` (an object, not an array) as an already-parsed model and skipped parsing. Now a parsed model is recognized only as an array of tagged section objects; all raw sources (Uint8Array, ArrayBuffer, string/URL, Response, byte array) go through `parse`.

### 5. Quota-file guarding
`src/host/wasip3/node/filesystem-node.ts`

The reserved `.jsco-quota.json` file is excluded from quota accounting, hidden from `readDirectory` at the mount root, and rejected (`VfsError('access')`) for any guest open/create/mkdir/symlink/readlink/metadata-hash access, so the guest can neither see nor tamper with it.

## Tests
- `tests/host/wasip3/enabled-interfaces.test.ts` — trapping-stub behavior.
- `tests/host/wasip3/node/filesystem-node.test.ts` — Node quota tracking, per-file/total limits, quota-file guarding & persistence.
- `tests/host/wasip3/vfs.test.ts`, `tests/host/wasip3/filesystem.test.ts` — in-memory VFS limits.
- `tests/index.test.ts`, `tests/resolver/error-paths.test.ts` — updated for the source-detection fix.
