### PR TITLE
Fix post-return (`cabi_post`) handling: run unconditionally, pass core results, isolate siblings

### DIFF
--- a/src/marshal/trampoline-lift.ts
+++ b/src/marshal/trampoline-lift.ts
@@ -16,7 +16,14 @@ function processFlatResult(plan: FunctionLiftPlan, ctx: MarshalingContext, rawWa
         result = plan.resultLowerers[0]!(ctx, rawWasm);
     }
     if (ctx.postReturnFn) {
-        ctx.postReturnFn();
+        // Canonical ABI: post-return receives the same core return value(s) the
+        // function produced, so the guest can free memory it owns (e.g. lowered
+        // strings). Multi-value flat returns arrive as an array → spread them.
+        if (Array.isArray(rawWasm)) {
+            ctx.postReturnFn(...rawWasm);
+        } else {
+            ctx.postReturnFn(rawWasm);
+        }
         ctx.postReturnFn = undefined;
     }
     if (isDebug && (ctx.verbose?.executor ?? 0) >= LogLevel.Summary) {
@@ -28,7 +35,10 @@ function processFlatResult(plan: FunctionLiftPlan, ctx: MarshalingContext, rawWa
 function processSpilledResult(plan: FunctionLiftPlan, ctx: MarshalingContext, rawWasm: any): any {
     const result = plan.resultLoader!(ctx, rawWasm as number);
     if (ctx.postReturnFn) {
-        ctx.postReturnFn();
+        // Canonical ABI: post-return receives the same core return value the
+        // function produced — here the spilled return-area pointer — so the
+        // guest's cabi_post can free the memory it allocated for the result.
+        ctx.postReturnFn(rawWasm);
         ctx.postReturnFn = undefined;
     }
     if (isDebug && (ctx.verbose?.executor ?? 0) >= LogLevel.Summary) {

--- a/src/marshal/trampoline-lift.ts
+++ b/src/marshal/trampoline-lift.ts
@@ -15,7 +15,7 @@ function processFlatResult(plan: FunctionLiftPlan, ctx: MarshalingContext, rawWa
     if (plan.resultLowerers.length === 1) {
         result = plan.resultLowerers[0]!(ctx, rawWasm);
     }
-    if (isDebug && ctx.postReturnFn) {
+    if (ctx.postReturnFn) {
         ctx.postReturnFn();
         ctx.postReturnFn = undefined;
     }
@@ -27,7 +27,7 @@ function processFlatResult(plan: FunctionLiftPlan, ctx: MarshalingContext, rawWa
 
 function processSpilledResult(plan: FunctionLiftPlan, ctx: MarshalingContext, rawWasm: any): any {
     const result = plan.resultLoader!(ctx, rawWasm as number);
-    if (isDebug && ctx.postReturnFn) {
+    if (ctx.postReturnFn) {
         ctx.postReturnFn();
         ctx.postReturnFn = undefined;
     }

--- a/src/resolver/component-functions.ts
+++ b/src/resolver/component-functions.ts
@@ -113,14 +113,21 @@ export const resolveCanonicalFunctionLift: Resolver<CanonicalFunctionLift> = (rc
         callerElement: rargs.callerElement,
         element: canonicalFunctionLift,
         binder: withDebugTrace(async (mctx, bargs) => {
-            // Wire up post-return function from canonical options
+            // Resolve THIS function's own post-return (cabi_post). It is applied
+            // per-call (below) rather than stored once on the shared per-instance
+            // mctx: sibling exports would otherwise clobber each other at bind
+            // time (last-writer-wins), so every method after the first would run
+            // the wrong cabi_post — or none, once the slot is consumed-and-cleared
+            // by the first lift. That corrupts guests which track call/post-call
+            // pairing (e.g. StarlingMonkey: "post_call was not called after last
+            // call").
+            let postReturnWasm: Function | undefined;
             if (postReturnResolution) {
                 const postReturnResult = await postReturnResolution.binder(mctx, {
                     callerArgs: bargs,
                     debugStack: bargs.debugStack,
                 });
-                const postReturnWasm = postReturnResult.result as Function;
-                mctx.postReturnFn = postReturnWasm;
+                postReturnWasm = postReturnResult.result as Function;
             }
 
             const args = {
@@ -156,6 +163,22 @@ export const resolveCanonicalFunctionLift: Resolver<CanonicalFunctionLift> = (rc
             }
 
             const jsFunction = liftingBinder(mctx, coreFn);
+
+            // Select this function's post-return immediately before each call so
+            // the sync lift trampoline runs the correct cabi_post for the result
+            // it just lifted, then clears it. JS is single-threaded and guests
+            // with post-return are single-task, so setting the shared slot
+            // per-call is sufficient and keeps siblings isolated.
+            if (postReturnWasm) {
+                const liftFn = jsFunction as (...callArgs: unknown[]) => unknown;
+                const postReturnFn = postReturnWasm;
+                return {
+                    result: (...callArgs: unknown[]): unknown => {
+                        mctx.postReturnFn = postReturnFn;
+                        return liftFn(...callArgs);
+                    },
+                };
+            }
 
             const binderResult = {
                 result: jsFunction


### PR DESCRIPTION
## Summary

This branch fixes three related defects in how jsco invokes a lifted function's
post-return callback (`cabi_post`) defined via canonical options. Post-return is
the spec-mandated hook a guest uses to free memory it allocated for a call's
result (lowered strings, lists, return areas, etc.). Getting it wrong corrupts
guests that track call/post-call pairing — e.g. StarlingMonkey traps with
*"post_call was not called after last call"*.

## Problems fixed

1. **Post-return only ran in debug builds.** The call site in the lift
   trampoline was guarded by `isDebug`, so in Release the guest's `cabi_post`
   was never invoked and guest-owned result memory leaked / pairing invariants
   broke.

2. **Post-return was called with no arguments.** The Canonical ABI requires
   `cabi_post` to receive the *same core return value(s)* the function produced
   so the guest can locate and free that memory. We were calling it with an
   empty argument list.

3. **Sibling exports clobbered each other's post-return.** The resolved
   `cabi_post` was stored once on the shared per-instance `MarshalingContext`
   (`mctx.postReturnFn`) at bind time. With multiple exports sharing one
   instance this was last-writer-wins: after the first lift consumed-and-cleared
   the slot, later methods ran the wrong `cabi_post` or none at all.

## Changes

### `src/marshal/trampoline-lift.ts`
- Removed the `isDebug` guard so post-return runs in all build configurations.
- **Flat results** (`processFlatResult`): forward the core return value(s) to
  `cabi_post`. Multi-value flat returns arrive as an array and are spread;
  single values are passed directly.
- **Spilled results** (`processSpilledResult`): forward the spilled return-area
  pointer to `cabi_post` so the guest can free the result area it allocated.

### `src/resolver/component-functions.ts`
- Resolve each function's own `cabi_post` into a local (`postReturnWasm`)
  instead of writing it to the shared `mctx`.
- When a function has a post-return, wrap its lifted JS function so that
  `mctx.postReturnFn` is set to *this* function's `cabi_post` immediately before
  each call. The trampoline then runs the correct callback and clears the slot.
  JS is single-threaded and post-return guests are single-task, so a per-call
  assignment to the shared slot is sufficient and keeps siblings isolated.

## Why per-call assignment is safe

The Component Model treats "the current call's post-return" as a single implicit
context. JS is single-threaded, so between the call and its synchronous lift
exactly one wasm context is live. Setting `mctx.postReturnFn` synchronously
right before invoking the lifted function is the literal spec mapping and avoids
the bind-time clobbering described above.
