### PR TITLE
Bump to 0.2.0-preview.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,14 @@
 
 All notable changes to this project are documented in this file.
 
+## [0.2.0-preview.1] - 2026-06-11
+
+First preview release published via CI (Trusted Publishing). No functional
+changes from `0.2.0-preview.0`.
+
 ## [0.2.0-preview.0] - 2026-06-11
 
 First preview release.
 
+[0.2.0-preview.1]: https://github.com/pavelsavara/jsco/releases/tag/v0.2.0-preview.1
 [0.2.0-preview.0]: https://github.com/pavelsavara/jsco/releases/tag/v0.2.0-preview.0

--- a/deploy/package.json
+++ b/deploy/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pavelsavara/jsco",
-    "version": "0.2.0-preview.0",
+    "version": "0.2.0-preview.1",
     "description": "WebAssembly Component Model runtime for browsers and Node.js, with WASIp1/p2/p3 hosts",
     "main": "index.js",
     "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pavelsavara/jsco",
-    "version": "0.2.0-preview.0",
+    "version": "0.2.0-preview.1",
     "description": "browser polyfill for running WASM components",
     "main": "index.js",
     "type": "module",


### PR DESCRIPTION
Version bump to `0.2.0-preview.1` to exercise the full CI publish pipeline (Trusted Publishing + dist-tag selection + GitHub release).

No functional changes from `0.2.0-preview.0`.

## After merge
- Tag `v0.2.0-preview.1` on main and push it to trigger the publish workflow.
- Verify: `npm view @pavelsavara/jsco@next version` returns `0.2.0-preview.1`.