### PR TITLE
Fix CI publish: allow same version in npm version step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,7 +40,7 @@ jobs:
       run: |
         VERSION="${GITHUB_REF_NAME#v}"
         cd dist/release
-        npm version "$VERSION" --no-git-tag-version
+        npm version "$VERSION" --no-git-tag-version --allow-same-version
         # Prerelease versions (containing a '-', e.g. 0.2.0-preview.0) publish to
         # the 'next' dist-tag so they don't become the default 'latest'. Stable
         # versions publish to 'latest'.


### PR DESCRIPTION
The `v0.2.0-preview.1` publish run failed at 'Set version from tag' with `npm error Version not changed`.

The `Bump to 0.2.0-preview.1` PR already set `deploy/package.json` to `0.2.0-preview.1`, so CI's `npm version 0.2.0-preview.1` refuses to set the same value. Adding `--allow-same-version` makes the step a no-op when the manifest already matches the tag.

Nothing was published to npm by the failed run, so re-tagging after merge is safe.

Run: https://github.com/pavelsavara/jsco/actions/runs/27335240803