### PR TITLE
Prepare 0.2.0-preview.0 npm release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 env:
   CARGO_TERM_COLOR: always
@@ -25,6 +26,10 @@ jobs:
         node-version: 24
         registry-url: https://registry.npmjs.org
 
+    # Trusted Publishing (OIDC) requires npm >= 11.5.1.
+    - name: Update npm
+      run: npm install -g npm@latest
+
     - name: Install npm dependencies
       run: npm ci
 
@@ -37,11 +42,13 @@ jobs:
         cd dist/release
         npm version "$VERSION" --no-git-tag-version
 
+    # Authentication is via OIDC Trusted Publishing — no NPM_TOKEN needed.
+    # Configure the trusted publisher for @pavelsavara/jsco on npmjs.com:
+    # Package settings -> Publishing access -> Trusted publisher (GitHub Actions),
+    # repo pavelsavara/jsco, workflow .github/workflows/publish.yml.
     - name: Publish to npm
       run: npm publish --access public
       working-directory: dist/release
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
     - name: Create GitHub release
       uses: softprops/action-gh-release@v2
@@ -50,7 +57,14 @@ jobs:
         files: |
           dist/release/index.js
           dist/release/index.d.ts
-          dist/release/wasip2.js
-          dist/release/wasip2.d.ts
-          dist/release/wasip2-node.js
-          dist/release/wasip2-node.d.ts
+          dist/release/cli.js
+          dist/release/wasip1-via-wasip3.js
+          dist/release/wasip1-via-wasip3.d.ts
+          dist/release/wasip2-via-wasip3.js
+          dist/release/wasip2-via-wasip3.d.ts
+          dist/release/wasip2-via-wasip3-node.js
+          dist/release/wasip2-via-wasip3-node.d.ts
+          dist/release/wasip3.js
+          dist/release/wasip3.d.ts
+          dist/release/wasip3-node.js
+          dist/release/wasip3-node.d.ts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+## [0.2.0-preview.0] - 2026-06-11
+
+First preview release.
+
+[0.2.0-preview.0]: https://github.com/pavelsavara/jsco/releases/tag/v0.2.0-preview.0

--- a/README.md
+++ b/README.md
@@ -202,11 +202,17 @@ HTTP/socket budgets enforced by the host. Run `jsco run --help` for the full lis
 - TypeScript, RollupJS, rust as dev time dependencies
 
 ## Status
-🚧 Work in progress 🚧
+🚧 Preview quality 🚧
+
+The WASIp1/p2/p3 hosts are implemented and pass an extensive
+test suite, but the API surface is not yet stable and behavior may change
+between preview releases. Not recommended for production use yet.
+Also this is one man + 🤖 show, come and help with testing.
 
 [![test](https://github.com/pavelsavara/jsco/actions/workflows/jest.yml/badge.svg)](https://github.com/pavelsavara/jsco/actions/workflows/jest.yml)
 
-See [./TODO.md](./TODO.md), contributors are welcome!
+See [./CHANGELOG.md](./CHANGELOG.md) for release notes and [./TODO.md](./TODO.md)
+for the roadmap. Contributors are welcome!
 
 ## JSPI
 

--- a/deploy/package.json
+++ b/deploy/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pavelsavara/jsco",
-    "version": "0.1.0",
+    "version": "0.2.0-preview.0",
     "description": "WebAssembly Component Model runtime for browsers and Node.js, with WASIp1/p2/p3 hosts",
     "main": "index.js",
     "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pavelsavara/jsco",
-    "version": "0.1.0",
+    "version": "0.2.0-preview.0",
     "description": "browser polyfill for running WASM components",
     "main": "index.js",
     "type": "module",
@@ -11,8 +11,8 @@
     "scripts": {
         "build": "rollup -c",
         "build:release": "rollup -c --environment Configuration:Release",
-        "build:npm": "npm run build:release && cp deploy/package.json dist/release/ && cp README.md dist/release/ && cp LICENSE dist/release/ && cp THIRD-PARTY-NOTICES.TXT dist/release/",
-        "build:npm:win": "npm run build:release && copy deploy\\package.json dist\\release\\ && copy README.md dist\\release\\ && copy LICENSE dist\\release\\ && copy THIRD-PARTY-NOTICES.TXT dist\\release\\",
+        "build:npm": "rm -rf dist/release && npm run build:release && cp deploy/package.json dist/release/ && cp README.md dist/release/ && cp LICENSE dist/release/ && cp THIRD-PARTY-NOTICES.TXT dist/release/",
+        "build:npm:win": "if exist dist\\release rmdir /s /q dist\\release && npm run build:release && copy deploy\\package.json dist\\release\\ && copy README.md dist\\release\\ && copy LICENSE dist\\release\\ && copy THIRD-PARTY-NOTICES.TXT dist\\release\\",
         "build:integration": "cd integration-tests && cargo component build --release --target wasm32-wasip1 -p consumer-p2 -p forwarder-p2 -p implementer-p2 -p hello-p2-world -p echo-reactor && cargo component build --release -p implementer-p2 --target wasm32-unknown-unknown",
         "build:integration-p3": "cd integration-tests && cargo build --release --target wasm32-wasip1 -p hello-p3-world -p implementer-p3 -p forwarder-p3 -p consumer-p3 && wasm-tools component new target/wasm32-wasip1/release/hello_p3_world.wasm --adapt wasi_snapshot_preview1.reactor.wasm -o hello-p3-world/hello_p3_world.wasm && wasm-tools component new target/wasm32-wasip1/release/implementer_p3.wasm --adapt wasi_snapshot_preview1.reactor.wasm -o implementer-p3/implementer_p3.wasm && wasm-tools component new target/wasm32-wasip1/release/forwarder_p3.wasm --adapt wasi_snapshot_preview1.reactor.wasm -o forwarder-p3/forwarder_p3.wasm && wasm-tools component new target/wasm32-wasip1/release/consumer_p3.wasm --adapt wasi_snapshot_preview1.reactor.wasm -o consumer-p3/consumer_p3.wasm",
         "build:compositions": "cd integration-tests && wac compose --dep jsco:forwarder-p2=target/wasm32-wasip1/release/forwarder_p2.wasm compositions/wrapped-forwarder.wac -o compositions/wrapped-forwarder.wasm && wac compose --dep jsco:forwarder-p2=target/wasm32-wasip1/release/forwarder_p2.wasm compositions/double-forwarder.wac -o compositions/double-forwarder.wasm && wac compose --dep jsco:forwarder-p2=target/wasm32-wasip1/release/forwarder_p2.wasm --dep jsco:wrapped-forwarder=compositions/wrapped-forwarder.wasm compositions/nested-double-forwarder.wac -o compositions/nested-double-forwarder.wasm && wac compose --dep jsco:forwarder-p2=target/wasm32-wasip1/release/forwarder_p2.wasm --dep jsco:implementer-p2=target/wasm32-unknown-unknown/release/implementer_p2.wasm compositions/forwarder-implementer.wac -o compositions/forwarder-implementer.wasm && wac compose --dep jsco:forwarder-p2=target/wasm32-wasip1/release/forwarder_p2.wasm --dep jsco:implementer-p2=target/wasm32-unknown-unknown/release/implementer_p2.wasm compositions/double-forwarder-implementer.wac -o compositions/double-forwarder-implementer.wasm && wac compose --dep jsco:forwarder-p2=target/wasm32-wasip1/release/forwarder_p2.wasm --dep jsco:forwarder-implementer=compositions/forwarder-implementer.wasm compositions/nested-forwarder-implementer.wac -o compositions/nested-forwarder-implementer.wasm",


### PR DESCRIPTION
Prepares the first preview release of `@pavelsavara/jsco` to npm.

## Changes
- Bump version to `0.2.0-preview.0` (package.json, deploy/package.json)
- Add CHANGELOG.md with first preview release entry
- Update README Status section from 'work in progress' to an honest preview-quality statement; link CHANGELOG
- Fix stale release-artifact file list in publish.yml (was referencing removed `wasip2.*` / `wasip2-node.*` outputs)
- Add clean step to build:npm / build:npm:win so stale dist artifacts can't leak
- Switch publish workflow to npm Trusted Publishing (OIDC) instead of NPM_TOKEN

## Follow-up
- After merge, the first `npm publish` will be done manually from main to claim the package name.
- Then configure the trusted publisher on npmjs.com and tag `v0.2.0-preview.0` for CI-driven releases.