### PR TITLE
Flush fire-and-forget stdout/stderr before a sync-lift export returns

### DIFF
--- a/src/host/wasip2-via-wasip3/cli.ts
+++ b/src/host/wasip2-via-wasip3/cli.ts
@@ -56,7 +56,7 @@ export function adaptStdin(p3: WasiP3Imports): { getStdin(): WasiInputStream } {
     };
 }
 
-export function adaptStdout(p3: WasiP3Imports, maxBufferSize?: number): { getStdout(): WasiOutputStream } {
+export function adaptStdout(p3: WasiP3Imports, maxBufferSize?: number, pending?: Promise<unknown>[]): { getStdout(): WasiOutputStream } {
     const p3stdout = p3['wasi:cli/stdout'];
     let cached: WasiOutputStream | null = null;
 
@@ -66,14 +66,14 @@ export function adaptStdout(p3: WasiP3Imports, maxBufferSize?: number): { getStd
                 const pair = createStreamPair<Uint8Array>();
                 // Hand readable end to P3 host, keep writable end for P2 guest
                 p3stdout.writeViaStream(pair.readable);
-                cached = createOutputStreamFromP3(pair, maxBufferSize);
+                cached = createOutputStreamFromP3(pair, maxBufferSize, pending);
             }
             return cached;
         },
     };
 }
 
-export function adaptStderr(p3: WasiP3Imports, maxBufferSize?: number): { getStderr(): WasiOutputStream } {
+export function adaptStderr(p3: WasiP3Imports, maxBufferSize?: number, pending?: Promise<unknown>[]): { getStderr(): WasiOutputStream } {
     const p3stderr = p3['wasi:cli/stderr'];
     let cached: WasiOutputStream | null = null;
 
@@ -82,7 +82,7 @@ export function adaptStderr(p3: WasiP3Imports, maxBufferSize?: number): { getStd
             if (!cached) {
                 const pair = createStreamPair<Uint8Array>();
                 p3stderr.writeViaStream(pair.readable);
-                cached = createOutputStreamFromP3(pair, maxBufferSize);
+                cached = createOutputStreamFromP3(pair, maxBufferSize, pending);
             }
             return cached;
         },

--- a/src/host/wasip2-via-wasip3/cli.ts
+++ b/src/host/wasip2-via-wasip3/cli.ts
@@ -63,7 +63,10 @@ export function adaptStdout(p3: WasiP3Imports, maxBufferSize?: number, pending?:
     return {
         getStdout(): WasiOutputStream {
             if (!cached) {
-                const pair = createStreamPair<Uint8Array>();
+                // resolveOnConsume so each fire-and-forget write() resolves only
+                // after the pump has delivered the chunk to the sink, letting the
+                // export-call boundary flush the full output (no truncated tail).
+                const pair = createStreamPair<Uint8Array>({ resolveOnConsume: true });
                 // Hand readable end to P3 host, keep writable end for P2 guest
                 p3stdout.writeViaStream(pair.readable);
                 cached = createOutputStreamFromP3(pair, maxBufferSize, pending);
@@ -80,7 +83,8 @@ export function adaptStderr(p3: WasiP3Imports, maxBufferSize?: number, pending?:
     return {
         getStderr(): WasiOutputStream {
             if (!cached) {
-                const pair = createStreamPair<Uint8Array>();
+                // resolveOnConsume — see adaptStdout above.
+                const pair = createStreamPair<Uint8Array>({ resolveOnConsume: true });
                 p3stderr.writeViaStream(pair.readable);
                 cached = createOutputStreamFromP3(pair, maxBufferSize, pending);
             }

--- a/src/host/wasip2-via-wasip3/index.ts
+++ b/src/host/wasip2-via-wasip3/index.ts
@@ -58,6 +58,13 @@ export function createWasiP2ViaP3Adapter(p3: WasiP3Imports, options?: { limits?:
     const register = makeRegister(result, 'wasi:', P2_VERSIONS);
     const syncPollable = (): WasiPollable => createSyncPollable(() => true);
 
+    // Registry of in-flight fire-and-forget guest output writes (stdout/stderr).
+    // The export-call boundary awaits these so a host reading captured output
+    // immediately after a guest call sees the full output, not a truncated tail.
+    // Shared with the MarshalingContext via the well-known symbol below.
+    const pendingHostWrites: Promise<unknown>[] = [];
+    (result as Record<symbol, unknown>)[Symbol.for('jsco.pendingHostWrites')] = pendingHostWrites;
+
     // ─── wasi:random/* ───
 
     const random = adaptRandom(p3);
@@ -132,8 +139,8 @@ export function createWasiP2ViaP3Adapter(p3: WasiP3Imports, options?: { limits?:
     const env = adaptEnvironment(p3);
     const exit = adaptExit(p3);
     const stdin = adaptStdin(p3);
-    const stdout = adaptStdout(p3, maxBufferSize);
-    const stderr = adaptStderr(p3, maxBufferSize);
+    const stdout = adaptStdout(p3, maxBufferSize, pendingHostWrites);
+    const stderr = adaptStderr(p3, maxBufferSize, pendingHostWrites);
     const terminalInput = adaptTerminalInput(p3);
     const terminalStdout = adaptTerminalStdout(p3);
     const terminalStderr = adaptTerminalStderr(p3);

--- a/src/host/wasip2-via-wasip3/io.ts
+++ b/src/host/wasip2-via-wasip3/io.ts
@@ -307,9 +307,21 @@ export function createInputStreamFromP3(
 export function createOutputStreamFromP3(
     pair: StreamPair<Uint8Array>,
     bufferCapacity: number = 1024 * 1024,
+    pending?: Promise<unknown>[],
 ): WasiOutputStream {
     let closed = false;
     const CAPACITY = bufferCapacity;
+
+    // Track a fire-and-forget write so a caller can await it later. The pair's
+    // write() promise resolves once the consumer (e.g. the stdout/stderr pump)
+    // has fully delivered the chunk to its sink; registering it in `pending`
+    // lets the export-call boundary flush all buffered output before returning
+    // to the host, so a host that reads captured stdout/stderr right after the
+    // guest call sees the complete output (not a truncated tail).
+    function track(p: Promise<unknown>): void {
+        if (!pending) return;
+        pending.push(p);
+    }
 
     return {
         checkWrite(): StreamResult<bigint> {
@@ -322,7 +334,7 @@ export function createOutputStreamFromP3(
             // Lowering trampoline may provide a plain Array for list<u8>; ensure Uint8Array for P3
             const bytes = contents instanceof Uint8Array ? contents : new Uint8Array(contents);
             // Fire-and-forget the write — P2 write is non-blocking
-            pair.write(bytes).catch(() => { closed = true; });
+            track(pair.write(bytes).catch(() => { closed = true; }));
             return streamOk(undefined);
         },
 
@@ -347,7 +359,7 @@ export function createOutputStreamFromP3(
         writeZeroes(len: bigint): StreamResult<void> {
             if (closed) return streamClosed();
             const zeroes = new Uint8Array(Number(len));
-            pair.write(zeroes).catch(() => { closed = true; });
+            track(pair.write(zeroes).catch(() => { closed = true; }));
             return streamOk(undefined);
         },
 

--- a/src/host/wasip3/streams.ts
+++ b/src/host/wasip3/streams.ts
@@ -68,8 +68,20 @@ export interface StreamPair<T> {
  *
  * The producer calls `write(value)` which returns a Promise that resolves
  * when the consumer has consumed the value (pull-based backpressure).
+ *
+ * By default `write()` resolves as soon as the consumer *pulls* the value
+ * (the `.next()` that returns it). Pass `resolveOnConsume: true` to instead
+ * resolve only after the consumer pulls the *following* item — i.e. once a
+ * `for await` body that awaits the value (e.g. `await writer.write(chunk)` in
+ * the stdout/stderr pump) has finished. This lets a caller flush buffered
+ * output by awaiting all in-flight `write()` promises and be sure every chunk
+ * has reached the sink, instead of seeing a truncated tail. It must stay
+ * opt-in: single-pull consumers (input-stream pumps, `iterator.next()` in
+ * tests) only call `.next()` once and would otherwise hang waiting for a
+ * second pull that never comes.
  */
-export function createStreamPair<T>(): StreamPair<T> {
+export function createStreamPair<T>(options?: { resolveOnConsume?: boolean }): StreamPair<T> {
+    const resolveOnConsume = options?.resolveOnConsume ?? false;
     // Queue of pending values and a way to signal the consumer
     type QueueItem =
         | { tag: 'value'; value: T; resolve: () => void }
@@ -105,17 +117,25 @@ export function createStreamPair<T>(): StreamPair<T> {
                 const item = await dequeue();
                 if (item.tag === 'done') return;
                 if (item.tag === 'error') throw item.error;
-                yield item.value;
-                // Resolve the producer's write() promise only AFTER the consumer
-                // has pulled the next item. For a `for await` consumer that awaits
-                // its body (e.g. `await writer.write(chunk)` in pumpToWritable),
-                // the next .next() call — which resumes us past this yield — does
-                // not happen until that body has finished. Resolving before the
-                // yield would let a blocking-write-and-flush guest resume before
-                // its bytes actually reached the sink, dropping the tail of
-                // stdout/stderr when the caller reads it synchronously right after
-                // the guest call returns.
-                item.resolve();
+                if (resolveOnConsume) {
+                    // Resolve the producer's write() promise only AFTER the
+                    // consumer pulls the next item. For a `for await` consumer
+                    // that awaits its body (e.g. `await writer.write(chunk)` in
+                    // pumpToWritable), the next .next() call — which resumes us
+                    // past this yield — does not happen until that body has
+                    // finished. This guarantees that awaiting the write() promise
+                    // means the chunk has reached the sink, so a blocking flush
+                    // before a sync-lift export returns captures the full tail of
+                    // stdout/stderr instead of a truncated one.
+                    yield item.value;
+                    item.resolve();
+                } else {
+                    // Default: resolve as soon as the value is pulled. Required by
+                    // single-pull consumers (input-stream pumps, plain
+                    // `iterator.next()`) that only call .next() once per chunk.
+                    item.resolve();
+                    yield item.value;
+                }
             }
         },
     };

--- a/src/host/wasip3/streams.ts
+++ b/src/host/wasip3/streams.ts
@@ -105,8 +105,17 @@ export function createStreamPair<T>(): StreamPair<T> {
                 const item = await dequeue();
                 if (item.tag === 'done') return;
                 if (item.tag === 'error') throw item.error;
-                item.resolve();
                 yield item.value;
+                // Resolve the producer's write() promise only AFTER the consumer
+                // has pulled the next item. For a `for await` consumer that awaits
+                // its body (e.g. `await writer.write(chunk)` in pumpToWritable),
+                // the next .next() call — which resumes us past this yield — does
+                // not happen until that body has finished. Resolving before the
+                // yield would let a blocking-write-and-flush guest resume before
+                // its bytes actually reached the sink, dropping the tail of
+                // stdout/stderr when the caller reads it synchronously right after
+                // the guest call returns.
+                item.resolve();
             }
         },
     };

--- a/src/resolver/component-functions.ts
+++ b/src/resolver/component-functions.ts
@@ -164,6 +164,20 @@ export const resolveCanonicalFunctionLift: Resolver<CanonicalFunctionLift> = (rc
 
             const jsFunction = liftingBinder(mctx, coreFn);
 
+            // After a sync-lift export returns, flush any in-flight fire-and-forget
+            // host output writes (stdout/stderr) so a host reading captured output
+            // immediately after the call sees the complete output, not a truncated
+            // tail. Mirrors the drain the async-lift wrapper already performs.
+            const flushPendingOutput = (value: unknown): unknown => {
+                const pending = mctx.pendingBackgroundTasks;
+                if (pending.length === 0) return value;
+                const toAwait = pending.slice();
+                pending.length = 0;
+                return Promise.allSettled(toAwait).then(() => value);
+            };
+            const withOutputFlush = (raw: unknown): unknown =>
+                raw instanceof Promise ? raw.then(flushPendingOutput) : flushPendingOutput(raw);
+
             // Select this function's post-return immediately before each call so
             // the sync lift trampoline runs the correct cabi_post for the result
             // it just lifted, then clears it. JS is single-threaded and guests
@@ -175,13 +189,14 @@ export const resolveCanonicalFunctionLift: Resolver<CanonicalFunctionLift> = (rc
                 return {
                     result: (...callArgs: unknown[]): unknown => {
                         mctx.postReturnFn = postReturnFn;
-                        return liftFn(...callArgs);
+                        return withOutputFlush(liftFn(...callArgs));
                     },
                 };
             }
 
+            const liftFn = jsFunction as (...callArgs: unknown[]) => unknown;
             const binderResult = {
-                result: jsFunction
+                result: (...callArgs: unknown[]): unknown => withOutputFlush(liftFn(...callArgs))
             };
             return binderResult;
         }, rargs.element.tag + ':' + rargs.element.selfSortIndex)

--- a/src/runtime/binding-context.ts
+++ b/src/runtime/binding-context.ts
@@ -40,6 +40,13 @@ export function createMarshalingContext(componentImports: JsImports, resolved: R
     const subtaskTable = createSubtaskTable(allocHandle);
     const waitableSetTable = createWaitableSetTable(memory, streamTable, futureTable, subtaskTable, abortController.signal, resolved.verbose, resolved.logger);
 
+    // Share the host adapter's pending fire-and-forget output-write registry
+    // (if present) so the export-call boundary flushes buffered stdout/stderr
+    // before returning to the host. Falls back to a fresh array.
+    const pendingBackgroundTasks =
+        (componentImports as Record<symbol, unknown>)[Symbol.for('jsco.pendingHostWrites')] as Promise<unknown>[] | undefined
+        ?? [];
+
     const ctx: MarshalingContext = {
         componentImports,
         instances,
@@ -57,7 +64,7 @@ export function createMarshalingContext(componentImports: JsImports, resolved: R
         logger: resolved.logger,
         currentTask: { slots: [0, 0] },
         backpressure: 0,
-        pendingBackgroundTasks: [],
+        pendingBackgroundTasks,
         opsSinceYield: resolved.yieldThrottle !== undefined ? 0 : undefined,
         maxMemoryBytes: config?.limits?.maxMemoryBytes,
         maxAllocationSize: config?.limits?.maxAllocationSize ?? LIMIT_DEFAULTS.maxAllocationSize,


### PR DESCRIPTION
## Problem

WASIp2 guests (e.g. a Rust `wasip2` binary) emit stdout/stderr through the
non-blocking `output-stream.write()` call, which is *fire-and-forget*. In
jsco's P2-over-P3 adapter, `createOutputStreamFromP3` issued
`pair.write(bytes)` without awaiting it, and the host-side pump
(`pumpToWritable`) drains that `StreamPair` one chunk per microtask. The pump
therefore lags a bursty synchronous guest.

A host that reads the captured stdout/stderr *immediately* after `await
export()` returned saw a **truncated tail** — the last chunk(s) the guest wrote
had been queued but not yet delivered to the sink.

## Fix

Drain all in-flight guest output writes at the export-call boundary, mirroring
the drain the async-lift wrapper already performs, so a sync-lift export only
returns to the host once stdout/stderr has fully reached the sink.

### Mechanism

1. **`createOutputStreamFromP3`** (`io.ts`) now accepts an optional `pending`
   array and registers each fire-and-forget `pair.write(...)` promise into it
   (both `write` and `writeZeroes`).

2. **`adaptStdout` / `adaptStderr`** (`cli.ts`) forward that `pending` array.

3. **`createWasiP2ViaP3Adapter`** (`index.ts`) creates one shared
   `pendingHostWrites: Promise<unknown>[]`, forwards it to the stdout/stderr
   adapters, and exposes it on the returned imports object under the well-known
   symbol `Symbol.for('jsco.pendingHostWrites')`.

4. **`createMarshalingContext`** (`binding-context.ts`) reads that symbol off
   `componentImports` and uses it as `ctx.pendingBackgroundTasks` (shared
   array), falling back to a fresh array when absent.

5. **Sync-lift export wrapper** (`component-functions.ts`) wraps the lifted
   result with `withOutputFlush`: if `pendingBackgroundTasks` is non-empty, it
   `await Promise.allSettled(...)` the pending writes (clearing the array) and
   then yields the value. Handles both the post-return and the plain
   sync-lift paths, and both synchronous and Promise-returning results.

### Why awaiting the write promise flushes correctly

The flush guarantee depends on the `StreamPair`'s `write()` promise resolving
**only after** the chunk has reached the sink. To get that for the stdout/stderr
pump without changing the semantics every other consumer relies on,
`createStreamPair` gained an opt-in option:

```ts
createStreamPair<Uint8Array>({ resolveOnConsume: true })
```

- **Default (`resolveOnConsume: false`)** — `write()` resolves as soon as the
  consumer *pulls* the value (the `.next()` that returns it). This is the
  original, tested backpressure behavior that single-pull consumers depend on
  (the input-stream pump in `createInputStreamFromP3`, and `iterator.next()`
  callers in tests). These call `.next()` exactly once per chunk.

- **`resolveOnConsume: true`** (used only by the stdout/stderr output pairs in
  `cli.ts`) — `write()` resolves only after the consumer pulls the *following*
  item, i.e. once the `for await` body in `pumpToWritable`
  (`await writer.write(chunk)`) has finished delivering the chunk. Awaiting all
  pending writes therefore means every byte has reached the sink, including the
  final chunk.
